### PR TITLE
Change route names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Sitemap.xml and Robots.txt
 
 Provides `sitemap.xml` and `robots.txt` from every VTEX Store.
+
+> Note: This is only a proxy for the VTEX catalog sitemap, so you need first to configure your sitemap in the VTEX admin and then install this app 

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd node/
+[ -d node_modules ] && rm -rf node_modules
+yarn cache clean
+yarn
+yarn lint

--- a/manifest.json
+++ b/manifest.json
@@ -5,11 +5,6 @@
   "title": "Sitemap",
   "description": "Proxy to sitemap.xml",
   "mustUpdateAt": "2019-08-01",
-  "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
-  "settingsSchema": {},
   "dependencies": {
     "vtex.render-server": "7.x"
   },
@@ -40,6 +35,6 @@
   ],
   "credentialType": "absolute",
   "scripts": {
-    "postreleasy": "vtex publish --verbose"
+    "prereleasy": "bash lint.sh"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "title": "Sitemap",
   "description": "Proxy to sitemap.xml",
   "mustUpdateAt": "2019-08-01",

--- a/node/index.ts
+++ b/node/index.ts
@@ -15,12 +15,12 @@ const statusLabel = (status: number) =>
   `${Math.floor(status/100)}xx`
 
 const log = (
-  {vtex: {account, workspace, route: {id}}, url, method, status}: ServiceContext,
+  {vtex: {account, workspace, route: {id}}, url, method, status}: Context,
   millis: number,
 ) =>
   `${new Date().toISOString()}\t${account}/${workspace}:${id}\t${status}\t${method}\t${url}\t${millis}ms`
 
-const prepare = (middleware: Middleware) => async (ctx: ServiceContext) => {
+const prepare = (middleware: Middleware) => async (ctx: Context) => {
   const {vtex: {production, route: {id}}} = ctx
   const start = process.hrtime()
   ctx.logger = new Logger(ctx.vtex, {timeout: 3000})

--- a/node/middlewares/robots.ts
+++ b/node/middlewares/robots.ts
@@ -1,6 +1,6 @@
 import {getRobotsTxt} from '../resources/site'
 
-export const robots = async (ctx: ServiceContext) => {
+export const robots = async (ctx: Context) => {
   const {data} = await getRobotsTxt(ctx)
   ctx.set('Content-Type', 'text/plain')
   ctx.body = data

--- a/node/middlewares/sitemap.ts
+++ b/node/middlewares/sitemap.ts
@@ -3,13 +3,13 @@ import { retry } from '../resources/retry'
 import { isCanonical, Route } from '../resources/route'
 import { getSiteMapXML } from '../resources/site'
 
-const updateRouteList = async (ctx: ServiceContext, route: Route[]) => {
+const updateRouteList = async (ctx: Context, route: Route[]) => {
   if (route.length > 0) {
     return ctx.renderClient.post('/canonical', {entries: route})
   }
 }
 
-export const sitemap = async (ctx: ServiceContext) => {
+export const sitemap = async (ctx: Context) => {
   const {vtex: {account}} = ctx
   const forwardedHost = ctx.get('x-forwarded-host')
   const routeList: Route[] = []
@@ -31,7 +31,7 @@ export const sitemap = async (ctx: ServiceContext) => {
 
   if (routeList.length > 0) {
     retry(updateRouteList.bind(null, ctx, routeList))
-    .catch(err => {
+    .catch((err: Error) => {
       console.error(err)
       ctx.logger.error(err, {message: 'Could not update route list'})
       return

--- a/node/package.json
+++ b/node/package.json
@@ -1,8 +1,6 @@
 {
-  "name": "vtex.store-sitemap",
-  "version": null,
   "dependencies": {
-    "@vtex/api": "^1.5.1",
+    "@vtex/api": "^1.5.2",
     "axios": "^0.18.0",
     "cheerio": "^1.0.0-rc.2",
     "ramda": "^0.25.0",
@@ -11,7 +9,7 @@
   "devDependencies": {
     "@types/axios": "^0.14.0",
     "@types/cheerio": "^0.22.8",
-    "@types/koa": "^2.0.46",
+    "@types/koa": "^2.0.48",
     "@types/node": "^7.0.8",
     "@types/ramda": "types/npm-ramda#dist",
     "@types/route-parser": "^0.1.1",

--- a/node/resources/retry.ts
+++ b/node/resources/retry.ts
@@ -1,6 +1,6 @@
 const RETRY_COUNT = 3
 
-export const retry = async (requestFn, retries = 0) => {
+export const retry = async (requestFn: any, retries = 0): Promise<any> => {
   try {
     return await requestFn()
   } catch (error) {

--- a/node/resources/route.ts
+++ b/node/resources/route.ts
@@ -1,8 +1,8 @@
 import * as RouteParser from 'route-parser'
 
-const identity = (x) => x
+const identity = <T>(x: T) => x
 
-const routeIdToStoreRoute = {
+const routeIdToStoreRoute: any = {
   brands: {
     id: 'store/brand',
     originalSitemapPathToSystem: (path: string) => `${path}/b`,
@@ -17,16 +17,16 @@ const routeIdToStoreRoute = {
 
 const removeHost = (fullPath: string, host: string) => fullPath.substring(fullPath.indexOf(host) + host.length)
 
-export const isCanonical = (ctx: ServiceContext) => routeIdToStoreRoute[ctx.vtex.route.id] != null
+export const isCanonical = (ctx: Context) => routeIdToStoreRoute[ctx.vtex.route.id] != null
 
 export class Route {
-  public params: Record<string, any>
+  public params?: Record<string, any>
   public id: string
   public path: string
   public canonical?: string
 
   constructor(
-    ctx: ServiceContext,
+    ctx: Context,
     path: string,
   ) {
     const forwardedHost = ctx.get('x-forwarded-host')

--- a/node/resources/site.ts
+++ b/node/resources/site.ts
@@ -4,7 +4,7 @@ const http = axios.create({
   timeout: 4000,
 })
 
-export const getSiteMapXML = async (ctx: ServiceContext) => http.get(
+export const getSiteMapXML = async (ctx: Context) => http.get(
   `http://${ctx.vtex.account}.vtexcommercestable.com.br${ctx.get('x-forwarded-path')}`,
   {
     headers: {
@@ -13,7 +13,7 @@ export const getSiteMapXML = async (ctx: ServiceContext) => http.get(
   }
 )
 
-export const getRobotsTxt = async (ctx: ServiceContext) => http.get(
+export const getRobotsTxt = async (ctx: Context) => http.get(
   `http://janus-edge.vtex.com.br/robots.txt?an=${ctx.vtex.account}`,
   {
     headers: {

--- a/node/service.json
+++ b/node/service.json
@@ -1,5 +1,4 @@
 {
-  "stack": "nodejs",
   "memory": 512,
   "ttl": 60,
   "timeout": 60,
@@ -9,19 +8,19 @@
       "public": true
     },
     "departments": {
-      "path": "/sitemap-departamentos.xml",
+      "path": "/sitemap-departments.xml",
       "public": true
     },
     "brands": {
-      "path": "/sitemap-marcas.xml",
+      "path": "/sitemap-brands.xml",
       "public": true
     },
     "products": {
-      "path": "/sitemap-produtos-:page:.xml",
+      "path": "/sitemap-products-:page:.xml",
       "public": true
     },
     "category": {
-      "path": "/sitemap-categoria-:specifier:.xml",
+      "path": "/sitemap-category-:specifier:.xml",
       "public": true
     },
     "robots": {

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -1,15 +1,25 @@
 {
   "compilerOptions": {
-    "types": ["node"],
+    "types": ["node", "koa"],
     "typeRoots": ["node_modules/@types"],
     "target": "es2017",
     "module": "commonjs",
+    "moduleResolution": "node",
     "sourceMap": false,
     "outDir": "service",
-    "allowJs": true,
+    "allowJs": false,
+    "noEmitOnError": true,
+    "allowSyntheticDefaultImports": false,
+    "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noImplicitThis": true
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "skipLibCheck": true,
+    "strictPropertyInitialization": true
   },
   "typeAcquisition": {
     "enable": false

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -1,14 +1,11 @@
-import { HttpClient, Logger, MetricsAccumulator, ServiceContext as ColossusServiceContext } from '@vtex/api'
-import { Context } from 'koa'
+import { HttpClient, Logger, MetricsAccumulator, ServiceContext } from '@vtex/api'
 
 declare global {
   const metrics: MetricsAccumulator
 
-  type LogLevel = 'info' | 'error' | 'warning' | 'debug'
+  type Middleware = (ctx: Context) => Promise<void>
 
-  type Middleware = (ctx: ServiceContext) => Promise<void>
-
-  interface ServiceContext extends ColossusServiceContext {
+  interface Context extends ServiceContext {
     logger: Logger
     renderClient: HttpClient
   }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -61,8 +61,8 @@
     "@types/serve-static" "*"
 
 "@types/http-assert@*":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.3.0.tgz#5e932606153da28e1d04f9043f4912cf61fd55dd"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.4.0.tgz#41d173466e396e99a14d75f7160cc997f2f9ed8b"
 
 "@types/keygrip@*":
   version "1.0.1"
@@ -72,13 +72,12 @@
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@types/koa-compose/-/koa-compose-3.2.2.tgz#dc106e000bbf92a3ac900f756df47344887ee847"
 
-"@types/koa@^2.0.46":
-  version "2.0.46"
-  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.0.46.tgz#24bc3cd405d10fcde81f876cd8285b44d4ddc3e9"
+"@types/koa@^2.0.48":
+  version "2.0.48"
+  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.0.48.tgz#29162783029d3e5df8b58c55f6bf0d35f78fc39f"
   dependencies:
     "@types/accepts" "*"
     "@types/cookies" "*"
-    "@types/events" "*"
     "@types/http-assert" "*"
     "@types/keygrip" "*"
     "@types/koa-compose" "*"
@@ -113,8 +112,8 @@
   resolved "https://codeload.github.com/types/npm-ramda/tar.gz/cdd495069ca7ca9cd774510c74649745964a8096"
 
 "@types/range-parser@*":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.2.tgz#fa8e1ad1d474688a757140c91de6dace6f4abc8d"
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
 
 "@types/route-parser@^0.1.1":
   version "0.1.1"
@@ -127,9 +126,9 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-1.5.1.tgz#0e7ccf8b9814bd67b6f59f2c5ab60f88384c2186"
+"@vtex/api@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-1.5.2.tgz#c33196c59ed3b7e5cd5694ec9e67754b325cb425"
   dependencies:
     "@types/lru-cache" "^4.1.1"
     "@types/p-queue" "^2.3.1"
@@ -867,7 +866,7 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
Recently, VTEX catalog changed from portuguese based sitemap to an english one. This pr solves this problem by adjusting the paths in `service.json`.

Also, this PR adds the new IO CI repo to this one and uses a stronger tsconfig and new lint