### PR TITLE
Fix - alternates links for cross-border accounts

### DIFF
--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -1,5 +1,5 @@
 import { AppGraphQLClient, InstanceOptions, IOContext } from '@vtex/api'
-import { Internal, ListInternalsResponse } from 'vtex.rewriter'
+import { EntityLocator, Internal, ListInternalsResponse, RoutesByBinding } from 'vtex.rewriter'
 
 export class Rewriter extends AppGraphQLClient {
   constructor(ctx: IOContext, opts?: InstanceOptions) {
@@ -46,4 +46,31 @@ export class Rewriter extends AppGraphQLClient {
       .then(res => res.data?.internal?.listInternals) as Promise<
       ListInternalsResponse
     >
+
+    public routesById = (
+      locator: EntityLocator
+    ): Promise<RoutesByBinding[]> =>
+      this.graphql
+        .query<
+          { internal: { routes: RoutesByBinding[] } },
+          { locator: EntityLocator }
+        >(
+          {
+            query: `
+        query Routes($locator: EntityLocator!) {
+          internal {
+            routes(locator: $locator) {
+              route
+              binding
+            }
+          }
+        }
+        `,
+            variables: { locator },
+          },
+          {
+            metric: 'rewriter-get-internals',
+          }
+        )
+      .then(res => res.data?.internal?.routes) as Promise<RoutesByBinding[]>
 }

--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -37,6 +37,9 @@ export class Rewriter extends AppGraphQLClient {
           variables: { limit, next },
         },
         {
+          headers: {
+            'cache-control': 'no-cache',
+          },
           metric: 'rewriter-get-internals',
         }
       )

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -10,7 +10,7 @@ import { Clients } from './clients'
 declare global {
   interface State extends RecorderState {
     platform?: string
-    binding: Binding | null
+    binding: Binding
     bucket: string
     forwardedHost: string
     forwardedPath: string
@@ -38,14 +38,15 @@ declare global {
   interface Route {
     id: string
     path: string,
+    alternates: AlternateRoute[]
     imagePath?: string
     imageTitle?: string
-    alternates?: AlternateRoute[]
   }
 
   interface AlternateRoute {
     bindingId: string
     path: string
+    locale: string
   }
 
   interface Config {

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -36,9 +36,16 @@ declare global {
   }
 
   interface Route {
+    id: string
     path: string,
     imagePath?: string
     imageTitle?: string
+    alternates?: AlternateRoute[]
+  }
+
+  interface AlternateRoute {
+    bindingId: string
+    path: string
   }
 
   interface Config {

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -38,7 +38,7 @@ declare global {
   interface Route {
     id: string
     path: string,
-    alternates: AlternateRoute[]
+    alternates?: AlternateRoute[]
     imagePath?: string
     imageTitle?: string
   }
@@ -46,7 +46,6 @@ declare global {
   interface AlternateRoute {
     bindingId: string
     path: string
-    locale: string
   }
 
   interface Config {

--- a/node/middlewares/generateMiddlewares/utils.ts
+++ b/node/middlewares/generateMiddlewares/utils.ts
@@ -115,8 +115,8 @@ export const isSitemapComplete = async (vbase: VBase) => {
     isProductsRoutesComplete,
     isRewriterRoutesComplete,
   ] = await Promise.all([
-    vbase.getJSON(CONFIG_BUCKET, PRODUCT_ROUTES_INDEX),
-    vbase.getJSON(CONFIG_BUCKET, REWRITER_ROUTES_INDEX),
+    vbase.getJSON(CONFIG_BUCKET, PRODUCT_ROUTES_INDEX, true),
+    vbase.getJSON(CONFIG_BUCKET, REWRITER_ROUTES_INDEX, true),
   ])
   return isProductsRoutesComplete && isRewriterRoutesComplete
 }

--- a/node/middlewares/sitemapEntry.ts
+++ b/node/middlewares/sitemapEntry.ts
@@ -22,14 +22,14 @@ const URLEntry = (
   },
   } = ctx
   const querystring = bindingAddress
-    ? `${bindingAddress}`
+    ? `?__bindingAddress=${bindingAddress}`
     : ''
   const loc = `https://${forwardedHost}${rootPath}${route.path}${querystring}`
   const localization = route.alternates && route.alternates.length > 1
     ? route.alternates.map(
-        ({ bindingId, path }) => {
-          const alternateBinding = getBinding(bindingId, matchingBindings)
-          if (bindingId === binding.id || !alternateBinding) {
+      ({ bindingId, path }) => {
+        const alternateBinding = getBinding(bindingId, matchingBindings)
+        if (bindingId === binding.id || !alternateBinding) {
             return ''
           }
           const { canonicalBaseAddress, defaultLocale: locale } = alternateBinding

--- a/node/middlewares/sitemapEntry.ts
+++ b/node/middlewares/sitemapEntry.ts
@@ -5,8 +5,8 @@ import RouteParser from 'route-parser'
 import { SITEMAP_URL } from '../utils'
 import { SitemapEntry } from './generateMiddlewares/utils'
 
-const getCanonicalBaseAddress = (bindingId: string, bindings: Binding[]) =>
-  bindings.find(binding => binding.id === bindingId)?.canonicalBaseAddress
+const getBinding = (bindingId: string, bindings: Binding[]) =>
+  bindings.find(binding => binding.id === bindingId)
 
 const URLEntry = (
   ctx: Context,
@@ -25,13 +25,14 @@ const URLEntry = (
     ? `${bindingAddress}`
     : ''
   const loc = `https://${forwardedHost}${rootPath}${route.path}${querystring}`
-  const localization = route.alternates?.length > 1
+  const localization = route.alternates && route.alternates.length > 1
     ? route.alternates.map(
-        ({ bindingId, locale, path }) => {
-          const canonicalBaseAddress = getCanonicalBaseAddress(bindingId, matchingBindings)
-          if (bindingId === binding.id || !canonicalBaseAddress) {
+        ({ bindingId, path }) => {
+          const alternateBinding = getBinding(bindingId, matchingBindings)
+          if (bindingId === binding.id || !alternateBinding) {
             return ''
           }
+          const { canonicalBaseAddress, defaultLocale: locale } = alternateBinding
           const href = querystring
             ? `https://${forwardedHost}${path}?__bindingAddress=${canonicalBaseAddress}`
             : `https://${canonicalBaseAddress}${path}`

--- a/node/middlewares/sitemapEntry.ts
+++ b/node/middlewares/sitemapEntry.ts
@@ -1,29 +1,43 @@
+import { Binding } from '@vtex/api'
 import * as cheerio from 'cheerio'
 import RouteParser from 'route-parser'
 
 import { SITEMAP_URL } from '../utils'
 import { SitemapEntry } from './generateMiddlewares/utils'
 
+const getCanonicalBaseAddress = (bindingId: string, bindings: Binding[]) =>
+  bindings.find(binding => binding.id === bindingId)?.canonicalBaseAddress
+
 const URLEntry = (
-  forwardedHost: string,
-  rootPath: string,
+  ctx: Context,
   route: Route,
-  lastUpdated: string,
-  supportedLocations: string[],
-  bindingAddress?: string
+  lastUpdated: string
 ): string => {
+  const { state: {
+    binding,
+    bindingAddress,
+    forwardedHost,
+    rootPath,
+    matchingBindings,
+  },
+  } = ctx
   const querystring = bindingAddress
-    ? `?__bindingAddress=${bindingAddress}`
+    ? `${bindingAddress}`
     : ''
   const loc = `https://${forwardedHost}${rootPath}${route.path}${querystring}`
-  const localization = supportedLocations.length > 1
-    ? supportedLocations
-      .map(
-        locale =>
-          `<xhtml:link rel="alternate" hreflang="${locale}" href="${loc}${
-          querystring ? '&' : '?'
-          }cultureInfo=${locale}"/>`
-      )
+  const localization = route.alternates?.length > 1
+    ? route.alternates.map(
+        ({ bindingId, locale, path }) => {
+          const canonicalBaseAddress = getCanonicalBaseAddress(bindingId, matchingBindings)
+          if (bindingId === binding.id || !canonicalBaseAddress) {
+            return ''
+          }
+          const href = querystring
+            ? `https://${forwardedHost}${path}?__bindingAddress=${canonicalBaseAddress}`
+            : `https://${canonicalBaseAddress}${path}`
+          return `<xhtml:link rel="alternate" hreflang="${locale}" href="${href}"/>`
+        }
+       )
       .join('\n')
     : ''
   let entry = `
@@ -47,11 +61,8 @@ export async function sitemapEntry(ctx: Context, next: () => Promise<void>) {
   const {
     state: {
       binding,
-      bindingAddress,
-      forwardedHost,
       forwardedPath,
       bucket,
-      rootPath,
     },
     clients: { vbase },
   } = ctx
@@ -90,14 +101,7 @@ export async function sitemapEntry(ctx: Context, next: () => Promise<void>) {
   const { routes, lastUpdated } = maybeRoutesInfo as SitemapEntry
   routes.forEach((route: Route) => {
     $('urlset').append(
-      URLEntry(
-        forwardedHost,
-        rootPath,
-        route,
-        lastUpdated,
-        binding.supportedLocales,
-        bindingAddress
-      )
+      URLEntry(ctx, route, lastUpdated)
     )
   })
 


### PR DESCRIPTION
Previously the alternate links were built with the binding's supported locale. However, cross border  clients want to have the links from other bindings instead. This PR does that

