### PR TITLE
Fix canonical middleware search params

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/node/middlewares/canonical.ts
+++ b/node/middlewares/canonical.ts
@@ -27,7 +27,7 @@ const routeTypeToStoreRoute: any = {
     domain: 'store',
     id: 'store.search',
     params: {
-      p1: path,
+      p1: split('?', path)[0],
     },
     path:`${path}/s`,
     pathId: '/:p1/s',


### PR DESCRIPTION
Removes query string part of the path in the `params` of the `search` route.