### PR TITLE
Deduplicate routes and index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Deduplicates routes and index
 
 ## [2.9.1] - 2020-07-20
 ### Fixed

--- a/node/middlewares/generateMiddlewares/groupEntries.ts
+++ b/node/middlewares/generateMiddlewares/groupEntries.ts
@@ -1,4 +1,3 @@
-import { uniq } from 'ramda'
 import { CONFIG_BUCKET, CONFIG_FILE, getBucket, hashString, STORE_PRODUCT, TENANT_CACHE_TTL_S } from '../../utils'
 import {
   cleanConfigBucket,
@@ -10,7 +9,8 @@ import {
   RAW_DATA_PREFIX,
   SitemapEntry,
   SitemapIndex,
-  splitFileName
+  splitFileName,
+  uniq
 } from './utils'
 
 const FILE_LIMIT = 5000

--- a/node/middlewares/generateMiddlewares/utils.ts
+++ b/node/middlewares/generateMiddlewares/utils.ts
@@ -37,6 +37,8 @@ export interface Message {
   context: string
 }
 
+export const uniq = <T>(array: T[]) => array.filter((value, idx) => array.indexOf(value) === idx)
+
 export const createFileName = (entity: string, count: number) => `${entity}-${count}`
 
 export const splitFileName = (file: string) => file.split('-')


### PR DESCRIPTION
While processing carrefour's sitemap the index file had a lot of duplicates causing routes repetition in the final sitemap. The problem probably was caused by some events timing out and being reprocessed. But as a way to avoid this again this PR deduplicates the routes and indexes.