### PR TITLE
New sitemap using rewriter list

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -31,6 +31,9 @@
       }
     },
     {
+      "name": "colossus-fire-event"
+    },
+    {
       "name": "colossus-write-logs"
     },
     {

--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -1,10 +1,23 @@
-import { AppGraphQLClient, InstanceOptions, IOContext } from "@vtex/api";
-import { path } from "ramda";
-import { Internal, ListInternalsResponse } from "vtex.rewriter";
+import { AppGraphQLClient, InstanceOptions, IOContext } from '@vtex/api'
+import { path } from 'ramda'
+
+export interface Internal {
+  from: string
+  type: string
+  id: string
+  endDate?: string
+  imagePath?: string
+  imageTitle?: string
+}
+
+export interface ListInternalsResponse {
+  routes?: Internal[]
+  next?: string
+}
 
 export class Rewriter extends AppGraphQLClient {
   constructor(ctx: IOContext, opts?: InstanceOptions) {
-    super("vtex.rewriter", ctx, opts);
+    super('vtex.rewriter', ctx, opts)
   }
 
   public listInternals = (
@@ -34,13 +47,13 @@ export class Rewriter extends AppGraphQLClient {
         }
       }
       `,
-          variables: { limit, next }
+          variables: { limit, next },
         },
         {
-          metric: "rewriter-get-internals"
+          metric: 'rewriter-get-internals',
         }
       )
-      .then(path(["data", "internal", "listInternals"])) as Promise<
+      .then(path(['data', 'internal', 'listInternals'])) as Promise<
       ListInternalsResponse
-    >;
+    >
 }

--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -1,84 +1,46 @@
-import { AppGraphQLClient, InstanceOptions, IOContext } from '@vtex/api'
-import { path } from 'ramda'
-
-export interface RouteIndexFiles {
-  lastChangeDate: string
-  routeIndexFiles: RouteIndexFileEntry[]
-}
-
-export interface RouteIndexFileEntry {
-  fileName: string
-  fileSize: number
-}
-
-export interface RouteIndexEntry {
-  id: string
-  lastChangeDate: string
-}
-
-export interface Internal {
-  from: string
-  declarer: string // vtex.store@2.x
-  type: string // product
-  id: string // 123
-  query: JSON | null // {subtype: 'default'}
-  bindings: string[] | null // binding where this route is appliable
-  endDate: string | null // When the internal route expires
-  imagePath: string | null
-  imageTitle: string | null
-}
+import { AppGraphQLClient, InstanceOptions, IOContext } from "@vtex/api";
+import { path } from "ramda";
+import { Internal, ListInternalsResponse } from "vtex.rewriter";
 
 export class Rewriter extends AppGraphQLClient {
-  public constructor(ctx: IOContext, opts?: InstanceOptions) {
-    super('vtex.rewriter', ctx, opts)
+  constructor(ctx: IOContext, opts?: InstanceOptions) {
+    super("vtex.rewriter", ctx, opts);
   }
 
-  public routesIndexFiles = (): Promise<RouteIndexFiles> =>
+  public listInternals = (
+    limit: number,
+    next: Maybe<string>
+  ): Promise<ListInternalsResponse> =>
     this.graphql
-      .query<string[], {}>(
+      .query<
+        { internal: { listInternals: { next: string; routes: Internal[] } } },
+        { next: Maybe<string>; limit: number }
+      >(
         {
           query: `
-      query RoutesIndexFiles {
+      query ListInternals($limit: Int, $next: String) {
         internal {
-          indexFiles {
-            routeIndexFiles {
-              fileName
-              fileSize
+          listInternals(limit: $limit, next: $next) {
+            routes {
+              from
+              type
+              endDate
+              imagePath
+              imageTitle
+              id
             }
+            next
           }
         }
       }
       `,
-          variables: {},
+          variables: { limit, next }
         },
         {
-          metric: 'rewriter-get-internals-index-files',
+          metric: "rewriter-get-internals"
         }
       )
-      .then(path(['data', 'internal', 'indexFiles']) as any) as Promise<RouteIndexFiles>
-
-  public listInternals = (from: number, to: number, indexFile: string): Promise<Internal[]> =>
-    this.graphql
-      .query<Internal[], { from: number; to: number, indexFile: string }>(
-        {
-          query: `
-      query ListInternals($from: Int!, $to: Int!, $indexFile: String) {
-        internal {
-          list(from: $from, to: $to, indexFile: $indexFile) {
-            from
-            type
-            endDate
-            imagePath
-            imageTitle
-          }
-        }
-      }
-      `,
-          variables: { from, to, indexFile },
-        },
-        {
-          metric: 'rewriter-get-internals',
-        }
-      )
-      .then(path(['data', 'internal', 'list']) as any) as Promise<Internal[]>
+      .then(path(["data", "internal", "listInternals"])) as Promise<
+      ListInternalsResponse
+    >;
 }

--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -1,5 +1,4 @@
 import { AppGraphQLClient, InstanceOptions, IOContext } from '@vtex/api'
-import { path } from 'ramda'
 
 export interface Internal {
   from: string
@@ -53,7 +52,7 @@ export class Rewriter extends AppGraphQLClient {
           metric: 'rewriter-get-internals',
         }
       )
-      .then(path(['data', 'internal', 'listInternals'])) as Promise<
+      .then(res => res.data?.internal?.listInternals) as Promise<
       ListInternalsResponse
     >
 }

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,83 +1,83 @@
-import "./globals";
+import './globals'
 
-import { ClientsConfig, LRUCache, method, Service } from "@vtex/api";
+import { ClientsConfig, LRUCache, method, Service } from '@vtex/api'
 
-import { Clients } from "./clients";
-import { cache } from "./middlewares/cache";
-import { getCanonical, saveCanonical } from "./middlewares/canonical";
-import { customSitemap } from "./middlewares/customSitemap";
-import { generateSitemap } from "./middlewares/generateSitemap";
-import { methodNotAllowed } from "./middlewares/methods";
-import { sitemap as newSitemap } from "./middlewares/newSitemap";
-import { robots } from "./middlewares/robots";
-import { sitemap } from "./middlewares/sitemap";
-import { prepareState } from "./middlewares/state";
-import { userSitemap } from "./middlewares/userSitemap";
+import { Clients } from './clients'
+import { cache } from './middlewares/cache'
+import { getCanonical, saveCanonical } from './middlewares/canonical'
+import { customSitemap } from './middlewares/customSitemap'
+import { generateSitemap } from './middlewares/generateSitemap'
+import { methodNotAllowed } from './middlewares/methods'
+import { sitemap as newSitemap } from './middlewares/newSitemap'
+import { robots } from './middlewares/robots'
+import { sitemap } from './middlewares/sitemap'
+import { prepareState } from './middlewares/state'
+import { userSitemap } from './middlewares/userSitemap'
 
-const ONE_SECOND_MS = 1 * 1000;
-const THREE_SECONDS_MS = 3 * 1000;
-const FIFTY_SECONDS_MS = 50 * 1000;
+const ONE_SECOND_MS = 1 * 1000
+const THREE_SECONDS_MS = 3 * 1000
+const FIFTY_SECONDS_MS = 50 * 1000
 
 const sitemapXML = method({
   DEFAULT: methodNotAllowed,
-  GET: [cache, sitemap]
-});
+  GET: [cache, sitemap],
+})
 
 const catalogCacheStorage = new LRUCache<string, any>({
-  max: 30000
-});
+  max: 30000,
+})
 
 const clients: ClientsConfig<Clients> = {
   implementation: Clients,
   options: {
     apps: {
       retries: 2,
-      timeout: ONE_SECOND_MS
+      timeout: ONE_SECOND_MS,
     },
     canonicals: {
       retries: 2,
-      timeout: ONE_SECOND_MS
+      timeout: ONE_SECOND_MS,
     },
     catalog: {
       memoryCache: catalogCacheStorage,
       retries: 1,
-      timeout: THREE_SECONDS_MS
+      timeout: THREE_SECONDS_MS,
     },
     default: {
-      timeout: FIFTY_SECONDS_MS
+      timeout: FIFTY_SECONDS_MS,
     },
     logger: {
-      timeout: THREE_SECONDS_MS
+      timeout: THREE_SECONDS_MS,
     },
     routes: {
-      timeout: THREE_SECONDS_MS
+      timeout: THREE_SECONDS_MS,
     },
     sitemapGC: {
-      timeout: FIFTY_SECONDS_MS
+      timeout: FIFTY_SECONDS_MS,
     },
     sitemapPortal: {
-      timeout: FIFTY_SECONDS_MS
-    }
-  }
-};
+      timeout: FIFTY_SECONDS_MS,
+    },
+  },
+}
 
 export default new Service<Clients, State>({
   clients,
   events: {
-    generateSitemap
+    generateSitemap,
   },
   routes: {
     brands: sitemapXML,
     canonical: method({
       DEFAULT: methodNotAllowed,
       GET: [cache, prepareState, getCanonical],
-      PUT: saveCanonical
+      PUT: saveCanonical,
     }),
     categories: sitemapXML,
     category: sitemapXML,
     custom: method({
       DEFAULT: methodNotAllowed,
-      GET: [cache, customSitemap]
+      GET: [cache, customSitemap],
     }),
     departments: sitemapXML,
     generateSitemap,
@@ -85,13 +85,13 @@ export default new Service<Clients, State>({
     products: sitemapXML,
     robots: method({
       DEFAULT: methodNotAllowed,
-      GET: [cache, robots]
+      GET: [cache, robots],
     }),
     sitemap: sitemapXML,
     sitemapXML,
     user: method({
       DEFAULT: methodNotAllowed,
-      GET: [cache, userSitemap]
-    })
-  }
-});
+      GET: [cache, userSitemap],
+    }),
+  },
+})

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,95 +1,97 @@
-import './globals'
+import "./globals";
 
-import { ClientsConfig, LRUCache, method, Service } from '@vtex/api'
+import { ClientsConfig, LRUCache, method, Service } from "@vtex/api";
 
-import { Clients } from './clients'
-import { cache } from './middlewares/cache'
-import { getCanonical, saveCanonical } from './middlewares/canonical'
-import { customSitemap } from './middlewares/customSitemap'
-import { methodNotAllowed } from './middlewares/methods'
-import { sitemap as newSitemap } from './middlewares/newSitemap'
-import { robots } from './middlewares/robots'
-import { sitemap } from './middlewares/sitemap'
-import { prepareState } from './middlewares/state'
-import { userSitemap } from './middlewares/userSitemap'
+import { Clients } from "./clients";
+import { cache } from "./middlewares/cache";
+import { getCanonical, saveCanonical } from "./middlewares/canonical";
+import { customSitemap } from "./middlewares/customSitemap";
+import { generateSitemap } from "./middlewares/generateSitemap";
+import { methodNotAllowed } from "./middlewares/methods";
+import { sitemap as newSitemap } from "./middlewares/newSitemap";
+import { robots } from "./middlewares/robots";
+import { sitemap } from "./middlewares/sitemap";
+import { prepareState } from "./middlewares/state";
+import { userSitemap } from "./middlewares/userSitemap";
 
-const ONE_SECOND_MS = 1 * 1000
-const THREE_SECONDS_MS = 3 * 1000
-const FIFTY_SECONDS_MS = 50 * 1000
+const ONE_SECOND_MS = 1 * 1000;
+const THREE_SECONDS_MS = 3 * 1000;
+const FIFTY_SECONDS_MS = 50 * 1000;
 
 const sitemapXML = method({
   DEFAULT: methodNotAllowed,
-  GET: [
-    cache,
-    sitemap,
-  ],
-})
+  GET: [cache, sitemap]
+});
 
 const catalogCacheStorage = new LRUCache<string, any>({
-  max: 30000,
-})
+  max: 30000
+});
 
 const clients: ClientsConfig<Clients> = {
   implementation: Clients,
   options: {
     apps: {
       retries: 2,
-      timeout: ONE_SECOND_MS,
+      timeout: ONE_SECOND_MS
     },
     canonicals: {
       retries: 2,
-      timeout: ONE_SECOND_MS,
+      timeout: ONE_SECOND_MS
     },
     catalog: {
       memoryCache: catalogCacheStorage,
       retries: 1,
-      timeout: THREE_SECONDS_MS,
+      timeout: THREE_SECONDS_MS
     },
     default: {
-      timeout: FIFTY_SECONDS_MS,
+      timeout: FIFTY_SECONDS_MS
     },
     logger: {
-      timeout: THREE_SECONDS_MS,
+      timeout: THREE_SECONDS_MS
     },
     routes: {
-      timeout: THREE_SECONDS_MS,
+      timeout: THREE_SECONDS_MS
     },
     sitemapGC: {
-      timeout: FIFTY_SECONDS_MS,
+      timeout: FIFTY_SECONDS_MS
     },
     sitemapPortal: {
-      timeout: FIFTY_SECONDS_MS,
-    },
-  },
-}
+      timeout: FIFTY_SECONDS_MS
+    }
+  }
+};
 
 export default new Service<Clients, State>({
   clients,
+  events: {
+    generateSitemap
+  },
   routes: {
     brands: sitemapXML,
     canonical: method({
       DEFAULT: methodNotAllowed,
       GET: [cache, prepareState, getCanonical],
-      PUT: saveCanonical,
+      PUT: saveCanonical
     }),
     categories: sitemapXML,
     category: sitemapXML,
     custom: method({
       DEFAULT: methodNotAllowed,
-      GET: [cache, customSitemap],
+      GET: [cache, customSitemap]
     }),
     departments: sitemapXML,
+    generateSitemap,
     newSitemap,
     products: sitemapXML,
     robots: method({
       DEFAULT: methodNotAllowed,
-      GET: [cache, robots],
+      GET: [cache, robots]
     }),
     sitemap: sitemapXML,
     sitemapXML,
     user: method({
       DEFAULT: methodNotAllowed,
-      GET: [cache, userSitemap],
-    }),
-  },
-})
+      GET: [cache, userSitemap]
+    })
+  }
+});

--- a/node/middlewares/generateSitemap.ts
+++ b/node/middlewares/generateSitemap.ts
@@ -30,10 +30,9 @@ const generate = async (ctx: Context) => {
 
     const to = from + length
     const entry = `sitemap-${from}-${to}`
-    const index = await vbase.getJSON<string[]>(
+    const { index } = await vbase.getJSON<{ index: string[] }>(
       SITEMAP_BUCKET,
-      SITEMAP_INDEX,
-      true
+      SITEMAP_INDEX
     )
     index.push(entry)
     const lastUpdated = currentDate()

--- a/node/middlewares/generateSitemap.ts
+++ b/node/middlewares/generateSitemap.ts
@@ -1,7 +1,8 @@
-import { startsWith } from 'ramda'
-import { Internal } from 'vtex.rewriter'
-
 /* eslint-disable no-await-in-loop */
+import { startsWith } from 'ramda'
+
+import { Internal } from '../clients/rewriter'
+
 export const SITEMAP_BUCKET = '_SITEMAP_'
 export const SITEMAP_INDEX = 'sitemap_index'
 export const GENERATE_SITEMAP_EVENT = 'sitemap.generate'

--- a/node/middlewares/generateSitemap.ts
+++ b/node/middlewares/generateSitemap.ts
@@ -1,54 +1,54 @@
-import { startsWith } from "ramda";
+import { startsWith } from 'ramda'
 
 /* eslint-disable no-await-in-loop */
-export const SITEMAP_BUCKET = "_SITEMAP_";
-export const SITEMAP_INDEX = "sitemap_index";
-export const GENERATE_SITEMAP_EVENT = "sitemap.generate";
-const LIST_LIMIT = 500;
+export const SITEMAP_BUCKET = '_SITEMAP_'
+export const SITEMAP_INDEX = 'sitemap_index'
+export const GENERATE_SITEMAP_EVENT = 'sitemap.generate'
+const LIST_LIMIT = 500
 
-const currentDate = (): string => new Date().toISOString().split("T")[0];
+const currentDate = (): string => new Date().toISOString().split('T')[0]
 
 const generate = async (ctx: Context) => {
-  const { vbase, rewriter } = ctx.clients;
-  let response;
-  let from = 0;
-  let next: Maybe<string>;
-  await vbase.saveJSON(SITEMAP_BUCKET, SITEMAP_INDEX, { index: [] });
+  const { vbase, rewriter } = ctx.clients
+  let response
+  let from = 0
+  let next: Maybe<string>
+  await vbase.saveJSON(SITEMAP_BUCKET, SITEMAP_INDEX, { index: [] })
   do {
-    response = await rewriter.listInternals(LIST_LIMIT, next);
-    const length: number = response.routes?.length;
+    response = await rewriter.listInternals(LIST_LIMIT, next)
+    const length: number = response.routes?.length
     if (!response.routes || !length) {
-      next = response.next;
-      continue;
+      next = response.next
+      continue
     }
     const list = response.routes.filter(
       internal =>
-        !startsWith("notFound", internal.type) && internal.id !== "search"
-    );
+        !startsWith('notFound', internal.type) && internal.id !== 'search'
+    )
 
-    next = response.next;
+    next = response.next
 
-    const to = from + length;
-    const entry = `sitemap-${from}-${to}`;
+    const to = from + length
+    const entry = `sitemap-${from}-${to}`
     const index = await vbase.getJSON<string[]>(
       SITEMAP_BUCKET,
       SITEMAP_INDEX,
       true
-    );
-    index.push(entry);
+    )
+    index.push(entry)
     await Promise.all([
       vbase.saveJSON(SITEMAP_BUCKET, SITEMAP_INDEX, {
         index,
-        lastUpdated: currentDate()
+        lastUpdated: currentDate(),
       }),
-      vbase.saveJSON(SITEMAP_BUCKET, entry, list)
-    ]);
-    from += length;
-  } while (next);
-};
+      vbase.saveJSON(SITEMAP_BUCKET, entry, list),
+    ])
+    from += length
+  } while (next)
+}
 
 export async function generateSitemap(ctx: Context) {
-  generate(ctx);
+  generate(ctx)
 
-  ctx.status = 200;
+  ctx.status = 200
 }

--- a/node/middlewares/generateSitemap.ts
+++ b/node/middlewares/generateSitemap.ts
@@ -1,72 +1,72 @@
-import { startsWith } from "ramda";
-import { Internal } from "vtex.rewriter";
+import { startsWith } from 'ramda'
+import { Internal } from 'vtex.rewriter'
 
 /* eslint-disable no-await-in-loop */
-export const SITEMAP_BUCKET = "_SITEMAP_";
-export const SITEMAP_INDEX = "sitemap_index";
-export const GENERATE_SITEMAP_EVENT = "sitemap.generate";
-const LIST_LIMIT = 500;
+export const SITEMAP_BUCKET = '_SITEMAP_'
+export const SITEMAP_INDEX = 'sitemap_index'
+export const GENERATE_SITEMAP_EVENT = 'sitemap.generate'
+const LIST_LIMIT = 500
 
 export interface SitemapIndex {
-  index: string[];
-  lastUpdated: string;
+  index: string[]
+  lastUpdated: string
 }
 
 export interface SitemapEntry {
-  routes: Internal[];
-  lastUpdated: string;
+  routes: Internal[]
+  lastUpdated: string
 }
 
-const currentDate = (): string => new Date().toISOString().split("T")[0];
+const currentDate = (): string => new Date().toISOString().split('T')[0]
 
 const generate = async (ctx: Context) => {
-  const { vbase, rewriter } = ctx.clients;
-  let response;
-  let from = 0;
-  let next: Maybe<string>;
+  const { vbase, rewriter } = ctx.clients
+  let response
+  let from = 0
+  let next: Maybe<string>
   await vbase.saveJSON<SitemapIndex>(SITEMAP_BUCKET, SITEMAP_INDEX, {
     index: [] as string[],
-    lastUpdated: ""
-  });
+    lastUpdated: '',
+  })
   do {
-    response = await rewriter.listInternals(LIST_LIMIT, next);
-    const length: number = response.routes?.length ?? 0;
+    response = await rewriter.listInternals(LIST_LIMIT, next)
+    const length: number = response.routes?.length ?? 0
     if (!response.routes || !length) {
-      next = response.next;
-      continue;
+      next = response.next
+      continue
     }
     const list = response.routes.filter(
       internal =>
-        !startsWith("notFound", internal.type) && internal.id !== "search"
-    );
+        !startsWith('notFound', internal.type) && internal.id !== 'search'
+    )
 
-    next = response.next;
+    next = response.next
 
-    const to = from + length;
-    const entry = `sitemap-${from}-${to}`;
+    const to = from + length
+    const entry = `sitemap-${from}-${to}`
     const indexData = await vbase.getJSON<SitemapIndex>(
       SITEMAP_BUCKET,
       SITEMAP_INDEX
-    );
-    const { index } = indexData as SitemapIndex;
-    index.push(entry);
-    const lastUpdated = currentDate();
+    )
+    const { index } = indexData as SitemapIndex
+    index.push(entry)
+    const lastUpdated = currentDate()
     await Promise.all([
       vbase.saveJSON<SitemapIndex>(SITEMAP_BUCKET, SITEMAP_INDEX, {
         index,
-        lastUpdated
+        lastUpdated,
       }),
       vbase.saveJSON<SitemapEntry>(SITEMAP_BUCKET, entry, {
         lastUpdated,
-        routes: list
-      })
-    ]);
-    from += length;
-  } while (next);
-};
+        routes: list,
+      }),
+    ])
+    from += length
+  } while (next)
+}
 
 export async function generateSitemap(ctx: Context) {
-  generate(ctx);
+  generate(ctx)
 
-  ctx.status = 200;
+  ctx.status = 200
 }

--- a/node/middlewares/generateSitemap.ts
+++ b/node/middlewares/generateSitemap.ts
@@ -1,0 +1,54 @@
+import { startsWith } from "ramda";
+
+/* eslint-disable no-await-in-loop */
+export const SITEMAP_BUCKET = "_SITEMAP_";
+export const SITEMAP_INDEX = "sitemap_index";
+export const GENERATE_SITEMAP_EVENT = "sitemap.generate";
+const LIST_LIMIT = 500;
+
+const currentDate = (): string => new Date().toISOString().split("T")[0];
+
+const generate = async (ctx: Context) => {
+  const { vbase, rewriter } = ctx.clients;
+  let response;
+  let from = 0;
+  let next: Maybe<string>;
+  await vbase.saveJSON(SITEMAP_BUCKET, SITEMAP_INDEX, { index: [] });
+  do {
+    response = await rewriter.listInternals(LIST_LIMIT, next);
+    const length: number = response.routes?.length;
+    if (!response.routes || !length) {
+      next = response.next;
+      continue;
+    }
+    const list = response.routes.filter(
+      internal =>
+        !startsWith("notFound", internal.type) && internal.id !== "search"
+    );
+
+    next = response.next;
+
+    const to = from + length;
+    const entry = `sitemap-${from}-${to}`;
+    const index = await vbase.getJSON<string[]>(
+      SITEMAP_BUCKET,
+      SITEMAP_INDEX,
+      true
+    );
+    index.push(entry);
+    await Promise.all([
+      vbase.saveJSON(SITEMAP_BUCKET, SITEMAP_INDEX, {
+        index,
+        lastUpdated: currentDate()
+      }),
+      vbase.saveJSON(SITEMAP_BUCKET, entry, list)
+    ]);
+    from += length;
+  } while (next);
+};
+
+export async function generateSitemap(ctx: Context) {
+  generate(ctx);
+
+  ctx.status = 200;
+}

--- a/node/middlewares/generateSitemap.ts
+++ b/node/middlewares/generateSitemap.ts
@@ -36,12 +36,16 @@ const generate = async (ctx: Context) => {
       true
     )
     index.push(entry)
+    const lastUpdated = currentDate()
     await Promise.all([
       vbase.saveJSON(SITEMAP_BUCKET, SITEMAP_INDEX, {
         index,
-        lastUpdated: currentDate(),
+        lastUpdated,
       }),
-      vbase.saveJSON(SITEMAP_BUCKET, entry, list),
+      vbase.saveJSON(SITEMAP_BUCKET, entry, {
+        lastUpdated,
+        routes: list,
+      }),
     ])
     from += length
   } while (next)

--- a/node/middlewares/newSitemap.ts
+++ b/node/middlewares/newSitemap.ts
@@ -1,36 +1,38 @@
-import * as cheerio from 'cheerio'
-import { keys, map, mergeAll, prop, range, replace } from 'ramda'
+import { VBase } from "@vtex/api";
+import * as cheerio from "cheerio";
+import { replace } from "ramda";
+import { Internal } from "vtex.rewriter";
 
-import { Internal, RouteIndexFileEntry } from '../clients/rewriter'
-import { currentDate } from '../resources/utils'
+import {
+  GENERATE_SITEMAP_EVENT,
+  SITEMAP_BUCKET,
+  SITEMAP_INDEX
+} from "./generateSitemap";
 
-const MAX_ROUTES_PER_REQUEST = 100
-const TEN_MINUTES_S = 10 * 60
+const ONE_DAY_S = 24 * 60 * 60;
 
-const sitemapIndexEntry = (forwardedHost: string, rootPath: string, entity: string, firstIndex?: number, lastIndex?: number): string => {
-  if (firstIndex && lastIndex) {
-    return `
-      <sitemap>
-        <loc>https://${forwardedHost}${rootPath}/_v/public/newsitemap/${entity}-${firstIndex}-${lastIndex}.xml</loc>
-        <lastmod>${currentDate()}</lastmod>
-      </sitemap>
-    `
-  }
-  return `
-    <sitemap>
-      <loc>https://${forwardedHost}${rootPath}/_v/public/newsitemap/${entity}.xml</loc>
-      <lastmod>${currentDate()}</lastmod>
-    </sitemap>
-  `
-}
+const sitemapIndexEntry = (
+  forwardedHost: string,
+  rootPath: string,
+  entry: string,
+  lastUpdated: string
+) =>
+  `<sitemap>
+      <loc>https://${forwardedHost}${rootPath}/_v/public/newsitemap/${entry}.xml</loc>
+      <lastmod>${lastUpdated}</lastmod>
+    </sitemap>`;
 
-const URLEntry = (forwardedHost: string, rootPath: string, route: Internal): string => {
+const URLEntry = (
+  forwardedHost: string,
+  rootPath: string,
+  route: Internal
+): string => {
   let entry = `
       <loc>https://${forwardedHost}${rootPath}${route.from}</loc>
       <lastmod>${currentDate()}</lastmod>
       <changefreq>weekly</changefreq>
       <priority>0.4</priority>
-    `
+    `;
   if (route.imagePath && route.imageTitle) {
     // add image metainfo
     entry = `
@@ -38,52 +40,92 @@ const URLEntry = (forwardedHost: string, rootPath: string, route: Internal): str
       <image:loc>${route.imagePath}</image:loc>
       <image:title>${route.imageTitle}</image:title>
     </image:image>
-    ` + entry
+    ${entry}`;
   }
-  return `<url>${entry}</url>`
-}
+  return `<url>${entry}</url>`;
+};
 
-export async function sitemap (ctx: Context) {
-  const { vtex: { production }, clients: { rewriter } } = ctx
-  const forwardedHost = ctx.get('x-forwarded-host')
-  let rootPath = ctx.get('x-vtex-root-path')
+const sitemapIndex = async (
+  forwardedHost: string,
+  rootPath: string,
+  vbase: VBase
+) => {
+  const $ = cheerio.load(
+    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    {
+      xmlMode: true
+    }
+  );
+
+  const indexData = await vbase.getJSON<{
+    index: string[];
+    lastUpdated: string;
+  }>(SITEMAP_BUCKET, SITEMAP_INDEX, true);
+
+  if (!indexData) {
+    throw new Error(
+      "Sitemap not generated, you need to do that first <LINK TO DOC>"
+    );
+  }
+  const { index, lastUpdated } = indexData;
+  index.forEach(entry =>
+    $("sitemapindex").append(
+      sitemapIndexEntry(forwardedHost, rootPath, entry, lastUpdated)
+    )
+  );
+  return $;
+};
+
+export async function sitemap(ctx: Context) {
+  const {
+    vtex: { production },
+    clients: { vbase, events }
+  } = ctx;
+  const forwardedHost = ctx.get("x-forwarded-host");
+  let rootPath = ctx.get("x-vtex-root-path");
   // Defend against malformed root path. It should always start with `/`.
-  if (rootPath && !rootPath.startsWith('/')) {
-    rootPath = `/${rootPath}`
+  if (rootPath && !rootPath.startsWith("/")) {
+    rootPath = `/${rootPath}`;
   }
-  const [forwardedPath] = ctx.get('x-forwarded-path').split('?')
+  const [forwardedPath] = ctx.get("x-forwarded-path").split("?");
 
-  const indexArray = await rewriter.routesIndexFiles().then(prop('routeIndexFiles'))
-  const indexTable = mergeAll(map((obj: RouteIndexFileEntry) => ({ [obj.fileName]: obj.fileSize }), indexArray))
-  let $: any
-  if (forwardedPath === '/_v/public/newsitemap/sitemap.xml') {
-    $ = cheerio.load('<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">', {
-      xmlMode: true,
-    })
-    const indexTitles = keys(indexTable) as string[]
-    indexTitles.forEach((entity: string) => {
-      const indexSize = indexTable[entity]
-      if (indexSize <= MAX_ROUTES_PER_REQUEST) {
-        $('sitemapindex').append(sitemapIndexEntry(forwardedHost, rootPath, entity))
-      } else {
-        range(0, Math.floor(indexSize/MAX_ROUTES_PER_REQUEST)).forEach(x => {
-          const [firstIndex, lastIndex] = [x*MAX_ROUTES_PER_REQUEST, (x+1)*MAX_ROUTES_PER_REQUEST-1]
-          $('sitemapindex').append(sitemapIndexEntry(forwardedHost, rootPath, entity, firstIndex, lastIndex))
-        })
-      }
-    })
+  let $: any;
+  if (forwardedPath === "/_v/public/newsitemap/sitemap.xml") {
+    $ = await sitemapIndex(forwardedHost, rootPath, vbase);
   } else {
-    $ = cheerio.load('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">', {
-      xmlMode: true,
-    })
-    const [entity, startIndex=0, maybeLastIndex] = replace(/^\/_v\/public\/newsitemap\/(.+?)\.xml$/, '$1', forwardedPath).split('-')
-    const lastIndex = maybeLastIndex ? Number(maybeLastIndex) : Number(indexTable[entity]) - 1
-    const routes = await rewriter.listInternals(Number(startIndex), lastIndex as number, entity)
-    routes.forEach((route: Internal) => $('urlset').append(URLEntry(forwardedHost, rootPath, route)))
+    $ = cheerio.load(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">',
+      {
+        xmlMode: true
+      }
+    );
+    const fileName = replace(
+      /^\/_v\/public\/newsitemap\/(.+?)\.xml$/,
+      "$1",
+      forwardedPath
+    );
+    const maybeRoutes = await vbase.getJSON<Internal[]>(
+      SITEMAP_BUCKET,
+      fileName,
+      true
+    );
+    if (!maybeRoutes) {
+      ctx.status = 404;
+      throw new Error("Sitemap entry not found");
+    }
+    maybeRoutes.forEach((route: Internal) => {
+      $("urlset").append(URLEntry(forwardedHost, rootPath, route));
+    });
   }
 
-  ctx.set('Content-Type', 'text/xml')
-  ctx.body = $.xml()
-  ctx.status = 200
-  ctx.set('cache-control', production ? `public, max-age=${TEN_MINUTES_S}`: 'no-cache')
+  ctx.set("Content-Type", "text/xml");
+  ctx.body = $.xml();
+  ctx.status = 200;
+  ctx.set(
+    "cache-control",
+    production ? `public, max-age=${ONE_DAY_S}` : "no-cache"
+  );
+  if (production) {
+    events.sendEvent("", GENERATE_SITEMAP_EVENT);
+  }
 }

--- a/node/middlewares/newSitemap.ts
+++ b/node/middlewares/newSitemap.ts
@@ -1,15 +1,17 @@
-import { VBase } from '@vtex/api'
-import * as cheerio from 'cheerio'
-import { replace } from 'ramda'
-import { Internal } from 'vtex.rewriter'
+import { VBase } from "@vtex/api";
+import * as cheerio from "cheerio";
+import { replace } from "ramda";
+import { Internal } from "vtex.rewriter";
 
 import {
   GENERATE_SITEMAP_EVENT,
   SITEMAP_BUCKET,
-  SITEMAP_INDEX
-} from './generateSitemap'
+  SITEMAP_INDEX,
+  SitemapEntry,
+  SitemapIndex
+} from "./generateSitemap";
 
-const ONE_DAY_S = 24 * 60 * 60
+const ONE_DAY_S = 24 * 60 * 60;
 
 const sitemapIndexEntry = (
   forwardedHost: string,
@@ -20,7 +22,7 @@ const sitemapIndexEntry = (
   `<sitemap>
       <loc>https://${forwardedHost}${rootPath}/_v/public/newsitemap/${entry}.xml</loc>
       <lastmod>${lastUpdated}</lastmod>
-    </sitemap>`
+    </sitemap>`;
 
 const URLEntry = (
   forwardedHost: string,
@@ -33,7 +35,7 @@ const URLEntry = (
       <lastmod>${lastUpdated}</lastmod>
       <changefreq>weekly</changefreq>
       <priority>0.4</priority>
-    `
+    `;
   if (route.imagePath && route.imageTitle) {
     // add image metainfo
     entry = `
@@ -41,10 +43,10 @@ const URLEntry = (
       <image:loc>${route.imagePath}</image:loc>
       <image:title>${route.imageTitle}</image:title>
     </image:image>
-    ${entry}`
+    ${entry}`;
   }
-  return `<url>${entry}</url>`
-}
+  return `<url>${entry}</url>`;
+};
 
 const sitemapIndex = async (
   forwardedHost: string,
@@ -54,80 +56,81 @@ const sitemapIndex = async (
   const $ = cheerio.load(
     '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
     {
-      xmlMode: true,
+      xmlMode: true
     }
-  )
+  );
 
-  const indexData = await vbase.getJSON<{
-    index: string[];
-    lastUpdated: string;
-  }>(SITEMAP_BUCKET, SITEMAP_INDEX, true)
+  const indexData = await vbase.getJSON<SitemapIndex>(
+    SITEMAP_BUCKET,
+    SITEMAP_INDEX,
+    true
+  );
 
   if (!indexData) {
     throw new Error(
-      'Sitemap not generated, you need to do that first <LINK TO DOC>'
-    )
+      "Sitemap not generated, you need to do that first <LINK TO DOC>"
+    );
   }
-  const { index, lastUpdated } = indexData
+  const { index, lastUpdated } = indexData as SitemapIndex;
   index.forEach(entry =>
-    $('sitemapindex').append(
+    $("sitemapindex").append(
       sitemapIndexEntry(forwardedHost, rootPath, entry, lastUpdated)
     )
-  )
-  return $
-}
+  );
+  return $;
+};
 
 export async function sitemap(ctx: Context) {
   const {
     vtex: { production },
-    clients: { vbase, events },
-  } = ctx
-  const forwardedHost = ctx.get('x-forwarded-host')
-  let rootPath = ctx.get('x-vtex-root-path')
+    clients: { vbase, events }
+  } = ctx;
+  const forwardedHost = ctx.get("x-forwarded-host");
+  let rootPath = ctx.get("x-vtex-root-path");
   // Defend against malformed root path. It should always start with `/`.
-  if (rootPath && !rootPath.startsWith('/')) {
-    rootPath = `/${rootPath}`
+  if (rootPath && !rootPath.startsWith("/")) {
+    rootPath = `/${rootPath}`;
   }
-  const [forwardedPath] = ctx.get('x-forwarded-path').split('?')
+  const [forwardedPath] = ctx.get("x-forwarded-path").split("?");
 
-  let $: any
-  if (forwardedPath === '/_v/public/newsitemap/sitemap.xml') {
-    $ = await sitemapIndex(forwardedHost, rootPath, vbase)
+  let $: any;
+  if (forwardedPath === "/_v/public/newsitemap/sitemap.xml") {
+    $ = await sitemapIndex(forwardedHost, rootPath, vbase);
   } else {
     $ = cheerio.load(
       '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">',
       {
-        xmlMode: true,
+        xmlMode: true
       }
-    )
+    );
     const fileName = replace(
       /^\/_v\/public\/newsitemap\/(.+?)\.xml$/,
-      '$1',
+      "$1",
       forwardedPath
-    )
-    const maybeRoutesInfo = await vbase.getJSON<{ lastUpdated: string, routes: Internal[] }>(
+    );
+    const maybeRoutesInfo = await vbase.getJSON<SitemapEntry>(
       SITEMAP_BUCKET,
       fileName,
       true
-    )
+    );
     if (!maybeRoutesInfo) {
-      ctx.status = 404
-      throw new Error('Sitemap entry not found')
+      ctx.status = 404;
+      throw new Error("Sitemap entry not found");
     }
-    const { routes, lastUpdated } = maybeRoutesInfo
+    const { routes, lastUpdated } = maybeRoutesInfo as SitemapEntry;
     routes.forEach((route: Internal) => {
-      $('urlset').append(URLEntry(forwardedHost, rootPath, route, lastUpdated))
-    })
+      $("urlset").append(URLEntry(forwardedHost, rootPath, route, lastUpdated));
+    });
   }
 
-  ctx.set('Content-Type', 'text/xml')
-  ctx.body = $.xml()
-  ctx.status = 200
+  ctx.set("Content-Type", "text/xml");
+  ctx.body = $.xml();
+  ctx.status = 200;
   ctx.set(
-    'cache-control',
-    production ? `public, max-age=${ONE_DAY_S}` : 'no-cache'
-  )
+    "cache-control",
+    production ? `public, max-age=${ONE_DAY_S}` : "no-cache"
+  );
   if (production) {
-    events.sendEvent('', GENERATE_SITEMAP_EVENT)
+    events.sendEvent("", GENERATE_SITEMAP_EVENT);
   }
 }

--- a/node/middlewares/newSitemap.ts
+++ b/node/middlewares/newSitemap.ts
@@ -1,17 +1,17 @@
-import { VBase } from "@vtex/api";
-import * as cheerio from "cheerio";
-import { replace } from "ramda";
-import { Internal } from "vtex.rewriter";
+import { VBase } from '@vtex/api'
+import * as cheerio from 'cheerio'
+import { replace } from 'ramda'
+import { Internal } from 'vtex.rewriter'
 
 import {
   GENERATE_SITEMAP_EVENT,
   SITEMAP_BUCKET,
   SITEMAP_INDEX,
   SitemapEntry,
-  SitemapIndex
-} from "./generateSitemap";
+  SitemapIndex,
+} from './generateSitemap'
 
-const ONE_DAY_S = 24 * 60 * 60;
+const ONE_DAY_S = 24 * 60 * 60
 
 const sitemapIndexEntry = (
   forwardedHost: string,
@@ -22,7 +22,7 @@ const sitemapIndexEntry = (
   `<sitemap>
       <loc>https://${forwardedHost}${rootPath}/_v/public/newsitemap/${entry}.xml</loc>
       <lastmod>${lastUpdated}</lastmod>
-    </sitemap>`;
+    </sitemap>`
 
 const URLEntry = (
   forwardedHost: string,
@@ -35,7 +35,7 @@ const URLEntry = (
       <lastmod>${lastUpdated}</lastmod>
       <changefreq>weekly</changefreq>
       <priority>0.4</priority>
-    `;
+    `
   if (route.imagePath && route.imageTitle) {
     // add image metainfo
     entry = `
@@ -43,10 +43,10 @@ const URLEntry = (
       <image:loc>${route.imagePath}</image:loc>
       <image:title>${route.imageTitle}</image:title>
     </image:image>
-    ${entry}`;
+    ${entry}`
   }
-  return `<url>${entry}</url>`;
-};
+  return `<url>${entry}</url>`
+}
 
 const sitemapIndex = async (
   forwardedHost: string,
@@ -56,81 +56,81 @@ const sitemapIndex = async (
   const $ = cheerio.load(
     '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
     {
-      xmlMode: true
+      xmlMode: true,
     }
-  );
+  )
 
   const indexData = await vbase.getJSON<SitemapIndex>(
     SITEMAP_BUCKET,
     SITEMAP_INDEX,
     true
-  );
+  )
 
   if (!indexData) {
     throw new Error(
-      "Sitemap not generated, you need to do that first <LINK TO DOC>"
-    );
+      'Sitemap not generated, you need to do that first <LINK TO DOC>'
+    )
   }
-  const { index, lastUpdated } = indexData as SitemapIndex;
+  const { index, lastUpdated } = indexData as SitemapIndex
   index.forEach(entry =>
-    $("sitemapindex").append(
+    $('sitemapindex').append(
       sitemapIndexEntry(forwardedHost, rootPath, entry, lastUpdated)
     )
-  );
-  return $;
-};
+  )
+  return $
+}
 
 export async function sitemap(ctx: Context) {
   const {
     vtex: { production },
-    clients: { vbase, events }
-  } = ctx;
-  const forwardedHost = ctx.get("x-forwarded-host");
-  let rootPath = ctx.get("x-vtex-root-path");
+    clients: { vbase, events },
+  } = ctx
+  const forwardedHost = ctx.get('x-forwarded-host')
+  let rootPath = ctx.get('x-vtex-root-path')
   // Defend against malformed root path. It should always start with `/`.
-  if (rootPath && !rootPath.startsWith("/")) {
-    rootPath = `/${rootPath}`;
+  if (rootPath && !rootPath.startsWith('/')) {
+    rootPath = `/${rootPath}`
   }
-  const [forwardedPath] = ctx.get("x-forwarded-path").split("?");
+  const [forwardedPath] = ctx.get('x-forwarded-path').split('?')
 
-  let $: any;
-  if (forwardedPath === "/_v/public/newsitemap/sitemap.xml") {
-    $ = await sitemapIndex(forwardedHost, rootPath, vbase);
+  let $: any
+  if (forwardedPath === '/_v/public/newsitemap/sitemap.xml') {
+    $ = await sitemapIndex(forwardedHost, rootPath, vbase)
   } else {
     $ = cheerio.load(
       '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">',
       {
-        xmlMode: true
+        xmlMode: true,
       }
-    );
+    )
     const fileName = replace(
       /^\/_v\/public\/newsitemap\/(.+?)\.xml$/,
-      "$1",
+      '$1',
       forwardedPath
-    );
+    )
     const maybeRoutesInfo = await vbase.getJSON<SitemapEntry>(
       SITEMAP_BUCKET,
       fileName,
       true
-    );
+    )
     if (!maybeRoutesInfo) {
-      ctx.status = 404;
-      throw new Error("Sitemap entry not found");
+      ctx.status = 404
+      throw new Error('Sitemap entry not found')
     }
-    const { routes, lastUpdated } = maybeRoutesInfo as SitemapEntry;
+    const { routes, lastUpdated } = maybeRoutesInfo as SitemapEntry
     routes.forEach((route: Internal) => {
-      $("urlset").append(URLEntry(forwardedHost, rootPath, route, lastUpdated));
-    });
+      $('urlset').append(URLEntry(forwardedHost, rootPath, route, lastUpdated))
+    })
   }
 
-  ctx.set("Content-Type", "text/xml");
-  ctx.body = $.xml();
-  ctx.status = 200;
+  ctx.set('Content-Type', 'text/xml')
+  ctx.body = $.xml()
+  ctx.status = 200
   ctx.set(
-    "cache-control",
-    production ? `public, max-age=${ONE_DAY_S}` : "no-cache"
-  );
+    'cache-control',
+    production ? `public, max-age=${ONE_DAY_S}` : 'no-cache'
+  )
   if (production) {
-    events.sendEvent("", GENERATE_SITEMAP_EVENT);
+    events.sendEvent('', GENERATE_SITEMAP_EVENT)
   }
 }

--- a/node/middlewares/newSitemap.ts
+++ b/node/middlewares/newSitemap.ts
@@ -1,8 +1,8 @@
 import { VBase } from '@vtex/api'
 import * as cheerio from 'cheerio'
 import { replace } from 'ramda'
-import { Internal } from 'vtex.rewriter'
 
+import { Internal } from '../clients/rewriter'
 import {
   GENERATE_SITEMAP_EVENT,
   SITEMAP_BUCKET,

--- a/node/middlewares/newSitemap.ts
+++ b/node/middlewares/newSitemap.ts
@@ -1,15 +1,15 @@
-import { VBase } from "@vtex/api";
-import * as cheerio from "cheerio";
-import { replace } from "ramda";
-import { Internal } from "vtex.rewriter";
+import { VBase } from '@vtex/api'
+import * as cheerio from 'cheerio'
+import { replace } from 'ramda'
+import { Internal } from 'vtex.rewriter'
 
 import {
   GENERATE_SITEMAP_EVENT,
   SITEMAP_BUCKET,
   SITEMAP_INDEX
-} from "./generateSitemap";
+} from './generateSitemap'
 
-const ONE_DAY_S = 24 * 60 * 60;
+const ONE_DAY_S = 24 * 60 * 60
 
 const sitemapIndexEntry = (
   forwardedHost: string,
@@ -20,19 +20,20 @@ const sitemapIndexEntry = (
   `<sitemap>
       <loc>https://${forwardedHost}${rootPath}/_v/public/newsitemap/${entry}.xml</loc>
       <lastmod>${lastUpdated}</lastmod>
-    </sitemap>`;
+    </sitemap>`
 
 const URLEntry = (
   forwardedHost: string,
   rootPath: string,
-  route: Internal
+  route: Internal,
+  lastUpdated: string
 ): string => {
   let entry = `
       <loc>https://${forwardedHost}${rootPath}${route.from}</loc>
-      <lastmod>${currentDate()}</lastmod>
+      <lastmod>${lastUpdated}</lastmod>
       <changefreq>weekly</changefreq>
       <priority>0.4</priority>
-    `;
+    `
   if (route.imagePath && route.imageTitle) {
     // add image metainfo
     entry = `
@@ -40,10 +41,10 @@ const URLEntry = (
       <image:loc>${route.imagePath}</image:loc>
       <image:title>${route.imageTitle}</image:title>
     </image:image>
-    ${entry}`;
+    ${entry}`
   }
-  return `<url>${entry}</url>`;
-};
+  return `<url>${entry}</url>`
+}
 
 const sitemapIndex = async (
   forwardedHost: string,
@@ -53,79 +54,80 @@ const sitemapIndex = async (
   const $ = cheerio.load(
     '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
     {
-      xmlMode: true
+      xmlMode: true,
     }
-  );
+  )
 
   const indexData = await vbase.getJSON<{
     index: string[];
     lastUpdated: string;
-  }>(SITEMAP_BUCKET, SITEMAP_INDEX, true);
+  }>(SITEMAP_BUCKET, SITEMAP_INDEX, true)
 
   if (!indexData) {
     throw new Error(
-      "Sitemap not generated, you need to do that first <LINK TO DOC>"
-    );
+      'Sitemap not generated, you need to do that first <LINK TO DOC>'
+    )
   }
-  const { index, lastUpdated } = indexData;
+  const { index, lastUpdated } = indexData
   index.forEach(entry =>
-    $("sitemapindex").append(
+    $('sitemapindex').append(
       sitemapIndexEntry(forwardedHost, rootPath, entry, lastUpdated)
     )
-  );
-  return $;
-};
+  )
+  return $
+}
 
 export async function sitemap(ctx: Context) {
   const {
     vtex: { production },
-    clients: { vbase, events }
-  } = ctx;
-  const forwardedHost = ctx.get("x-forwarded-host");
-  let rootPath = ctx.get("x-vtex-root-path");
+    clients: { vbase, events },
+  } = ctx
+  const forwardedHost = ctx.get('x-forwarded-host')
+  let rootPath = ctx.get('x-vtex-root-path')
   // Defend against malformed root path. It should always start with `/`.
-  if (rootPath && !rootPath.startsWith("/")) {
-    rootPath = `/${rootPath}`;
+  if (rootPath && !rootPath.startsWith('/')) {
+    rootPath = `/${rootPath}`
   }
-  const [forwardedPath] = ctx.get("x-forwarded-path").split("?");
+  const [forwardedPath] = ctx.get('x-forwarded-path').split('?')
 
-  let $: any;
-  if (forwardedPath === "/_v/public/newsitemap/sitemap.xml") {
-    $ = await sitemapIndex(forwardedHost, rootPath, vbase);
+  let $: any
+  if (forwardedPath === '/_v/public/newsitemap/sitemap.xml') {
+    $ = await sitemapIndex(forwardedHost, rootPath, vbase)
   } else {
     $ = cheerio.load(
       '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">',
       {
-        xmlMode: true
+        xmlMode: true,
       }
-    );
+    )
     const fileName = replace(
       /^\/_v\/public\/newsitemap\/(.+?)\.xml$/,
-      "$1",
+      '$1',
       forwardedPath
-    );
-    const maybeRoutes = await vbase.getJSON<Internal[]>(
+    )
+    const maybeRoutesInfo = await vbase.getJSON<{ lastUpdated: string, routes: Internal[] }>(
       SITEMAP_BUCKET,
       fileName,
       true
-    );
-    if (!maybeRoutes) {
-      ctx.status = 404;
-      throw new Error("Sitemap entry not found");
+    )
+    if (!maybeRoutesInfo) {
+      ctx.status = 404
+      throw new Error('Sitemap entry not found')
     }
-    maybeRoutes.forEach((route: Internal) => {
-      $("urlset").append(URLEntry(forwardedHost, rootPath, route));
-    });
+    const { routes, lastUpdated } = maybeRoutesInfo
+    routes.forEach((route: Internal) => {
+      $('urlset').append(URLEntry(forwardedHost, rootPath, route, lastUpdated))
+    })
   }
 
-  ctx.set("Content-Type", "text/xml");
-  ctx.body = $.xml();
-  ctx.status = 200;
+  ctx.set('Content-Type', 'text/xml')
+  ctx.body = $.xml()
+  ctx.status = 200
   ctx.set(
-    "cache-control",
-    production ? `public, max-age=${ONE_DAY_S}` : "no-cache"
-  );
+    'cache-control',
+    production ? `public, max-age=${ONE_DAY_S}` : 'no-cache'
+  )
   if (production) {
-    events.sendEvent("", GENERATE_SITEMAP_EVENT);
+    events.sendEvent('', GENERATE_SITEMAP_EVENT)
   }
 }

--- a/node/package.json
+++ b/node/package.json
@@ -14,13 +14,16 @@
     "@types/cheerio": "^0.22.8",
     "@types/co-body": "^0.0.3",
     "@types/koa": "^2.0.48",
-    "@types/node": "^7.0.8",
+    "@types/node": "^12.0.0",
     "@types/ramda": "^0.26.8",
     "@types/route-parser": "^0.1.2",
-    "@vtex/api": "^3.55.2",
+    "@vtex/api": "^3.0.0",
+    "gocommerce.sitemap-app": "http://gocommerce.vtexassets.com/_v/public/typings/v1/gocommerce.sitemap-app@1.2.0/public/_types/react",
     "tslint": "^5.11.0",
     "tslint-config-vtex": "^2.1.0",
-    "typescript": "3.5.2"
+    "typescript": "3.8.3",
+    "vtex.catalog-api-proxy": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.7.2/public/_types/react",
+    "vtex.rewriter": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.30.0/public/@types/vtex.rewriter"
   },
   "resolutions": {
     "**/lodash": "^4.17.11"

--- a/node/resources/utils.ts
+++ b/node/resources/utils.ts
@@ -6,3 +6,5 @@ export const notFound = <T>(fallback: T) => (error: any): T => {
 }
 
 export const currentDate = ():string => (new Date()).toISOString().split('T')[0]
+
+export class SitemapNotFound extends Error {}

--- a/node/service.json
+++ b/node/service.json
@@ -45,7 +45,7 @@
       "path": "/_v/public/newsitemap/:path",
       "public": true
     },
-    "sitemapGenerator": {
+    "generateSitemap": {
       "path": "/generate-sitemap",
       "public": false
     },

--- a/node/service.json
+++ b/node/service.json
@@ -45,6 +45,10 @@
       "path": "/_v/public/newsitemap/:path",
       "public": true
     },
+    "sitemapGenerator": {
+      "path": "/generate-sitemap",
+      "public": false
+    },
     "robots": {
       "path": "/robots.txt",
       "public": true
@@ -53,6 +57,12 @@
       "path": "/canonical",
       "public": false,
       "smartcache": true
+    }
+  },
+  "events": {
+    "generateSitemap": {
+      "sender": "vtex.store-sitemap",
+      "keys": ["sitemap.generate"]
     }
   }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2,17 +2,43 @@
 # yarn lockfile v1
 
 
-"@apollographql/apollo-tools@^0.3.3", "@apollographql/apollo-tools@^0.3.6":
+"@apollo/protobufjs@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.0.3.tgz#02c655aedd4ba7c7f64cbc3d2b1dd9a000a391ba"
+  integrity sha512-gqeT810Ect9WIqsrgfUvr+ljSB5m1PyBae9HGdrRyQ3HjHjTcjVvxpsMYXlUk4rUHnrfUqyoGvLSy2yLlRGEOw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.0"
+    "@types/node" "^10.1.0"
+    long "^4.0.0"
+
+"@apollographql/apollo-tools@^0.3.3":
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/@apollographql/apollo-tools/-/apollo-tools-0.3.7.tgz#3bc9c35b9fff65febd4ddc0c1fc04677693a3d40"
   integrity sha512-+ertvzAwzkYmuUtT8zH3Zi6jPdyxZwOgnYaZHY7iLnMVJDhQKWlkyjLMF8wyzlPiEdDImVUMm5lOIBZo7LkGlg==
   dependencies:
     apollo-env "0.5.1"
 
-"@apollographql/graphql-playground-html@1.6.20":
-  version "1.6.20"
-  resolved "https://registry.yarnpkg.com/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.20.tgz#bf9f2acdf319c0959fad8ec1239741dd2ead4e8d"
-  integrity sha512-3LWZa80HcP70Pl+H4KhLDJ7S0px+9/c8GTXdl6SpunRecUaB27g/oOQnAjNHLHdbWuGE0uyqcuGiTfbKB3ilaQ==
+"@apollographql/apollo-tools@^0.4.3":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@apollographql/apollo-tools/-/apollo-tools-0.4.4.tgz#e2564c35b22536de1e4a633b2fdea219583d082c"
+  integrity sha512-kldvB9c+vzimel4yEktlkB08gaJ5DQn9ZuIfFf1kpAw+++5hFwYRWTyKgOhF9LbOWNWGropesYC7WwLja2erhQ==
+  dependencies:
+    apollo-env "^0.6.2"
+
+"@apollographql/graphql-playground-html@1.6.24":
+  version "1.6.24"
+  resolved "https://registry.yarnpkg.com/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz#3ce939cb127fb8aaa3ffc1e90dff9b8af9f2e3dc"
+  integrity sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -131,6 +157,23 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/fs-capacitor@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz#17113e25817f584f58100fb7a08eed288b81956e"
+  integrity sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/graphql-upload@^8.0.0":
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/@types/graphql-upload/-/graphql-upload-8.0.3.tgz#b371edb5f305a2a1f7b7843a890a2a7adc55c3ec"
+  integrity sha512-hmLg9pCU/GmxBscg8GCr1vmSoEmbItNNxdD5YH2TJkXm//8atjwuprB+xJBK714JG1dkxbbhp5RHX+Pz1KsCMA==
+  dependencies:
+    "@types/express" "*"
+    "@types/fs-capacitor" "*"
+    "@types/koa" "*"
+    graphql "^14.5.3"
+
 "@types/http-assert@*":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.4.0.tgz#41d173466e396e99a14d75f7160cc997f2f9ed8b"
@@ -162,26 +205,35 @@
     "@types/node" "*"
 
 "@types/long@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
-  integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
 "@types/mime@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
+
+"@types/node-fetch@2.5.5":
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.5.tgz#cd264e20a81f4600a6c52864d38e7fef72485e92"
+  integrity sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
 
 "@types/node@*":
   version "10.5.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.7.tgz#960d9feb3ade2233bcc9843c918d740b4f78a7cf"
 
 "@types/node@^10.1.0":
-  version "10.14.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.9.tgz#2e8d678039d27943ce53a1913386133227fd9066"
-  integrity sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg==
+  version "10.17.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.17.tgz#7a183163a9e6ff720d86502db23ba4aade5999b8"
+  integrity sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==
 
-"@types/node@^7.0.8":
-  version "7.0.69"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.69.tgz#709629340708ec0e1845559bf5c0c88d26d31dca"
+"@types/node@^12.0.0":
+  version "12.12.30"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.30.tgz#3501e6f09b954de9c404671cefdbcc5d9d7c45f6"
+  integrity sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg==
 
 "@types/qs@*":
   version "6.5.1"
@@ -209,21 +261,21 @@
     "@types/mime" "*"
 
 "@types/ws@^6.0.0":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.1.tgz#ca7a3f3756aa12f62a0a62145ed14c6db25d5a28"
-  integrity sha512-EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.4.tgz#7797707c8acce8f76d8c34b370d4645b70421ff1"
+  integrity sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==
   dependencies:
-    "@types/events" "*"
     "@types/node" "*"
 
-"@vtex/api@^3.55.2":
-  version "3.55.2"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.55.2.tgz#086bfdc95d5da268a64f0a4df3e4879589e03e81"
-  integrity sha512-i0LaoSHJdGOwmlFDQ3X1RvY0mqQIFATH91VesLT20avgE6m/lQLvnSwVrX+zfI2SIsCpcMCHnUaJ+R8MIB/S/Q==
+"@vtex/api@^3.0.0":
+  version "3.72.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.72.1.tgz#963ff26758acf26a5e79f22d8e020e9ee6625a29"
+  integrity sha512-EuKkyRmkKcUA3HiVDJkS4RMgdvvwcFTzwkhVQNWgzFs4k1X/ib0oRHdowQCvN8ryAWBwx10i0QOALSK1I9xTqg==
   dependencies:
     "@types/koa" "^2.0.48"
     "@types/koa-compose" "^3.2.3"
     "@wry/equality" "^0.1.9"
+    agentkeepalive "^4.0.2"
     apollo-datasource "^0.3.1"
     apollo-server-core "^2.4.8"
     apollo-server-errors "^2.2.1"
@@ -240,6 +292,7 @@
     graphql-extensions "^0.5.7"
     graphql-tools "^3.1.1"
     graphql-upload "^8.0.4"
+    js-base64 "^2.5.1"
     koa-compose "^4.1.0"
     lru-cache "^5.1.1"
     mime-types "^2.1.12"
@@ -251,6 +304,7 @@
     semver "^5.5.1"
     stats-lite vtex/node-stats-lite#dist
     tar-fs "^2.0.0"
+    xss "^1.0.6"
 
 "@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.9"
@@ -258,6 +312,15 @@
   integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
   dependencies:
     tslib "^1.9.3"
+
+agentkeepalive@^4.0.2:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.1.0.tgz#a48e040ed16745dd29ce923675f60c9c90f39ee0"
+  integrity sha512-CW/n1wxF8RpEuuiq6Vbn9S8m0VSYDMnZESqaJ6F2cWN9fY8rei2qaxweIaRgq+ek8TqfoFIsUjaGNKGGEHElSg==
+  dependencies:
+    debug "^4.1.0"
+    depd "^1.1.2"
+    humanize-ms "^1.2.1"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -273,13 +336,13 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-apollo-cache-control@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.7.2.tgz#b8852422d973c582493e85c776abc9c660090162"
-  integrity sha512-7prjFN8H9lRE0npqGG8kM3XICvNCcgQt6eCy8kkcPOIZwM+F8m8ShjEfNF9UWW32i+poOk3G67HegPRyjCc6/Q==
+apollo-cache-control@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.9.0.tgz#43d2eec16d40248683f46b9b28937a89ad3b5c54"
+  integrity sha512-iLT6IT4Ul5cMfBcJAvhpk3a7AD6fXqvFxNmJEPVapVJHbSKYIjra4PTis13sOyN5Y3WQS6a+NRFxAW8+hL3q3Q==
   dependencies:
-    apollo-server-env "2.4.0"
-    graphql-extensions "0.7.2"
+    apollo-server-env "^2.4.3"
+    graphql-extensions "^0.11.0"
 
 apollo-datasource-rest@^0.2.1:
   version "0.2.1"
@@ -298,14 +361,6 @@ apollo-datasource@0.2.1:
     apollo-server-caching "0.2.1"
     apollo-server-env "2.2.0"
 
-apollo-datasource@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-0.5.0.tgz#7a8c97e23da7b9c15cb65103d63178ab19eca5e9"
-  integrity sha512-SVXxJyKlWguuDjxkY/WGlC/ykdsTmPxSF0z8FenagcQ91aPURXzXP1ZDz5PbamY+0iiCRubazkxtTQw4GWTFPg==
-  dependencies:
-    apollo-server-caching "0.4.0"
-    apollo-server-env "2.4.0"
-
 apollo-datasource@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-0.3.1.tgz#4b7ec4c2dd7d08eb7edc865b95fd46b83a4679fd"
@@ -314,24 +369,34 @@ apollo-datasource@^0.3.1:
     apollo-server-caching "0.3.1"
     apollo-server-env "2.2.0"
 
-apollo-engine-reporting-protobuf@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.3.1.tgz#a581257fa8e3bb115ce38bf1b22e052d1475ad69"
-  integrity sha512-Ui3nPG6BSZF8BEqxFs6EkX6mj2OnFLMejxEHSOdM82bakyeouCGd7J0fiy8AD6liJoIyc4X7XfH4ZGGMvMh11A==
+apollo-datasource@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-0.7.0.tgz#2a6d82edb2eba21b4ddf21877009ba39ff821945"
+  integrity sha512-Yja12BgNQhzuFGG/5Nw2MQe0hkuQy2+9er09HxeEyAf2rUDIPnhPrn1MDoZTB8MU7UGfjwITC+1ofzKkkrZobA==
   dependencies:
-    protobufjs "^6.8.6"
+    apollo-server-caching "^0.5.1"
+    apollo-server-env "^2.4.3"
 
-apollo-engine-reporting@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/apollo-engine-reporting/-/apollo-engine-reporting-1.3.1.tgz#f2c2c63f865871a57c15cdbb2a3bcd4b4af28115"
-  integrity sha512-e0Xp+0yite8DH/xm9fnJt42CxfWAcY6waiq3icCMAgO9T7saXzVOPpl84SkuA+hIJUBtfaKrTnC+7Jxi/I7OrQ==
+apollo-engine-reporting-protobuf@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.4.tgz#73a064f8c9f2d6605192d1673729c66ec47d9cb7"
+  integrity sha512-SGrIkUR7Q/VjU8YG98xcvo340C4DaNUhg/TXOtGsMlfiJDzHwVau/Bv6zifAzBafp2lj0XND6Daj5kyT/eSI/w==
   dependencies:
-    apollo-engine-reporting-protobuf "0.3.1"
-    apollo-graphql "^0.3.0"
-    apollo-server-core "2.6.3"
-    apollo-server-env "2.4.0"
+    "@apollo/protobufjs" "^1.0.3"
+
+apollo-engine-reporting@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/apollo-engine-reporting/-/apollo-engine-reporting-1.7.0.tgz#34a54ef96da5cfe1dea3a4fdf02768d1cc7e154f"
+  integrity sha512-jsjSnoHrRmk4XXK4aFU17YSJILmWsilKRwIeN74QJsSxjn5SCVF4EI/ebf/MNrTHpft8EhShx+wdkAcOD9ivqA==
+  dependencies:
+    apollo-engine-reporting-protobuf "^0.4.4"
+    apollo-graphql "^0.4.0"
+    apollo-server-caching "^0.5.1"
+    apollo-server-env "^2.4.3"
+    apollo-server-errors "^2.4.0"
+    apollo-server-types "^0.3.0"
     async-retry "^1.2.1"
-    graphql-extensions "0.7.2"
+    graphql-extensions "^0.11.0"
 
 apollo-env@0.5.1:
   version "0.5.1"
@@ -342,15 +407,35 @@ apollo-env@0.5.1:
     node-fetch "^2.2.0"
     sha.js "^2.4.11"
 
-apollo-graphql@^0.3.0:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/apollo-graphql/-/apollo-graphql-0.3.2.tgz#8881a87f1d5fcf80837b34dba90737e664eabe9a"
-  integrity sha512-YbzYGR14GV0023m//EU66vOzZ3i7c04V/SF8Qk+60vf1sOWyKgO6mxZJ4BKhw10qWUayirhSDxq3frYE+qSG0A==
+apollo-env@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/apollo-env/-/apollo-env-0.6.2.tgz#7d456cf3f36e410ce5e7b5f81506efd15095aadf"
+  integrity sha512-Vb/doL1ZbzkNDJCQ6kYGOrphRx63rMERYo3MT2pzm2pNEdm6AK60InMgJaeh3RLK3cjGllOXFAgP8IY+m+TaEg==
   dependencies:
-    apollo-env "0.5.1"
+    "@types/node-fetch" "2.5.5"
+    core-js "^3.0.1"
+    node-fetch "^2.2.0"
+    sha.js "^2.4.11"
+
+apollo-graphql@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/apollo-graphql/-/apollo-graphql-0.4.1.tgz#c9470b11cf29f046f6e9b747034417c200222e91"
+  integrity sha512-dz2wtGeCqUDAKAj4KXLKLZiFY791aoXduul3KcLo8/6SwqWlsuZiPe0oB8mENHZZc/EchCpTMTJZX2ZENsOt2A==
+  dependencies:
+    apollo-env "^0.6.2"
     lodash.sortby "^4.7.0"
 
-apollo-link@^1.2.2, apollo-link@^1.2.3:
+apollo-link@^1.2.2:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.13.tgz#dff00fbf19dfcd90fddbc14b6a3f9a771acac6c4"
+  integrity sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==
+  dependencies:
+    apollo-utilities "^1.3.0"
+    ts-invariant "^0.4.0"
+    tslib "^1.9.3"
+    zen-observable-ts "^0.8.20"
+
+apollo-link@^1.2.3:
   version "1.2.12"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.12.tgz#014b514fba95f1945c38ad4c216f31bcfee68429"
   integrity sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==
@@ -373,32 +458,33 @@ apollo-server-caching@0.3.1:
   dependencies:
     lru-cache "^5.0.0"
 
-apollo-server-caching@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.4.0.tgz#e82917590d723c0adc1fa52900e79e93ad65e4d9"
-  integrity sha512-GTOZdbLhrSOKYNWMYgaqX5cVNSMT0bGUTZKV8/tYlyYmsB6ey7l6iId3Q7UpHS6F6OR2lstz5XaKZ+T3fDfPzQ==
+apollo-server-caching@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.5.1.tgz#5cd0536ad5473abb667cc82b59bc56b96fb35db6"
+  integrity sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==
   dependencies:
     lru-cache "^5.0.0"
 
-apollo-server-core@2.6.3, apollo-server-core@^2.4.8:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.6.3.tgz#786c8251c82cf29acb5cae9635a321f0644332ae"
-  integrity sha512-tfC0QO1NbJW3ShkB5pRCnUaYEkW2AwnswaTeedkfv//EO3yiC/9LeouCK5F22T8stQG+vGjvCqf0C8ldI/XsIA==
+apollo-server-core@^2.4.8:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.11.0.tgz#91a055ce6cf12a8b43e8a4811d465d97fa324eac"
+  integrity sha512-jHLOqwTRlyWzqWNRlwr2M/xfrt+lw2pHtKYyxUGRjWFo8EM5TX1gDcTKtbtvx9p5m+ZBDAhcWp/rpq0vSz4tqg==
   dependencies:
-    "@apollographql/apollo-tools" "^0.3.6"
-    "@apollographql/graphql-playground-html" "1.6.20"
+    "@apollographql/apollo-tools" "^0.4.3"
+    "@apollographql/graphql-playground-html" "1.6.24"
+    "@types/graphql-upload" "^8.0.0"
     "@types/ws" "^6.0.0"
-    apollo-cache-control "0.7.2"
-    apollo-datasource "0.5.0"
-    apollo-engine-reporting "1.3.1"
-    apollo-server-caching "0.4.0"
-    apollo-server-env "2.4.0"
-    apollo-server-errors "2.3.0"
-    apollo-server-plugin-base "0.5.2"
-    apollo-tracing "0.7.2"
+    apollo-cache-control "^0.9.0"
+    apollo-datasource "^0.7.0"
+    apollo-engine-reporting "^1.7.0"
+    apollo-server-caching "^0.5.1"
+    apollo-server-env "^2.4.3"
+    apollo-server-errors "^2.4.0"
+    apollo-server-plugin-base "^0.7.0"
+    apollo-server-types "^0.3.0"
+    apollo-tracing "^0.9.0"
     fast-json-stable-stringify "^2.0.0"
-    graphql-extensions "0.7.2"
-    graphql-subscriptions "^1.0.0"
+    graphql-extensions "^0.11.0"
     graphql-tag "^2.9.2"
     graphql-tools "^4.0.0"
     graphql-upload "^8.0.2"
@@ -413,10 +499,10 @@ apollo-server-env@2.2.0:
     node-fetch "^2.1.2"
     util.promisify "^1.0.0"
 
-apollo-server-env@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-2.4.0.tgz#6611556c6b627a1636eed31317d4f7ea30705872"
-  integrity sha512-7ispR68lv92viFeu5zsRUVGP+oxsVI3WeeBNniM22Cx619maBUwcYTIC3+Y3LpXILhLZCzA1FASZwusgSlyN9w==
+apollo-server-env@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-2.4.3.tgz#9bceedaae07eafb96becdfd478f8d92617d825d2"
+  integrity sha512-23R5Xo9OMYX0iyTu2/qT0EUb+AULCBriA9w8HDfMoChB8M+lFClqUkYtaTTHDfp6eoARLW8kDBhPOBavsvKAjA==
   dependencies:
     node-fetch "^2.1.2"
     util.promisify "^1.0.0"
@@ -425,23 +511,39 @@ apollo-server-errors@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.2.0.tgz#5b452a1d6ff76440eb0f127511dc58031a8f3cb5"
 
-apollo-server-errors@2.3.0, apollo-server-errors@^2.2.1:
+apollo-server-errors@^2.2.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.3.0.tgz#700622b66a16dffcad3b017e4796749814edc061"
   integrity sha512-rUvzwMo2ZQgzzPh2kcJyfbRSfVKRMhfIlhY7BzUfM4x6ZT0aijlgsf714Ll3Mbf5Fxii32kD0A/DmKsTecpccw==
 
-apollo-server-plugin-base@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.5.2.tgz#f97ba983f1e825fec49cba8ff6a23d00e1901819"
-  integrity sha512-j81CpadRLhxikBYHMh91X4aTxfzFnmmebEiIR9rruS6dywWCxV2aLW87l9ocD1MiueNam0ysdwZkX4F3D4csNw==
+apollo-server-errors@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.4.0.tgz#3096db02b6ae8d434a6b2678f74eddaad8b98452"
+  integrity sha512-ZouZfr2sGavvI18rgdRcyY2ausRAlVtWNOax9zca8ZG2io86dM59jXBmUVSNlVZSmBsIh45YxYC0eRvr2vmRdg==
 
-apollo-tracing@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.7.2.tgz#7730159a4670bca465ac1bfa01f9902610a7aba4"
-  integrity sha512-bT4/n8Vy9DweC3+XWJelJD41FBlKMXR0OVxjLMiCe9clb4yTgKhYxRGTyh9KjmhWsng9gG/DphO0ixWsOgdXmA==
+apollo-server-plugin-base@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.7.0.tgz#5c52ee311c8ef884b8b17be1b7e9d4597966dae1"
+  integrity sha512-//xgYrBYLQSr92W0z3mYsFGoVz3wxKNsv3KcOUBhbOCGTbjZgP7vHOE1vhHhRcpZKKXmjXTVONdrnNJ+XVGi6A==
   dependencies:
-    apollo-server-env "2.4.0"
-    graphql-extensions "0.7.2"
+    apollo-server-types "^0.3.0"
+
+apollo-server-types@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-types/-/apollo-server-types-0.3.0.tgz#01732e5fc6c4a2a522f051d5685c57a8e3dc620e"
+  integrity sha512-FMo7kbTkhph9dfIQ3xDbRLObqmdQH9mwSjxhGsX+JxGMRPPXgd3+GZvCeVKOi/udxh//w1otSeAqItjvbj0tfQ==
+  dependencies:
+    apollo-engine-reporting-protobuf "^0.4.4"
+    apollo-server-caching "^0.5.1"
+    apollo-server-env "^2.4.3"
+
+apollo-tracing@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.9.0.tgz#673916ae674b9a8d72603f73af0b8561dfd38306"
+  integrity sha512-oqspTrf4BLGbKkIk1vF+I31C2v7PPJmF36TFpT/+zJxNvJw54ji4ZMhtytgVqbVldQEintJmdHQIidYBGKmu+g==
+  dependencies:
+    apollo-server-env "^2.4.3"
+    graphql-extensions "^0.11.0"
 
 apollo-utilities@^1.0.1, apollo-utilities@^1.3.0:
   version "1.3.2"
@@ -491,14 +593,14 @@ argparse@^1.0.7:
     sprintf-js "~1.0.2"
 
 async-limiter@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
-  integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
 async-retry@^1.2.1:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.2.3.tgz#a6521f338358d322b1a0012b79030c6f411d1ce0"
-  integrity sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.1.tgz#139f31f8ddce50c0870b0ba558a6079684aaed55"
+  integrity sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==
   dependencies:
     retry "0.12.0"
 
@@ -508,6 +610,11 @@ async@^2.0.0:
   integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
   dependencies:
     lodash "^4.17.11"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 axios-retry@^3.1.2:
   version "3.1.2"
@@ -689,9 +796,21 @@ color-name@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^2.12.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+
+commander@^2.9.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 compress-commons@^1.2.0:
   version "1.2.2"
@@ -713,9 +832,9 @@ cookie@^0.3.1:
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
 core-js@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.1.4.tgz#3a2837fc48e582e1ae25907afcd6cf03b0cc7a07"
-  integrity sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
+  integrity sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -749,6 +868,11 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
+cssfilter@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
+  integrity sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=
+
 dataloader@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
@@ -760,13 +884,25 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 define-properties@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   dependencies:
     object-keys "^1.0.12"
 
-depd@~1.1.2:
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
@@ -890,6 +1026,15 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 fs-capacitor@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-2.0.4.tgz#5a22e72d40ae5078b4fe64fe4d08c0d3fc88ad3c"
@@ -940,16 +1085,22 @@ glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+"gocommerce.sitemap-app@http://gocommerce.vtexassets.com/_v/public/typings/v1/gocommerce.sitemap-app@1.2.0/public/_types/react":
+  version "0.0.0"
+  resolved "http://gocommerce.vtexassets.com/_v/public/typings/v1/gocommerce.sitemap-app@1.2.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+
 graceful-fs@^4.1.0, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
 
-graphql-extensions@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.7.2.tgz#8711543f835661eaf24b48d6ac2aad44dbbd5506"
-  integrity sha512-TuVINuAOrEtzQAkAlCZMi9aP5rcZ+pVaqoBI5fD2k5O9fmb8OuXUQOW028MUhC66tg4E7h4YSF1uYUIimbu4SQ==
+graphql-extensions@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.11.0.tgz#2923b06f7452dad186d835327974b6c3ebb9c58f"
+  integrity sha512-zd4qfUiJoYBx2MwJusM36SEJ+YmJ1ki8YF8nlm9mgaPDUzsnmFq4lxULxUfhLAXFwZw7MbEN2vV4V6WiNgSJLg==
   dependencies:
-    "@apollographql/apollo-tools" "^0.3.6"
+    "@apollographql/apollo-tools" "^0.4.3"
+    apollo-server-env "^2.4.3"
+    apollo-server-types "^0.3.0"
 
 graphql-extensions@^0.5.7:
   version "0.5.7"
@@ -958,17 +1109,10 @@ graphql-extensions@^0.5.7:
   dependencies:
     "@apollographql/apollo-tools" "^0.3.3"
 
-graphql-subscriptions@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz#5f2fa4233eda44cf7570526adfcf3c16937aef11"
-  integrity sha512-6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==
-  dependencies:
-    iterall "^1.2.1"
-
 graphql-tag@^2.9.2:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
-  integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.3.tgz#ea1baba5eb8fc6339e4c4cf049dabe522b0edf03"
+  integrity sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==
 
 graphql-tools@^3.1.1:
   version "3.1.1"
@@ -982,9 +1126,9 @@ graphql-tools@^3.1.1:
     uuid "^3.1.0"
 
 graphql-tools@^4.0.0:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.4.tgz#ca08a63454221fdde825fe45fbd315eb2a6d566b"
-  integrity sha512-chF12etTIGVVGy3fCTJ1ivJX2KB7OSG4c6UOJQuqOHCmBQwTyNgCDuejZKvpYxNZiEx7bwIjrodDgDe9RIkjlw==
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.7.tgz#743309b96cb657ff45b607ee0a07193cd987e43c"
+  integrity sha512-rApl8sT8t/W1uQRcwzxMYyUBiCl/XicluApiDkNze5TX/GR0BSTQMjM2UcRGdTmkbsb1Eqq6afkyyeG/zMxZYQ==
   dependencies:
     apollo-link "^1.2.3"
     apollo-utilities "^1.0.1"
@@ -993,13 +1137,13 @@ graphql-tools@^4.0.0:
     uuid "^3.1.0"
 
 graphql-upload@^8.0.2, graphql-upload@^8.0.4:
-  version "8.0.7"
-  resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-8.0.7.tgz#8644264e241529552ea4b3797e7ee15809cf01a3"
-  integrity sha512-gi2yygbDPXbHPC7H0PNPqP++VKSoNoJO4UrXWq4T0Bi4IhyUd3Ycop/FSxhx2svWIK3jdXR/i0vi91yR1aAF0g==
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-8.1.0.tgz#6d0ab662db5677a68bfb1f2c870ab2544c14939a"
+  integrity sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==
   dependencies:
     busboy "^0.3.1"
     fs-capacitor "^2.0.4"
-    http-errors "^1.7.2"
+    http-errors "^1.7.3"
     object-path "^0.11.4"
 
 graphql@^0.13.2:
@@ -1013,6 +1157,13 @@ graphql@^14.1.1:
   version "14.1.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.1.1.tgz#d5d77df4b19ef41538d7215d1e7a28834619fac0"
   integrity sha512-C5zDzLqvfPAgTtP8AUPIt9keDabrdRAqSWjj2OPRKrKxI9Fb65I36s1uCs1UUBFnSWTdO7hyHi7z1ZbwKMKF6Q==
+  dependencies:
+    iterall "^1.2.2"
+
+graphql@^14.5.3:
+  version "14.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
+  integrity sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
   dependencies:
     iterall "^1.2.2"
 
@@ -1060,16 +1211,23 @@ http-errors@1.6.3:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
-http-errors@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
-  integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
+http-errors@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
+  integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
   dependencies:
     depd "~1.1.2"
-    inherits "2.0.3"
+    inherits "2.0.4"
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
+  dependencies:
+    ms "^2.0.0"
 
 iconv-lite@0.4.23:
   version "0.4.23"
@@ -1097,10 +1255,15 @@ inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
+inherits@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
 is-buffer@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
-  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
@@ -1139,9 +1302,19 @@ isnumber@~1.0.0:
   resolved "https://registry.yarnpkg.com/isnumber/-/isnumber-1.0.0.tgz#0e3f9759b581d99dd85086f0ec2a74909cfadd01"
   integrity sha1-Dj+XWbWB2Z3YUIbw7Cp0kJz63QE=
 
-iterall@^1.1.3, iterall@^1.2.1, iterall@^1.2.2:
+iterall@^1.1.3, iterall@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
+
+iterall@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
+  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
+
+js-base64@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
+  integrity sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==
 
 js-tokens@^3.0.2:
   version "3.0.2"
@@ -1275,6 +1448,11 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+ms@^2.0.0, ms@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
 node-fetch@^2.1.2:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.1.tgz#1fe551e0ded6c45b3b3b937d0fb46f76df718d1e"
@@ -1352,25 +1530,6 @@ path-parse@^1.0.5:
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
-
-protobufjs@^6.8.6:
-  version "6.8.8"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
-  integrity sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^4.0.0"
-    "@types/node" "^10.1.0"
-    long "^4.0.0"
 
 pump@^3.0.0:
   version "3.0.0"
@@ -1453,7 +1612,12 @@ rwlock@^5.0.0:
   resolved "https://registry.yarnpkg.com/rwlock/-/rwlock-5.0.0.tgz#888d6a77a3351cc1a209204ef2ee1722093836cf"
   integrity sha1-iI1qd6M1HMGiCSBO8u4XIgk4Ns8=
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
+  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
+
+safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -1665,10 +1829,10 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -1695,6 +1859,14 @@ uuid@^3.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
+"vtex.catalog-api-proxy@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.7.2/public/_types/react":
+  version "0.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.7.2/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+
+"vtex.rewriter@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.30.0/public/@types/vtex.rewriter":
+  version "1.30.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.30.0/public/@types/vtex.rewriter#e69bb25422308b48140d6838379395a7cf463e84"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -1713,6 +1885,14 @@ ws@^6.0.0:
   dependencies:
     async-limiter "~1.0.0"
 
+xss@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.6.tgz#eaf11e9fc476e3ae289944a1009efddd8a124b51"
+  integrity sha512-6Q9TPBeNyoTRxgZFk5Ggaepk/4vUOYdOsIUYvLehcsIZTFjaavbVnsuAkLA5lIFuug5hw8zxcB9tm01gsjph2A==
+  dependencies:
+    commander "^2.9.0"
+    cssfilter "0.0.10"
+
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
@@ -1726,6 +1906,14 @@ zen-observable-ts@^0.8.19:
   version "0.8.19"
   resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz#c094cd20e83ddb02a11144a6e2a89706946b5694"
   integrity sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==
+  dependencies:
+    tslib "^1.9.3"
+    zen-observable "^0.8.0"
+
+zen-observable-ts@^0.8.20:
+  version "0.8.20"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz#44091e335d3fcbc97f6497e63e7f57d5b516b163"
+  integrity sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==
   dependencies:
     tslib "^1.9.3"
     zen-observable "^0.8.0"


### PR DESCRIPTION
# What this does?

Creates a sitemap from the entries in rewriter database, every time the sitemap is accessed it publishes an event to generate the sitemap. `store-sitemap` listens to this events, then it uses rewriter's list api to generate the pages and saves it in Vbase. When the sitemap is accessed it returns the page according to what is saved in VBase.

It is possible to generate the sitemap through an API.

# How to test it

1. Generate the sitemap through the API: **POST** `http://store-sitemap.vtex.aws-us-east-1.vtex.io/{{account}}/{{workspace}}/generate-sitemap`

> It may take a while to completely generate the sitemap

2. Access the sitemap through the path `/_v/public/newsitemap/sitemap.xml`