### PR TITLE
saves only brand and department routes in vbase

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/node/middlewares/canonical.ts
+++ b/node/middlewares/canonical.ts
@@ -1,6 +1,6 @@
 import { json as parseBody } from 'co-body'
 
-import { precedence, removeQuerystring, Route } from '../resources/route'
+import { isSearch, precedence, removeQuerystring, Route } from '../resources/route'
 
 export const getCanonical: Middleware = async (ctx: Context) => {
   const {clients: {canonicals}, query: {canonicalPath}} = ctx
@@ -19,7 +19,7 @@ export const saveCanonical: Middleware = async (ctx: Context) => {
   const {canonical: canonicalPath} = newRoute
   const path = removeQuerystring(canonicalPath)
   const savedRoute = await canonicals.load(path)
-  if (!savedRoute || precedence(newRoute, savedRoute)) {
+  if (!isSearch(newRoute) && (!savedRoute || precedence(newRoute, savedRoute))) {
     await canonicals.save(newRoute)
   }
 

--- a/node/resources/route.ts
+++ b/node/resources/route.ts
@@ -20,14 +20,18 @@ export const isCanonical = (ctx: Context) => routeIdToStoreRoute[ctx.vtex.route.
 
 export const isValid = (route: Route) => route.id && route.path && route.canonical && route.pathId
 
+const lastSegment = (path: string | undefined) => path && last(split('/', path))
+
+export const isSearch = ({path}: {path?: string}) => lastSegment(path) === 's'
+
 /**
  * Returns true if route r1 takes precedence over route r2
  * Precedence rules can be found in `https://help.vtex.com/tutorial/como-funciona-a-busca-da-vtex/`
  */
 export const precedence = (r1: Route, r2: Route) => {
   const deepEquals = equals(r1, r2)
-  const lastSegmentR1 = last(split('/', r1.path))
-  const lastSegmentR2 = last(split('/', r2.path))
+  const lastSegmentR1 = lastSegment(r1.path)
+  const lastSegmentR2 = lastSegment(r2.path)
 
   if (deepEquals) {
     return false


### PR DESCRIPTION
This is a port of the fix addressing the same issue described in [here](https://github.com/vtex/render-server/pull/351)