### PR TITLE
[WIP] Removes Vbase memory cache

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.9.1",
+  "version": "2.9.2-beta.12",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/node/index.ts
+++ b/node/index.ts
@@ -38,12 +38,7 @@ const tenantCacheStorage = new LRUCache<string, Cached>({
   max: 3000,
 })
 
-const vbaseCacheStorage = new LRUCache<string, Cached>({
-  max: 3000,
-})
-
 metrics.trackCache('tenant', tenantCacheStorage)
-metrics.trackCache('vbase', vbaseCacheStorage)
 
 const clients: ClientsConfig<Clients> = {
   implementation: Clients,
@@ -68,9 +63,6 @@ const clients: ClientsConfig<Clients> = {
     },
     tenant: {
       memoryCache: tenantCacheStorage,
-    },
-    vbase: {
-      memoryCache: vbaseCacheStorage,
     },
   },
 }

--- a/node/middlewares/generateMiddlewares/prepare.ts
+++ b/node/middlewares/generateMiddlewares/prepare.ts
@@ -10,7 +10,7 @@ export async function prepare(ctx: EventContext, next: () => Promise<void>) {
   const { generationId: currentGenerationId } = await vbase.getJSON<GenerationConfig>(CONFIG_BUCKET, GENERATION_CONFIG_FILE, true)
     || { generationId: null }
   if (generationId !== currentGenerationId) {
-    logger.debug({ message: 'Invalid generation id', payload: body })
+    logger.debug({ message: 'Invalid generation id', payload: body, currentGenerationId })
     return
   }
   await next()


### PR DESCRIPTION
The VBase cache was blocking some sitemap generation, since it was returning the cached generationId after a new generation started. We always want to