### PR TITLE
Event chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Updated generation middleware to event chain
 
 ## [2.2.3] - 2020-05-08
 ### Fixed

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,5 +1,7 @@
 import { IOClients } from '@vtex/api'
 
+
+import { Meta } from './meta'
 import { Rewriter } from './rewriter'
 import { Robots } from './robots'
 import { RobotsGC } from './robotsGC'
@@ -15,5 +17,9 @@ export class Clients extends IOClients {
 
   public get rewriter() {
     return this.getOrSet('rewriter', Rewriter)
+  }
+
+  public get meta() {
+    return this.getOrSet('meta', Meta)
   }
 }

--- a/node/clients/meta.ts
+++ b/node/clients/meta.ts
@@ -1,0 +1,10 @@
+import { AppClient, InstanceOptions, IOContext } from '@vtex/api'
+
+
+export class Meta extends AppClient {
+  constructor(ctx: IOContext, opts?: InstanceOptions) {
+    super('vtex.store-sitemap@2.x', ctx, opts)
+  }
+
+  public makeMetaRequest = () => this.http.get('/meta')
+}

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -8,7 +8,7 @@ import {
 import { Clients } from './clients'
 
 declare global {
-  interface State extends RecorderState {
+  interface State extends RecorderState, SitemapGenerationEvent {
     platform?: string
     binding: Binding | null
     bucket: string
@@ -35,5 +35,11 @@ declare global {
   interface Config {
     productionPrefix: string
     generationPrefix: string
+  }
+
+  interface SitemapGenerationEvent {
+    next: Maybe<string>
+    report: Record<string, number>
+    count: number
   }
 }

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -17,7 +17,6 @@ declare global {
     rootPath: string
     matchingBindings: Binding[]
     bindingAddress?: string
-    config?: Config
   }
 
   type Context = ServiceContext<Clients, State>

--- a/node/index.ts
+++ b/node/index.ts
@@ -16,6 +16,7 @@ import {
   generateSitemap,
   generateSitemapFromREST,
 } from './middlewares/generateSitemap'
+import { meta } from './middlewares/meta'
 import { methodNotAllowed } from './middlewares/methods'
 import { prepare } from './middlewares/prepare'
 import { robots } from './middlewares/robots'
@@ -76,5 +77,6 @@ export default new Service<Clients, State, ParamsContext>({
     }),
     sitemap: sitemapPipeline,
     sitemapEntry: sitemapEntryPipeline,
+    meta,
   },
 })

--- a/node/index.ts
+++ b/node/index.ts
@@ -33,8 +33,13 @@ const rewriterCacheStorage = new LRUCache<string, Cached>({
   max: 3000,
 })
 
+const vbaseCacheStorage = new LRUCache<string, Cached>({
+  max: 3000,
+})
+
 metrics.trackCache('rewrite', rewriterCacheStorage)
 metrics.trackCache('tenant', tenantCacheStorage)
+metrics.trackCache('vbase', vbaseCacheStorage)
 
 const clients: ClientsConfig<Clients> = {
   implementation: Clients,
@@ -49,6 +54,9 @@ const clients: ClientsConfig<Clients> = {
     },
     tenant: {
       memoryCache: tenantCacheStorage,
+    },
+    vbase: {
+      memoryCache: vbaseCacheStorage,
     },
   },
 }

--- a/node/middlewares/generateSitemap.ts
+++ b/node/middlewares/generateSitemap.ts
@@ -78,8 +78,8 @@ const generate = async (ctx: EventContext) => {
 
   const routesByBinding = routes.reduce(
     (acc, internal) => {
+      report[internal.type] = (report[internal.type] || 0) + 1
       if (!startsWith('notFound', internal.type) && internal.id !== 'search') {
-        report[internal.type] = (report[internal.type] || 0) + 1
         const { binding } = internal
         const bindingRoutes: Internal[] = path([binding, internal.type], acc) || []
         acc[binding] = {

--- a/node/middlewares/generateSitemap.ts
+++ b/node/middlewares/generateSitemap.ts
@@ -121,7 +121,6 @@ const generate = async (ctx: EventContext) => {
   )
 
   if (responseNext) {
-    // Ne middleware
     const payload: SitemapGenerationEvent = {
       count: count + 1,
       next: responseNext,

--- a/node/middlewares/generateSitemap.ts
+++ b/node/middlewares/generateSitemap.ts
@@ -53,7 +53,7 @@ const generate = async (ctx: EventContext) => {
   if (!ctx.body.count) {
     await initializeSitemap(ctx)
   }
-  const { clients: { events,vbase, rewriter }, body, vtex: { logger } } = ctx
+  const { clients: { events, vbase, rewriter, meta }, body, vtex: { logger } } = ctx
   const {generationPrefix, productionPrefix } = await vbase.getJSON<Config>(CONFIG_BUCKET, CONFIG_FILE, true) || DEFAULT_CONFIG
   const {
     count,
@@ -72,7 +72,7 @@ const generate = async (ctx: EventContext) => {
   })
 
   const response = await rewriter.listInternals(LIST_LIMIT, next)
-  // Call meta?
+  await meta.makeMetaRequest()
   const routes: Internal[] = response.routes || []
   const responseNext = response.next
 
@@ -96,7 +96,7 @@ const generate = async (ctx: EventContext) => {
     Object.keys(routesByBinding).map(async bindingId => {
       const bucket = getBucket(generationPrefix, hashString(bindingId))
       const groupedRoutes = routesByBinding[bindingId]
-      // Call meta?
+      await meta.makeMetaRequest()
       await Promise.all(
         Object.keys(groupedRoutes).map(async entityType => {
           const entityRoutes = routesByBinding[bindingId][entityType]

--- a/node/middlewares/generateSitemap.ts
+++ b/node/middlewares/generateSitemap.ts
@@ -6,6 +6,7 @@ import { CONFIG_BUCKET, CONFIG_FILE, getBucket, hashString, TENANT_CACHE_TTL_S }
 
 export const SITEMAP_INDEX = 'sitemap_index'
 export const GENERATE_SITEMAP_EVENT = 'sitemap.generate'
+
 const LIST_LIMIT = 300
 
 export interface SitemapIndex {
@@ -23,91 +24,17 @@ const DEFAULT_CONFIG: Config = {
   productionPrefix: 'A',
 }
 
+const DEFAULT_EVENT: SitemapGenerationEvent = {
+  count: 0,
+  next: null,
+  report: {},
+}
+
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 const currentDate = (): string => new Date().toISOString().split('T')[0]
 
-const generate = async (ctx: Context | EventContext) => {
-  const { state: { config }, clients: { vbase, rewriter } } = ctx
-
-  const {generationPrefix, productionPrefix } = config!
-
-  let response
-  let next: Maybe<string>
-  let count = 0
-
-  const report: Record<string, number> = {}
-
-  do {
-    response = await rewriter.listInternals(LIST_LIMIT, next)
-    const length: number = response.routes?.length ?? 0
-    if (!response.routes || !length) {
-      next = response.next
-      continue
-    }
-    const routesByBinding = response.routes.reduce(
-      (acc, internal) => {
-        if (!startsWith('notFound', internal.type) && internal.id !== 'search') {
-          report[internal.type] = (report[internal.type] || 0) + 1
-          const { binding } = internal
-          const routes: Internal[] = path([binding, internal.type], acc) || []
-          acc[binding] = {
-            ...acc[binding] || {},
-            [internal.type]: routes.concat(internal),
-          }
-        }
-        return acc
-      },
-      {} as Record<string, Record<string,Internal[]>>
-    )
-
-    await Promise.all(
-      Object.keys(routesByBinding).map(async bindingId => {
-        const bucket = getBucket(generationPrefix, hashString(bindingId))
-        const groupedRoutes = routesByBinding[bindingId]
-        await Promise.all(
-          Object.keys(groupedRoutes).map(async entityType => {
-            const routes = routesByBinding[bindingId][entityType]
-            const entry = `${entityType}-${count}`
-            const indexData = await vbase.getJSON<SitemapIndex>(bucket, SITEMAP_INDEX, true)
-            const { index } = indexData as SitemapIndex
-            index.push(entry)
-            const lastUpdated = currentDate()
-            await Promise.all([
-              vbase.saveJSON<SitemapIndex>(bucket, SITEMAP_INDEX, {
-                index,
-                lastUpdated,
-              }),
-              vbase.saveJSON<SitemapEntry>(bucket, entry, {
-                lastUpdated,
-                routes,
-              }),
-            ])
-          })
-        )
-      })
-    )
-
-    count++
-    next = response.next
-    await sleep(300)
-  } while (next)
-  await vbase.saveJSON<Config>(CONFIG_BUCKET, CONFIG_FILE, {
-    generationPrefix: productionPrefix,
-    productionPrefix: generationPrefix,
-  })
-  ctx.vtex.logger.info({
-    message: 'Sitemap complete',
-    report,
-  })
-}
-
-export async function generateSitemapFromREST(ctx: Context) {
-  generateSitemap(ctx)
-  ctx.status = 200
-}
-
-export async function generateSitemap(ctx: Context | EventContext) {
+const initializeSitemap = async (ctx: EventContext) => {
   const { tenant, vbase } = ctx.clients
   const { bindings } = await tenant.info({
     forceMaxAge: TENANT_CACHE_TTL_S,
@@ -121,5 +48,106 @@ export async function generateSitemap(ctx: Context | EventContext) {
       lastUpdated: '',
     })
   ))
+}
+
+const generate = async (ctx: EventContext) => {
+  const { state: { config }, clients: { events,vbase, rewriter }, body, vtex: { logger } } = ctx
+  if (!body.count) {
+    await initializeSitemap(ctx)
+  }
+  const {generationPrefix, productionPrefix } = config!
+  const {
+    count,
+    next,
+    report,
+  }: SitemapGenerationEvent = !body.count
+  ? DEFAULT_EVENT
+  : body
+  logger.debug({
+    message: 'Event received',
+    payload: {
+      count,
+      next,
+      report,
+    },
+  })
+
+  const response = await rewriter.listInternals(LIST_LIMIT, next)
+  // Call meta?
+  const routes: Internal[] = response.routes || []
+  const responseNext = response.next
+
+  const routesByBinding = routes.reduce(
+    (acc, internal) => {
+      if (!startsWith('notFound', internal.type) && internal.id !== 'search') {
+        report[internal.type] = (report[internal.type] || 0) + 1
+        const { binding } = internal
+        const bindingRoutes: Internal[] = path([binding, internal.type], acc) || []
+        acc[binding] = {
+          ...acc[binding] || {},
+          [internal.type]: bindingRoutes.concat(internal),
+        }
+      }
+      return acc
+    },
+    {} as Record<string, Record<string, Internal[]>>
+  )
+
+  await Promise.all(
+    Object.keys(routesByBinding).map(async bindingId => {
+      const bucket = getBucket(generationPrefix, hashString(bindingId))
+      const groupedRoutes = routesByBinding[bindingId]
+      // Call meta?
+      await Promise.all(
+        Object.keys(groupedRoutes).map(async entityType => {
+          const entityRoutes = routesByBinding[bindingId][entityType]
+          const entry = `${entityType}-${count}`
+          const indexData = await vbase.getJSON<SitemapIndex>(bucket, SITEMAP_INDEX, true)
+          const { index } = indexData as SitemapIndex
+          index.push(entry)
+          const lastUpdated = currentDate()
+          await Promise.all([
+            vbase.saveJSON<SitemapIndex>(bucket, SITEMAP_INDEX, {
+              index,
+              lastUpdated,
+            }),
+            vbase.saveJSON<SitemapEntry>(bucket, entry, {
+              lastUpdated,
+              routes: entityRoutes,
+            }),
+          ])
+        })
+      )
+    })
+  )
+
+  if (responseNext) {
+    const payload: SitemapGenerationEvent = {
+      count: count + 1,
+      next: responseNext,
+      report,
+    }
+    await sleep(300)
+    events.sendEvent('', GENERATE_SITEMAP_EVENT, payload)
+    logger.debug({ message: 'Event sent', payload, })
+  } else {
+    await vbase.saveJSON<Config>(CONFIG_BUCKET, CONFIG_FILE, {
+      generationPrefix: productionPrefix,
+      productionPrefix: generationPrefix,
+    })
+    ctx.vtex.logger.info({
+      message: 'Sitemap complete',
+      report,
+    })
+  }
+}
+
+export async function generateSitemapFromREST(ctx: Context) {
+  const { events } = ctx.clients
+  events.sendEvent('', GENERATE_SITEMAP_EVENT)
+  ctx.status = 200
+}
+
+export async function generateSitemap(ctx: EventContext) {
   generate(ctx)
 }

--- a/node/middlewares/meta.ts
+++ b/node/middlewares/meta.ts
@@ -1,0 +1,3 @@
+export async function meta(ctx: Context) {
+  ctx.status = 200
+}

--- a/node/service.json
+++ b/node/service.json
@@ -21,6 +21,10 @@
     "robots": {
       "path": "/robots.txt",
       "public": true
+    },
+    "meta": {
+      "path": "/meta",
+      "public": false
     }
   },
   "events": {


### PR DESCRIPTION
Starts using event chain, since it is a better method to avoid the pod's death and simulate a job in IO. 