### PR TITLE
Wait event

### DIFF
--- a/node/globals.ts
+++ b/node/globals.ts
@@ -71,6 +71,11 @@ declare global {
     indexFile: string
   }
 
+  interface WaiitEvent {
+    payload: Record<string, any>
+    event: string
+  }
+
   interface RewriterRoutesGenerationEvent extends DefaultEvent  {
     next: Maybe<string>
     report: Record<string, number>

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -71,7 +71,7 @@ declare global {
     indexFile: string
   }
 
-  interface WaiitEvent {
+  interface WaitEvent {
     payload: Record<string, any>
     event: string
   }

--- a/node/index.ts
+++ b/node/index.ts
@@ -29,6 +29,7 @@ import { settings } from './middlewares/settings'
 import { sitemap } from './middlewares/sitemap'
 import { sitemapEntry } from './middlewares/sitemapEntry'
 import { tenant } from './middlewares/tenant'
+import { wait } from './middlewares/wait'
 
 const THREE_SECONDS_MS = 3 * 1000
 const EIGHT_SECOND_MS = 8 * 1000
@@ -84,6 +85,7 @@ export default new Service<Clients, State, ParamsContext>({
     generateRewriterRoutes: [generationPrepare, generateRewriterRoutes, sendNextEvent],
     generateSitemap: [settings, generationPrepare, generateSitemap],
     groupEntries: [settings, generationPrepare, groupEntries],
+    wait,
   },
   routes: {
     generateSitemap: generateSitemapFromREST,

--- a/node/middlewares/generateMiddlewares/sendNextEvent.ts
+++ b/node/middlewares/generateMiddlewares/sendNextEvent.ts
@@ -1,9 +1,14 @@
+import { WAIT_EVENT } from '../wait'
 import { sleep } from './utils'
 
 export async function sendNextEvent(ctx: EventContext) {
   const { clients: { events }, state: { nextEvent } } = ctx
   const { payload, event } = nextEvent
-  await sleep(300)
-  events.sendEvent('', event, payload)
+  await sleep(100)
+  const waitPayload: WaitEvent = {
+    event,
+    payload,
+  }
+  events.sendEvent('', WAIT_EVENT, waitPayload)
 }
 

--- a/node/middlewares/wait.ts
+++ b/node/middlewares/wait.ts
@@ -1,0 +1,9 @@
+import { sleep } from './generateMiddlewares/utils'
+
+export async function wait(ctx: EventContext) {
+  const { body, clients: { events } } = ctx
+  await sleep(100)
+
+  const { event, payload } = body
+  events.sendEvent('', event, payload)
+}

--- a/node/middlewares/wait.ts
+++ b/node/middlewares/wait.ts
@@ -1,8 +1,10 @@
 import { sleep } from './generateMiddlewares/utils'
 
+export const WAIT_EVENT = 'sitemap.wait'
+
 export async function wait(ctx: EventContext) {
   const { body, clients: { events } } = ctx
-  await sleep(100)
+  await sleep(50)
 
   const { event, payload } = body
   events.sendEvent('', event, payload)

--- a/node/service.json
+++ b/node/service.json
@@ -43,6 +43,10 @@
     "groupEntries": {
       "sender": "vtex.store-sitemap",
       "keys": ["sitemap.generate:group-entries"]
+    },
+    "wait": {
+      "sender": "vtex.store-sitemap",
+      "keys": ["sitemap.wait"]
     }
   }
 }


### PR DESCRIPTION
Due to the processing velocity of the events and the amount of accounts generating the sitemap our infrastructure was not supporting the quantity of saves being made by the sitemap.

This PR addresses this issue by adding a wait event for every generation event sent by the app.