### PR TITLE
Removes querstring from route path

### DIFF
--- a/node/middlewares/canonical.ts
+++ b/node/middlewares/canonical.ts
@@ -1,10 +1,11 @@
 import { json as parseBody } from 'co-body'
 
-import { precedence, Route } from '../resources/route'
+import { precedence, removeQuerystring, Route } from '../resources/route'
 
 export const getCanonical: Middleware = async (ctx: Context) => {
   const {clients: {canonicals}, query: {canonicalPath}} = ctx
-  const maybeRoute = await canonicals.load(canonicalPath)
+  const path = removeQuerystring(canonicalPath)
+  const maybeRoute = await canonicals.load(path)
   if (maybeRoute) {
     ctx.body = maybeRoute
     ctx.status = 200
@@ -14,10 +15,10 @@ export const getCanonical: Middleware = async (ctx: Context) => {
 
 export const saveCanonical: Middleware = async (ctx: Context) => {
   const {clients: {canonicals}} = ctx
-  const newRoute: Route = await parseBody(ctx)
+  const newRoute = Route.from(await parseBody(ctx))
   const {canonical: canonicalPath} = newRoute
-  const savedRoute = await canonicals.load(canonicalPath)
-
+  const path = removeQuerystring(canonicalPath)
+  const savedRoute = await canonicals.load(path)
   if (!savedRoute || precedence(newRoute, savedRoute)) {
     await canonicals.save(newRoute)
   }

--- a/node/resources/route.ts
+++ b/node/resources/route.ts
@@ -1,4 +1,4 @@
-import { equals, identity, last, split } from 'ramda'
+import { compose, equals, head, identity, last, split } from 'ramda'
 import RouteParser = require('route-parser')
 
 const routeIdToStoreRoute: any = {
@@ -45,7 +45,18 @@ export const precedence = (r1: Route, r2: Route) => {
   return true
 }
 
+export const removeQuerystring = (path: string) => compose<string, string[], string>(
+  head,
+  split('?')
+)(path)
+
 export class Route {
+  public static from = (route: Route): Route => ({
+    ...route,
+    canonical: removeQuerystring(route.canonical),
+    path: removeQuerystring(route.path),
+  })
+
   public params?: Record<string, string>
   public id: string
   public path: string


### PR DESCRIPTION
Removes querstring from route path so we don't save the canonical routes with specification filters, for example