### PR TITLE
Fix path and params of catalog discovered routes

### DIFF
--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -5,8 +5,8 @@ export class Catalog extends AppClient {
     super('vtex.catalog-api-proxy', ctx, opts)
   }
 
-  public pageType = (path: string) => this.get<CatalogPageTypeResponse>(
-    `/pub/portal/pagetype/${path}`,
+  public pageType = (path: string, query: string) => this.get<CatalogPageTypeResponse>(
+    `/pub/portal/pagetype/${path}${query}`,
     { metric: 'catalog-pagetype' }
   )
 


### PR DESCRIPTION
query string is being mixed with path, which produces bad params and breaks search result

ex: https://storetheme.vtex.com/electronics?v=01 doesn't work, but 
https://storetheme.vtex.com/electronics does