### PR TITLE
Fix custom sitemap

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/node/dataSources/index.ts
+++ b/node/dataSources/index.ts
@@ -1,6 +1,5 @@
-import { Apps, Logger } from '@vtex/api'
+import { Apps, Logger, LRUCache } from '@vtex/api'
 import { DataSource } from 'apollo-datasource'
-import { InMemoryLRUCache } from 'apollo-server-caching'
 import { Dictionary, forEachObjIndexed } from 'ramda'
 
 import { Context } from '../utils/helpers'
@@ -30,11 +29,11 @@ export const dataSources = (): DataSources => ({
   sitemap: new SiteMap(),
 })
 
-const cache = new InMemoryLRUCache({
-  maxSize: 100,
+const cache = new LRUCache<string, string>({
+  max: 100,
 })
 
 export const initialize = (context: Context) => forEachObjIndexed<DataSource<Context>, DataSources>(
-  (dataSource) => dataSource && dataSource.initialize && dataSource.initialize({context, cache}),
+  (dataSource) => dataSource && dataSource.initialize && dataSource.initialize({context, cache} as any),
   context.dataSources
 )

--- a/node/middlewares/customSitemap.ts
+++ b/node/middlewares/customSitemap.ts
@@ -1,6 +1,6 @@
 import { Apps } from '@vtex/api'
 import * as cheerio from 'cheerio'
-import { compose, forEach, keys, map, not, path, reject } from 'ramda'
+import { forEach, keys, map, not, path, reject } from 'ramda'
 
 import { currentDate, notFound } from '../resources/utils'
 import { Context, Maybe, Middleware } from '../utils/helpers'
@@ -25,10 +25,8 @@ const jsonToXml = (url: URL): string => {
   return $.xml()
 }
 
-const addToSitemap = ($: any, urls: URL[]): void => compose<URL[], string[], void>(
-  $('urlset').append,
-  map(jsonToXml)
-)(urls)
+const addToSitemap = ($: any, urls: URL[]): void =>
+  $('urlset').append(map(jsonToXml, urls))
 
 interface URL {
   loc: string

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@vtex/api": "^1.5.4 <1.8.0",
+    "@vtex/api": "^1.9.0",
     "apollo-datasource-rest": "^0.2.1",
     "apollo-server-caching": "^0.2.1",
     "bluebird": "^3.5.0",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@vtex/api": "^1.5.4",
+    "@vtex/api": "^1.5.4 <1.8.0",
     "apollo-datasource-rest": "^0.2.1",
     "apollo-server-caching": "^0.2.1",
     "bluebird": "^3.5.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -72,6 +72,11 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/graphql@^14.0.4":
+  version "14.0.7"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.7.tgz#daa09397220a68ce1cbb3f76a315ff3cd92312f6"
+  integrity sha512-BoLDjdvLQsXPZLJux3lEZANwGr3Xag56Ngy0U3y8uoRSDdeLcn43H3oBcgZlnd++iOQElBpaRVDHPzEDekyvXQ==
+
 "@types/http-assert@*":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.4.0.tgz#41d173466e396e99a14d75f7160cc997f2f9ed8b"
@@ -142,10 +147,12 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@^1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-1.5.4.tgz#94da0fd07013e12c313ae6a74b2c8fdb65be4478"
+"@vtex/api@^1.5.4 <1.8.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-1.7.0.tgz#e81afa2b1ba20e4357624dca7fad60414a47cdda"
+  integrity sha512-Gg35jlcoDdrSlfI0hQh2p1umcKWFnnVFgw4qxzxL5G66R8jjOFkv1KeexPgummVs8owqMJGA8i2pEAjSlhsBSA==
   dependencies:
+    "@types/graphql" "^14.0.4"
     "@types/lru-cache" "^4.1.1"
     "@types/p-queue" "^2.3.1"
     "@types/ramda" "^0.25.38"
@@ -154,6 +161,8 @@
     axios "^0.18.0"
     axios-retry "^3.0.3"
     fs-extra "^7.0.0"
+    graphql "^14.0.2"
+    graphql-tools "^4.0.3"
     json-stringify-safe "^5.0.1"
     koa-compose "^4.1.0"
     lru-cache "^4.1.3"
@@ -206,6 +215,13 @@ apollo-datasource@^0.1.3:
     apollo-server-caching "0.1.2"
     apollo-server-env "2.0.3"
 
+apollo-link@^1.2.3:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.8.tgz#0f252adefd5047ac1a9f35ba9439d216587dcd84"
+  integrity sha512-lfzGRxhK9RmiH3HPFi7TIEBhhDY9M5a2ZDnllcfy5QDk7cCQHQ1WQArcw1FK0g1B+mV4Kl72DSrlvZHZJEolrA==
+  dependencies:
+    zen-observable-ts "^0.8.15"
+
 apollo-server-caching@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.1.2.tgz#f5b85701945110a5fca1956450e8553576635936"
@@ -235,6 +251,15 @@ apollo-server-env@2.2.0:
 apollo-server-errors@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.2.0.tgz#5b452a1d6ff76440eb0f127511dc58031a8f3cb5"
+
+apollo-utilities@^1.0.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.2.1.tgz#1c3a1ebf5607d7c8efe7636daaf58e7463b41b3c"
+  integrity sha512-Zv8Udp9XTSFiN8oyXOjf6PMHepD4yxxReLsl6dPUy5Ths7jti3nmlBzZUOxuTWRwZn0MoclqL7RQ5UEJN8MAxg==
+  dependencies:
+    fast-json-stable-stringify "^2.0.0"
+    ts-invariant "^0.2.1"
+    tslib "^1.9.3"
 
 archiver-utils@^2.0.0:
   version "2.0.0"
@@ -481,6 +506,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
+deprecated-decorator@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz#00966317b7a12fe92f3cc831f7583af329b86c37"
+  integrity sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=
+
 diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
@@ -571,6 +601,11 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
+
 follow-redirects@^1.3.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.2.tgz#5a9d80e0165957e5ef0c1210678fc5c4acb9fb03"
@@ -616,9 +651,21 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
 
-graphql@^14.1.1:
+graphql-tools@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.4.tgz#ca08a63454221fdde825fe45fbd315eb2a6d566b"
+  integrity sha512-chF12etTIGVVGy3fCTJ1ivJX2KB7OSG4c6UOJQuqOHCmBQwTyNgCDuejZKvpYxNZiEx7bwIjrodDgDe9RIkjlw==
+  dependencies:
+    apollo-link "^1.2.3"
+    apollo-utilities "^1.0.1"
+    deprecated-decorator "^0.1.6"
+    iterall "^1.1.3"
+    uuid "^3.1.0"
+
+graphql@^14.0.2, graphql@^14.1.1:
   version "14.1.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.1.1.tgz#d5d77df4b19ef41538d7215d1e7a28834619fac0"
+  integrity sha512-C5zDzLqvfPAgTtP8AUPIt9keDabrdRAqSWjj2OPRKrKxI9Fb65I36s1uCs1UUBFnSWTdO7hyHi7z1ZbwKMKF6Q==
   dependencies:
     iterall "^1.2.2"
 
@@ -735,7 +782,7 @@ isnumber@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isnumber/-/isnumber-1.0.0.tgz#0e3f9759b581d99dd85086f0ec2a74909cfadd01"
 
-iterall@^1.2.2:
+iterall@^1.1.3, iterall@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 
@@ -948,6 +995,7 @@ qs@^6.5.2:
 querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 ramda@^0.25.0:
   version "0.25.0"
@@ -1020,7 +1068,7 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -1077,9 +1125,17 @@ to-buffer@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
 
-tslib@^1.0.0, tslib@^1.8.0, tslib@^1.8.1:
+ts-invariant@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.2.1.tgz#3d587f9d6e3bded97bf9ec17951dd9814d5a9d3f"
+  integrity sha512-Z/JSxzVmhTo50I+LKagEISFJW3pvPCqsMWLamCTX8Kr3N5aMrnGOqcflbe5hLUzwjvgPfnLzQtHZv0yWQ+FIHg==
+  dependencies:
+    tslib "^1.9.3"
+
+tslib@^1.0.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tslint-config-prettier@^1.6.0:
   version "1.14.0"
@@ -1157,6 +1213,11 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
+uuid@^3.1.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -1172,6 +1233,18 @@ yallist@^2.1.2:
 yallist@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+
+zen-observable-ts@^0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.15.tgz#6cf7df6aa619076e4af2f707ccf8a6290d26699b"
+  integrity sha512-sXKPWiw6JszNEkRv5dQ+lQCttyjHM2Iks74QU5NP8mMPS/NrzTlHDr780gf/wOBqmHkPO6NCLMlsa+fAQ8VE8w==
+  dependencies:
+    zen-observable "^0.8.0"
+
+zen-observable@^0.8.0:
+  version "0.8.13"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.13.tgz#a9f1b9dbdfd2d60a08761ceac6a861427d44ae2e"
+  integrity sha512-fa+6aDUVvavYsefZw0zaZ/v3ckEtMgCFi30sn91SEZea4y/6jQp05E3omjkX91zV6RVdn15fqnFZ6RKjRGbp2g==
 
 zip-stream@^2.0.1:
   version "2.0.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1068,7 +1068,7 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -147,10 +147,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@^1.5.4 <1.8.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-1.7.0.tgz#e81afa2b1ba20e4357624dca7fad60414a47cdda"
-  integrity sha512-Gg35jlcoDdrSlfI0hQh2p1umcKWFnnVFgw4qxzxL5G66R8jjOFkv1KeexPgummVs8owqMJGA8i2pEAjSlhsBSA==
+"@vtex/api@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-1.9.0.tgz#2a3c11c7bbc79452b05fc49491e744769fa7d715"
+  integrity sha512-sfIuIaj/88ucc351NLSwTBjdOqfI+JSHytWMqOd8KFOua6lm2jRIL9BZJOppFUE0AdkASJ3o0PiTmkUtAd2mAg==
   dependencies:
     "@types/graphql" "^14.0.4"
     "@types/lru-cache" "^4.1.1"


### PR DESCRIPTION
**Problems:** 
1. Custom sitemaps were not showing up, even after adding a `sitemap` folder with a `sitemap.json` file in the root of an app which uses the `sitemap@0.x` builder. 
2. Using `@vtex/api` at version `>=1.8.0` makes `sitemap-custom.xml` break with `error:   cacheStorage.has is not a function`.

**Solutions:** 
1. Removing the `compose` function made custom sitemaps show up. I don't really understand why, though.
2. `cacheStorage.has is not a function` happened because `InMemoryLRUCache` does not implement `.has()`. Using `LRUCache` from `@vtex/api` instead fixed the problem.

**Testing:** In `storecomponents`, add `sitemap/sitemap.json` in the root of the `store-theme` app with the following content:
```
{
  "urlset": {
    "url": [
      {
        "loc": "http://foo.bar"
      },
      {
        "loc": "http://baz.bar"
      }
    ]
  }
}
```
Add `sitemap@0.x` to the list of builders in `manifest.json`, link the app and access
`https://{{workspace}}--storecomponents.myvtexdev.com/sitemap-custom.xml`. The content below should be present:
```
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>http://foo.bar</loc>
    <lastmod>2019-03-04</lastmod>
    <changefreq>weekly</changefreq>
    <priority>0.4</priority>
  </url>
  <url>
    <loc>http://baz.bar</loc>
    <lastmod>2019-03-04</lastmod>
    <changefreq>weekly</changefreq>
    <priority>0.4</priority>
  </url>
</urlset>
```


