### PR TITLE
Allow group entities to process various files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Adapts group entites middleware to event chain, to handle huge sitemaps
 
 ## [2.9.4] - 2020-08-14
 ### Fixed

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -69,6 +69,7 @@ declare global {
 
   interface GroupEntriesEvent extends DefaultEvent {
     indexFile: string
+    from: number
   }
 
   interface RewriterRoutesGenerationEvent extends DefaultEvent  {

--- a/node/index.ts
+++ b/node/index.ts
@@ -88,7 +88,7 @@ export default new Service<Clients, State, ParamsContext>({
     generateProductRoutes: [throttle, generationPrepare, tenant, generateProductRoutes, sendNextEvent],
     generateRewriterRoutes: [throttle, generationPrepare, generateRewriterRoutes, sendNextEvent],
     generateSitemap: [settings, generationPrepare, generateSitemap],
-    groupEntries: [throttle, settings, generationPrepare, groupEntries],
+    groupEntries: [throttle, settings, generationPrepare, groupEntries, sendNextEvent],
   },
   routes: {
     generateSitemap: generateSitemapFromREST,

--- a/node/middlewares/generateMiddlewares/generateProductRoutes.test.ts
+++ b/node/middlewares/generateMiddlewares/generateProductRoutes.test.ts
@@ -289,7 +289,7 @@ describe('Test product routes generation', () => {
     expect(next).toBeCalled()
     expect(context.state.nextEvent).toStrictEqual({
       event: GROUP_ENTRIES_EVENT,
-      payload: { generationId: '1', indexFile: 'productRoutesIndex.json' },
+      payload: { from: 0, generationId: '1', indexFile: 'productRoutesIndex.json' },
     })
   })
 

--- a/node/middlewares/generateMiddlewares/generateProductRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateProductRoutes.ts
@@ -225,6 +225,7 @@ export async function generateProductRoutes(ctx: EventContext, next: () => Promi
     ctx.state.nextEvent = {
       event: GROUP_ENTRIES_EVENT,
       payload: {
+        from: 0,
         generationId,
         indexFile: PRODUCT_ROUTES_INDEX,
       },

--- a/node/middlewares/generateMiddlewares/generateRewriterRoutes.test.ts
+++ b/node/middlewares/generateMiddlewares/generateRewriterRoutes.test.ts
@@ -204,7 +204,7 @@ describe('Test rewriter routes generation', () => {
     expect(next).toBeCalled()
     expect(context.state.nextEvent).toStrictEqual({
       event: GROUP_ENTRIES_EVENT,
-      payload: { generationId: '1', indexFile: 'rewriterRoutesIndex.json' },
+      payload: { from: 0, generationId: '1', indexFile: 'rewriterRoutesIndex.json' },
     }
     )
   })

--- a/node/middlewares/generateMiddlewares/generateRewriterRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateRewriterRoutes.ts
@@ -125,6 +125,7 @@ export async function generateRewriterRoutes(ctx: EventContext, nextMiddleware: 
     ctx.state.nextEvent = {
       event: GROUP_ENTRIES_EVENT,
       payload: {
+        from: 0,
         generationId,
         indexFile: REWRITER_ROUTES_INDEX,
       },

--- a/node/middlewares/generateMiddlewares/generateSitemap.test.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.test.ts
@@ -28,10 +28,10 @@ const DEFAULT_REWRITER_ROUTES_PAYLOAD = {
   report: {},
 }
 
-const DEFAULT_PRODUCT_ROUTES_PAYLOAD = {
-  from: 0,
+const DEFAULT_PRODUCT_ROUTES_PAYLOAD: ProductRoutesGenerationEvent= {
   generationId: '1',
   invalidProducts: 0,
+  page: 1,
   processedProducts: 0,
 }
 
@@ -58,11 +58,11 @@ describe('Test generate sitemap', () => {
     jest.clearAllMocks()
 
     context = {
+      ...contextMock.object,
       body: {
         generationId: '1',
       },
       clients: new ClientsImpl({}, ioContext.object),
-      ...contextMock.object,
       state: {
         ...state.object,
         settings: {

--- a/node/middlewares/generateMiddlewares/groupEntries.test.ts
+++ b/node/middlewares/generateMiddlewares/groupEntries.test.ts
@@ -118,8 +118,8 @@ describe('Test group entries', () => {
     next = jest.fn()
 
     context = {
-      clients: new ClientsImpl({}, ioContext.object),
       ...contextMock.object,
+      clients: new ClientsImpl({}, ioContext.object),
       state: {
         ...state.object,
         enabledIndexFiles: [REWRITER_ROUTES_INDEX, PRODUCT_ROUTES_INDEX],
@@ -205,7 +205,18 @@ describe('Test group entries', () => {
 
     // Saves two product routes in different files
     const rawBucket = getBucket(RAW_DATA_PREFIX, hashString('1'))
-    const tooManyRoutes = new Array(5001).fill(BANANA_PRODUCT_ROUTE)
+    const tooManyRoutes = []
+    for (let i = 0; i <= 5000; i++) {
+      tooManyRoutes.push(
+        {
+          alternates: [
+            { bindingId: '1', path: `/banana-${i}/p` },
+          ],
+          id: i,
+          path: `/banana-${i}/p`,
+        }
+      )
+    }
     await vbaseClient.saveJSON(rawBucket, 'product-0', { routes: tooManyRoutes })
     await vbaseClient.saveJSON(rawBucket, PRODUCT_ROUTES_INDEX, { index: ['product-0'] })
 

--- a/node/middlewares/generateMiddlewares/groupEntries.ts
+++ b/node/middlewares/generateMiddlewares/groupEntries.ts
@@ -1,4 +1,4 @@
-import { last, uniq } from 'ramda'
+import { last } from 'ramda'
 import { CONFIG_BUCKET, CONFIG_FILE, getBucket, hashString, STORE_PRODUCT, TENANT_CACHE_TTL_S } from '../../utils'
 import {
   cleanConfigBucket,

--- a/node/middlewares/generateMiddlewares/groupEntries.ts
+++ b/node/middlewares/generateMiddlewares/groupEntries.ts
@@ -15,7 +15,7 @@ import {
   uniq
 } from './utils'
 
-const FILE_PROCESS_LIMIT = 3000
+const FILE_PROCESS_LIMIT = 1500
 const FILE_LIMIT = 5000
 
 const groupEntityEntries = async (entity: string, files: string[], index: string[] | undefined, bucket: string, rawBucket: string, ctx: EventContext) => {

--- a/node/middlewares/throttle.ts
+++ b/node/middlewares/throttle.ts
@@ -1,7 +1,7 @@
 import { TooManyRequestsError } from '@vtex/api'
 import { sleep } from './generateMiddlewares/utils'
 
-const MAX_REQUEST = 5
+const MAX_REQUEST = 4
 let COUNTER = 0
 
 export async function throttle(


### PR DESCRIPTION
In cases where the catalog is huge, the number of files generated is too much for the processing of the grouping function to complete without timing out. This PR converts the grouping middleware to the event chain architecture of other middlwares.