### PR TITLE
Wait event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Uses app's token for catalog api request
 
 ## [2.8.3] - 2020-07-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Uses app's token for catalog api request
+- Increases generation blocking time
+- Increases sitemap cache
 
 ## [2.8.3] - 2020-07-08
 ### Fixed

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -71,6 +71,11 @@ declare global {
     indexFile: string
   }
 
+  interface WaiitEvent {
+    payload: Record<string, any>
+    event: string
+  }
+
   interface RewriterRoutesGenerationEvent extends DefaultEvent  {
     next: Maybe<string>
     report: Record<string, number>

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -71,7 +71,7 @@ declare global {
     indexFile: string
   }
 
-  interface WaiitEvent {
+  interface WaitEvent {
     payload: Record<string, any>
     event: string
   }

--- a/node/index.ts
+++ b/node/index.ts
@@ -29,6 +29,7 @@ import { settings } from './middlewares/settings'
 import { sitemap } from './middlewares/sitemap'
 import { sitemapEntry } from './middlewares/sitemapEntry'
 import { tenant } from './middlewares/tenant'
+import { wait } from './middlewares/wait'
 
 const THREE_SECONDS_MS = 3 * 1000
 const EIGHT_SECOND_MS = 8 * 1000
@@ -84,6 +85,7 @@ export default new Service<Clients, State, ParamsContext>({
     generateRewriterRoutes: [generationPrepare, generateRewriterRoutes, sendNextEvent],
     generateSitemap: [settings, generationPrepare, generateSitemap],
     groupEntries: [settings, generationPrepare, groupEntries],
+    wait,
   },
   routes: {
     generateSitemap: generateSitemapFromREST,

--- a/node/middlewares/generateMiddlewares/sendNextEvent.ts
+++ b/node/middlewares/generateMiddlewares/sendNextEvent.ts
@@ -1,9 +1,14 @@
+import { WAIT_EVENT } from '../wait'
 import { sleep } from './utils'
 
 export async function sendNextEvent(ctx: EventContext) {
   const { clients: { events }, state: { nextEvent } } = ctx
   const { payload, event } = nextEvent
-  await sleep(300)
-  events.sendEvent('', event, payload)
+  await sleep(100)
+  const waitPayload: WaitEvent = {
+    event,
+    payload,
+  }
+  events.sendEvent('', WAIT_EVENT, waitPayload)
 }
 

--- a/node/middlewares/generateMiddlewares/utils.ts
+++ b/node/middlewares/generateMiddlewares/utils.ts
@@ -3,7 +3,7 @@ import { all } from 'ramda'
 import { Product, SalesChannel } from 'vtex.catalog-graphql'
 
 import { Messages } from '../../clients/messages'
-import { CONFIG_BUCKET, GENERATION_CONFIG_FILE, getBucket, hashString, STORE_PRODUCT, TENANT_CACHE_TTL_S } from '../../utils'
+import { CONFIG_BUCKET, getBucket, hashString, STORE_PRODUCT, TENANT_CACHE_TTL_S } from '../../utils'
 
 export const RAW_DATA_PREFIX = `${LINKED ? 'L' : ''}C`
 

--- a/node/middlewares/generateMiddlewares/utils.ts
+++ b/node/middlewares/generateMiddlewares/utils.ts
@@ -135,7 +135,6 @@ export const completeRoutes = async (file: string, vbase: VBase) =>
 
 export const cleanConfigBucket = async (enabledIndexFiles: string[], vbase: VBase) =>
   Promise.all([
-    vbase.deleteFile(CONFIG_BUCKET, GENERATION_CONFIG_FILE),
     ...enabledIndexFiles.map(
     indexFile => vbase.deleteFile(CONFIG_BUCKET, indexFile)),
   ])

--- a/node/middlewares/prepare.ts
+++ b/node/middlewares/prepare.ts
@@ -48,7 +48,7 @@ export async function prepare(ctx: Context, next: () => Promise<void>) {
   ctx.status = 200
   ctx.set(
     'cache-control',
-    production ? `public, max-age=${ONE_DAY}` : 'no-cache'
+    production ? `public, max-age=${ONE_DAY_S}` : 'no-cache'
   )
   if (production) {
     startSitemapGeneration(ctx)

--- a/node/middlewares/prepare.ts
+++ b/node/middlewares/prepare.ts
@@ -4,9 +4,8 @@ import { BindingResolver } from '../resources/bindings'
 import { CONFIG_BUCKET, CONFIG_FILE, getBucket, getMatchingBindings, hashString, startSitemapGeneration } from '../utils'
 import { DEFAULT_CONFIG } from './generateMiddlewares/utils'
 
-// TODO: Make cache last one day
-// const ONE_DAY_S = 24 * 60 * 60
-const TWO_HOURS = 2 * 60 * 60
+const ONE_DAY_S = 24 * 60 * 60
+
 export async function prepare(ctx: Context, next: () => Promise<void>) {
   const {
     vtex: { production },
@@ -49,7 +48,7 @@ export async function prepare(ctx: Context, next: () => Promise<void>) {
   ctx.status = 200
   ctx.set(
     'cache-control',
-    production ? `public, max-age=${TWO_HOURS}` : 'no-cache'
+    production ? `public, max-age=${ONE_DAY}` : 'no-cache'
   )
   if (production) {
     startSitemapGeneration(ctx)

--- a/node/middlewares/wait.ts
+++ b/node/middlewares/wait.ts
@@ -1,0 +1,9 @@
+import { sleep } from './generateMiddlewares/utils'
+
+export async function wait(ctx: EventContext) {
+  const { body, clients: { events } } = ctx
+  await sleep(100)
+
+  const { event, payload } = body
+  events.sendEvent('', event, payload)
+}

--- a/node/middlewares/wait.ts
+++ b/node/middlewares/wait.ts
@@ -1,8 +1,10 @@
 import { sleep } from './generateMiddlewares/utils'
 
+export const WAIT_EVENT = 'sitemap.wait'
+
 export async function wait(ctx: EventContext) {
   const { body, clients: { events } } = ctx
-  await sleep(100)
+  await sleep(50)
 
   const { event, payload } = body
   events.sendEvent('', event, payload)

--- a/node/service.json
+++ b/node/service.json
@@ -43,6 +43,10 @@
     "groupEntries": {
       "sender": "vtex.store-sitemap",
       "keys": ["sitemap.generate:group-entries"]
+    },
+    "wait": {
+      "sender": "vtex.store-sitemap",
+      "keys": ["sitemap.wait"]
     }
   }
 }

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -11,7 +11,7 @@ export const TENANT_CACHE_TTL_S = 60 * 10
 
 export const STORE_PRODUCT = 'vtex-storefront'
 
-const oneHourFromNowMS = () => `${new Date(Date.now() + 1 * 60 * 60 * 1000)}`
+const oneDayFromNowMS = () => `${new Date(Date.now() + 24 * 60 * 60 * 1000)}`
 
 const validBinding = (path: string) => (binding: Binding) => {
   const isStoreBinding = binding.targetProduct === STORE_PRODUCT
@@ -70,7 +70,7 @@ export const startSitemapGeneration = async (ctx: Context) => {
   const generationId = (Math.random() * 10000).toString()
   logger.info({ message: 'New generation starting', generationId })
   await vbase.saveJSON<GenerationConfig>(CONFIG_BUCKET, GENERATION_CONFIG_FILE, {
-    endDate: oneHourFromNowMS(),
+    endDate: oneDayFromNowMS(),
     generationId,
   })
   events.sendEvent('', GENERATE_SITEMAP_EVENT, { generationId })

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -11,7 +11,7 @@ export const TENANT_CACHE_TTL_S = 60 * 10
 
 export const STORE_PRODUCT = 'vtex-storefront'
 
-const oneDayFromNowMS = () => `${new Date(Date.now() + 24 * 60 * 60 * 1000)}`
+const oneWeekFromNowMS = () => `${new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)}`
 
 const validBinding = (path: string) => (binding: Binding) => {
   const isStoreBinding = binding.targetProduct === STORE_PRODUCT
@@ -70,7 +70,7 @@ export const startSitemapGeneration = async (ctx: Context) => {
   const generationId = (Math.random() * 10000).toString()
   logger.info({ message: 'New generation starting', generationId })
   await vbase.saveJSON<GenerationConfig>(CONFIG_BUCKET, GENERATION_CONFIG_FILE, {
-    endDate: oneDayFromNowMS(),
+    endDate: oneWeekFromNowMS(),
     generationId,
   })
   events.sendEvent('', GENERATE_SITEMAP_EVENT, { generationId })

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4828,7 +4828,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
Due to the processing velocity of the events and the amount of accounts generating the sitemap our infrastructure was not supporting the quantity of saves being made by the sitemap. 

This PR addresses this issue by adding a wait event for every generation event sent by the app.