### PR TITLE
Uses apps token for catalog api authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Uses app's token for catalog api request
 
 ## [2.8.2] - 2020-07-02
 ### Fixed

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -19,17 +19,15 @@ export class Catalog extends ExternalClient {
         headers: {
           ...(options?.headers ?? {}),
           'Content-Type': 'application/json',
+          'VtexIdclientAutCookie': context.authToken,
           'X-Vtex-Use-Https': 'true',
         },
       }
     )
   }
 
-  public getProductsAndSkuIds (from: number, to: number, authToken?: string): Promise<GetProductsAndSkuIdsReponse>{
+  public getProductsAndSkuIds (from: number, to: number): Promise<GetProductsAndSkuIdsReponse>{
     return this.http.get('/api/catalog_system/pvt/products/GetProductAndSkuIds', {
-      headers: {
-        ...authToken ? { VtexIdclientAutCookie: authToken } : {},
-      },
       params: {
         _from: from,
         _to: to,

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -58,7 +58,6 @@ declare global {
 
   interface GenerationConfig {
     generationId: string
-    authToken: string
     endDate: string
   }
 

--- a/node/middlewares/generateMiddlewares/generateProductRoutes.test.ts
+++ b/node/middlewares/generateMiddlewares/generateProductRoutes.test.ts
@@ -14,7 +14,7 @@ import { TranslateArgs } from 'vtex.messages'
 
 import { Clients } from '../../clients'
 import { Messages } from '../../clients/messages'
-import { CONFIG_BUCKET, GENERATION_CONFIG_FILE, getBucket, hashString } from '../../utils'
+import { getBucket, hashString } from '../../utils'
 import { Catalog, GetProductsAndSkuIdsReponse } from './../../clients/catalog'
 import { GraphQLServer, ProductNotFound } from './../../clients/graphqlServer'
 import { STORE_PRODUCT } from './../../utils'
@@ -273,7 +273,6 @@ describe('Test product routes generation', () => {
         logger: loggerMock.object,
       },
     }
-    context.clients.vbase.saveJSON(CONFIG_BUCKET, GENERATION_CONFIG_FILE, { authToken: 'TOKEN' })
     next = jest.fn()
   })
 

--- a/node/middlewares/generateMiddlewares/generateProductRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateProductRoutes.ts
@@ -3,7 +3,7 @@ import { zipObj } from 'ramda'
 import { Product } from 'vtex.catalog-graphql'
 
 import { Clients } from '../../clients'
-import { CONFIG_BUCKET, GENERATION_CONFIG_FILE, getBucket, hashString, TENANT_CACHE_TTL_S } from '../../utils'
+import { getBucket, hashString, TENANT_CACHE_TTL_S } from '../../utils'
 import { GraphQLServer, ProductNotFound } from './../../clients/graphqlServer'
 import {
   createFileName,
@@ -179,10 +179,8 @@ export async function generateProductRoutes(ctx: EventContext, next: () => Promi
     invalidProducts,
   }: ProductRoutesGenerationEvent = body!
 
-  const { authToken } = await vbase.getJSON<GenerationConfig>(CONFIG_BUCKET, GENERATION_CONFIG_FILE)
-
   const to = from + PAGE_LIMIT - 1
-  const { data, range: { total } } = await catalog.getProductsAndSkuIds(from, to, authToken)
+  const { data, range: { total } } = await catalog.getProductsAndSkuIds(from, to)
 
   const productsInfo = await Promise.all(Object.keys(data).map(getProductInfo(data, tenantInfo, ctx.clients)))
 

--- a/node/middlewares/generateMiddlewares/groupEntries.ts
+++ b/node/middlewares/generateMiddlewares/groupEntries.ts
@@ -108,12 +108,12 @@ export async function groupEntries(ctx: EventContext) {
 
   const isComplete = await isSitemapComplete(enabledIndexFiles, vbase, logger)
   if (isComplete) {
-    logger.info({ message: `Sitemap complete`, payload: body })
     await vbase.saveJSON<Config>(CONFIG_BUCKET, CONFIG_FILE, {
       generationPrefix: productionPrefix,
       productionPrefix: generationPrefix,
     })
     await cleanConfigBucket(enabledIndexFiles, vbase)
+    logger.info({ message: `Sitemap complete`, payload: body })
     return
   }
 }

--- a/node/middlewares/prepare.ts
+++ b/node/middlewares/prepare.ts
@@ -9,14 +9,9 @@ import { DEFAULT_CONFIG } from './generateMiddlewares/utils'
 const TWO_HOURS = 2 * 60 * 60
 export async function prepare(ctx: Context, next: () => Promise<void>) {
   const {
-    vtex: { adminUserAuthToken, production, logger },
+    vtex: { production },
     clients: { vbase, tenant },
   } = ctx
-  if (!adminUserAuthToken) {
-      ctx.status = 401
-      logger.error(`Missing adminUserAuth token`)
-      return
-  }
   const forwardedHost = ctx.get('x-forwarded-host')
   let rootPath = ctx.get('x-vtex-root-path')
   // Defend against malformed root path. It should always start with `/`.

--- a/node/utils.test.ts
+++ b/node/utils.test.ts
@@ -18,7 +18,6 @@ const minusOneHourFromNowMS = () => `${new Date(Date.now() - 1 * 60 * 60 * 1000)
 const eventSent = jest.fn()
 
 const DEFAULT_CONFIG = {
-  authToken: 'TOKEN',
   endDate: oneHourFromNowMS(),
   generationId: '10',
 }
@@ -96,25 +95,12 @@ describe('Test startSitemapGeneration', () => {
         },
         vtex: {
           ...ioContext.object,
-          adminUserAuthToken: 'TOKEN',
           logger: loggerMock.object,
         },
       }
     })
 
-   it('Should return 401 if auth token isnt found', async () => {
-     const thisContext = {
-       ...context,
-       vtex: {
-         ...context.vtex,
-         adminUserAuthToken: undefined,
-       },
-     }
-     await startSitemapGeneration(thisContext)
-     expect(thisContext.status).toStrictEqual(401)
-   })
-
-   it('Should not start a generation if has already started', async () => {
+    it('Should not start a generation if has already started', async () => {
      const { vbase: vbaseClient } = context.clients
      await vbaseClient.saveJSON(CONFIG_BUCKET, GENERATION_CONFIG_FILE, DEFAULT_CONFIG)
      await startSitemapGeneration(context)

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -59,13 +59,7 @@ export const hashString = (str: string) => {
 export const getBucket = (prefix: string, bucketName: string) => `${prefix}_${bucketName}`
 
 export const startSitemapGeneration = async (ctx: Context) => {
-  const { clients: { vbase, events }, vtex: { logger, adminUserAuthToken } } = ctx
-  if (!adminUserAuthToken) {
-      ctx.status = 401
-      ctx.body = 'Missing adminUserAuth token'
-      logger.error(ctx.body)
-      return
-  }
+  const { clients: { vbase, events }, vtex: { logger } } = ctx
   const force = ctx.query.__force !== undefined
   const config = await vbase.getJSON<GenerationConfig>(CONFIG_BUCKET, GENERATION_CONFIG_FILE, true)
   if (config && validDate(config.endDate) && !force) {
@@ -76,7 +70,6 @@ export const startSitemapGeneration = async (ctx: Context) => {
   const generationId = (Math.random() * 10000).toString()
   logger.info({ message: 'New generation starting', generationId })
   await vbase.saveJSON<GenerationConfig>(CONFIG_BUCKET, GENERATION_CONFIG_FILE, {
-    authToken: adminUserAuthToken,
     endDate: oneHourFromNowMS(),
     generationId,
   })


### PR DESCRIPTION
Previously the sitemap app used the user token to authorize the request to the product list API from the catalog. However, this caused accounts with a huge catalog to not be able to create a sitemap, the token became invalid before the generation ended. 

Using the app's token will allow the generation of large sitemaps, even if it takes a while.