### PR TITLE
Reenables sitemap generation via API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Reenables sitemap generation via API
 
 ## [2.9.0] - 2020-07-16
 ### Feature

--- a/node/middlewares/generateMiddlewares/generateSitemap.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.ts
@@ -3,7 +3,6 @@ import {
   GENERATE_APPS_ROUTES_EVENT,
   GENERATE_PRODUCT_ROUTES_EVENT,
   GENERATE_REWRITER_ROUTES_EVENT,
-  SITEMAP_GENERATION_ENABLED
 } from './utils'
 
 export async function generateSitemapFromREST(ctx: Context) {
@@ -18,11 +17,7 @@ const DEFAULT_REWRITER_ROUTES_PAYLOAD = {
 }
 
 export async function generateSitemap(ctx: EventContext) {
-  const { clients: { events }, body: { generationId }, state: { settings }, vtex: { logger }}  = ctx
-  if (!SITEMAP_GENERATION_ENABLED) {
-    logger.info('Sitemap generation disbled')
-    return
-  }
+  const { clients: { events }, body: { generationId }, state: { settings } }  = ctx
   if (settings.enableNavigationRoutes) {
     events.sendEvent('', GENERATE_REWRITER_ROUTES_EVENT, {
       ...DEFAULT_REWRITER_ROUTES_PAYLOAD,

--- a/node/middlewares/generateMiddlewares/prepare.ts
+++ b/node/middlewares/generateMiddlewares/prepare.ts
@@ -1,13 +1,8 @@
 import { CONFIG_BUCKET, GENERATION_CONFIG_FILE } from '../../utils'
-import { SITEMAP_GENERATION_ENABLED } from './utils'
 
 export async function prepare(ctx: EventContext, next: () => Promise<void>) {
   const { body, vtex: { logger }, clients: { vbase } } = ctx
   const { generationId } = body
-  if (!SITEMAP_GENERATION_ENABLED) {
-    logger.info('Sitemap generation disbled')
-    return
-  }
   if (!generationId) {
     logger.error({ message: 'Missing generation id', payload: body })
     return

--- a/node/middlewares/generateMiddlewares/utils.ts
+++ b/node/middlewares/generateMiddlewares/utils.ts
@@ -17,9 +17,6 @@ export const GENERATE_PRODUCT_ROUTES_EVENT = 'sitemap.generate:product-routes'
 export const GENERATE_APPS_ROUTES_EVENT = 'sitemap.generate:apps-routes'
 export const GROUP_ENTRIES_EVENT = 'sitemap.generate:group-entries'
 
-export const SITEMAP_GENERATION_ENABLED = false
-
-
 export const DEFAULT_CONFIG: Config = {
   generationPrefix: `${LINKED ? 'L' : ''}B`,
   productionPrefix: `${LINKED ? 'L' : ''}A`,

--- a/node/middlewares/prepare.ts
+++ b/node/middlewares/prepare.ts
@@ -1,7 +1,7 @@
 import { parse } from 'query-string'
 
 import { BindingResolver } from '../resources/bindings'
-import { CONFIG_BUCKET, CONFIG_FILE, getBucket, getMatchingBindings, hashString, startSitemapGeneration } from '../utils'
+import { CONFIG_BUCKET, CONFIG_FILE, getBucket, getMatchingBindings, hashString } from '../utils'
 import { DEFAULT_CONFIG } from './generateMiddlewares/utils'
 
 const ONE_DAY_S = 24 * 60 * 60
@@ -50,9 +50,10 @@ export async function prepare(ctx: Context, next: () => Promise<void>) {
     'cache-control',
     production ? `public, max-age=${ONE_DAY_S}` : 'no-cache'
   )
-  if (production) {
-    startSitemapGeneration(ctx)
-  }
+  // TODO: Re-enable generation
+  // if (production) {
+  //   startSitemapGeneration(ctx)
+  // }
 
   return
 }


### PR DESCRIPTION
Since the release notes with the sitemap doc is released, we should enable sitemap generation for API requests. But not on every sitemap entry in production.