### PR TITLE
Remove unnecessary urls when in gocommerce

### DIFF
--- a/node/clients/sitemap/base.ts
+++ b/node/clients/sitemap/base.ts
@@ -2,4 +2,6 @@ export interface SiteMap {
   fromLegacy: (forwardedPath: string) => Promise<string>
 
   replaceHost: (str: string, forwardedHost: string) => string
+
+  appendSitemapItems: (currSitemap: any, items: string[]) => void
 }

--- a/node/clients/sitemap/gocommerce.ts
+++ b/node/clients/sitemap/gocommerce.ts
@@ -14,4 +14,6 @@ export class SitemapGC extends AppClient implements SiteMap {
     const regex = new RegExp(`${workspace}--${account}.mygocommerce.com`, 'g')
     return str.replace(regex, forwardedHost)
   }
+
+  public appendSitemapItems = async (_currSitemap: any, _items: string[]) => {}
 }

--- a/node/clients/sitemap/portal.ts
+++ b/node/clients/sitemap/portal.ts
@@ -2,6 +2,8 @@ import { JanusClient } from '@vtex/api'
 
 import { SiteMap } from './base'
 
+import { currentDate } from '../../resources/utils'
+
 export class SitemapPortal extends JanusClient implements SiteMap {
   public fromLegacy = async (forwardedPath: string) =>
     this.http.get<string>(forwardedPath)
@@ -9,5 +11,18 @@ export class SitemapPortal extends JanusClient implements SiteMap {
   public replaceHost = (str: string, newHost: string) => {
     const regex = new RegExp('portal.vtexcommercestable.com.br', 'g')
     return str.replace(regex, newHost)
+  }
+
+  public appendSitemapItems = async (currSitemap: any, items: string[]) => {
+    const xmlSitemapItem = (loc: string) => `
+      <sitemap>
+        <loc>${loc}</loc>
+        <lastmod>${currentDate()}</lastmod>
+      </sitemap>
+    `
+
+    for (const item of items) {
+      currSitemap.append(xmlSitemapItem(item))
+    }
   }
 }

--- a/node/middlewares/sitemap.ts
+++ b/node/middlewares/sitemap.ts
@@ -3,14 +3,6 @@ import { forEach } from 'ramda'
 
 import { sitemapClientFromCtx } from '../clients/sitemap'
 import { isCanonical, Route } from '../resources/route'
-import { currentDate } from '../resources/utils'
-
-const xmlSitemapItem = (loc: string) => `
-  <sitemap>
-    <loc>${loc}</loc>
-    <lastmod>${currentDate()}</lastmod>
-  </sitemap>
-`
 
 const TEN_MINUTES_S = 10 * 60
 
@@ -29,10 +21,10 @@ export const sitemap: Middleware = async (ctx: Context) => {
   })
 
   if (forwardedPath === '/sitemap.xml') {
-    $('sitemapindex').append(
-      xmlSitemapItem(`https://${forwardedHost}/sitemap/sitemap-custom.xml`),
-      xmlSitemapItem(`https://${forwardedHost}/sitemap/sitemap-user-routes.xml`)
-    )
+    await sitemapClient.appendSitemapItems($('sitemapindex'), [
+      `https://${forwardedHost}/sitemap/sitemap-custom.xml`,
+      `https://${forwardedHost}/sitemap/sitemap-user-routes.xml`,
+    ])
   }
 
   const routeList: Route[] = []


### PR DESCRIPTION
We don't use some urls in gocommerce's sitemap, so we need to remove it. Google penalizes empty sitemaps.