### PR TITLE
Save canonicals with precedence

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/node/middlewares/canonical.ts
+++ b/node/middlewares/canonical.ts
@@ -1,6 +1,6 @@
 import { json as parseBody } from 'co-body'
 
-import { Route } from '../resources/route'
+import { precedence, Route } from '../resources/route'
 
 export const getCanonical: Middleware = async (ctx: Context) => {
   const {clients: {canonicals}, query: {canonicalPath}} = ctx
@@ -14,7 +14,13 @@ export const getCanonical: Middleware = async (ctx: Context) => {
 
 export const saveCanonical: Middleware = async (ctx: Context) => {
   const {clients: {canonicals}} = ctx
-  const canonicalRoute: Route = await parseBody(ctx)
-  await canonicals.save(canonicalRoute)
+  const newRoute: Route = await parseBody(ctx)
+  const {canonical: canonicalPath} = newRoute
+  const savedRoute = await canonicals.load(canonicalPath)
+
+  if (!savedRoute || precedence(newRoute, savedRoute)) {
+    await canonicals.save(newRoute)
+  }
+
   ctx.status = 204
 }

--- a/node/resources/route.ts
+++ b/node/resources/route.ts
@@ -1,4 +1,4 @@
-import { identity, last, split } from 'ramda'
+import { equals, identity, last, split } from 'ramda'
 import RouteParser = require('route-parser')
 
 const routeIdToStoreRoute: any = {
@@ -25,10 +25,13 @@ export const isValid = (route: Route) => route.id && route.path && route.canonic
  * Precedence rules can be found in `https://help.vtex.com/tutorial/como-funciona-a-busca-da-vtex/`
  */
 export const precedence = (r1: Route, r2: Route) => {
+  const deepEquals = equals(r1, r2)
   const lastSegmentR1 = last(split('/', r1.path))
   const lastSegmentR2 = last(split('/', r2.path))
 
-  if (lastSegmentR1 === lastSegmentR2) {
+  if (deepEquals) {
+    return false
+  } else if (lastSegmentR1 === lastSegmentR2) {
     return true
   } else if(lastSegmentR1 === 'b') {
     return true

--- a/node/resources/route.ts
+++ b/node/resources/route.ts
@@ -1,4 +1,4 @@
-import { identity } from 'ramda'
+import { identity, last, split } from 'ramda'
 import RouteParser = require('route-parser')
 
 const routeIdToStoreRoute: any = {
@@ -19,6 +19,28 @@ const removeHost = (fullPath: string, host: string) => fullPath.substring(fullPa
 export const isCanonical = (ctx: Context) => routeIdToStoreRoute[ctx.vtex.route.id] != null
 
 export const isValid = (route: Route) => route.id && route.path && route.canonical && route.pathId
+
+/**
+ * Returns true if route r1 takes precedence over route r2
+ * Precedence rules can be found in `https://help.vtex.com/tutorial/como-funciona-a-busca-da-vtex/`
+ */
+export const precedence = (r1: Route, r2: Route) => {
+  const lastSegmentR1 = last(split('/', r1.path))
+  const lastSegmentR2 = last(split('/', r2.path))
+
+  if (lastSegmentR1 === lastSegmentR2) {
+    return false
+  } else if(lastSegmentR1 === 'b') {
+    return true
+  } else if(lastSegmentR2 === 'b') {
+    return false
+  } else if(lastSegmentR1 === 'd') {
+    return true
+  } else if(lastSegmentR2 === 'd') {
+    return false
+  }
+  return true
+}
 
 export class Route {
   public params?: Record<string, string>

--- a/node/resources/route.ts
+++ b/node/resources/route.ts
@@ -29,7 +29,7 @@ export const precedence = (r1: Route, r2: Route) => {
   const lastSegmentR2 = last(split('/', r2.path))
 
   if (lastSegmentR1 === lastSegmentR2) {
-    return false
+    return true
   } else if(lastSegmentR1 === 'b') {
     return true
   } else if(lastSegmentR2 === 'b') {


### PR DESCRIPTION
The main idea in here is to only save canonical routes when they increase their precedence level. This solves the case when a `/d` route becomes a plain text search.

However, if a `/d` route becomes a `/b`, it will not be able to go back to its correct form. I think we will ultimately solve this by calling the catalog api directly, but this fix should be enough for now