### PR TITLE
Makes generation endpoint public and improve message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Makes generation route public
 
 ## [2.9.4] - 2020-08-14
 ### Fixed

--- a/node/service.json
+++ b/node/service.json
@@ -15,8 +15,8 @@
       "public": true
     },
     "generateSitemap": {
-      "path": "/generate-sitemap",
-      "public": false
+      "path": "/_v/generate-sitemap",
+      "public": true
     },
     "robots": {
       "path": "/robots.txt",

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -64,7 +64,7 @@ export const startSitemapGeneration = async (ctx: Context) => {
   const config = await vbase.getJSON<GenerationConfig>(CONFIG_BUCKET, GENERATION_CONFIG_FILE, true)
   if (config && validDate(config.endDate) && !force) {
     ctx.status = 202
-    ctx.body = 'Sitemap generation already in place'
+    ctx.body = `Sitemap generation already in place\nNext generation available: ${config.endDate}`
     return
   }
   const generationId = (Math.random() * 10000).toString()


### PR DESCRIPTION
Some users are having problems generating the sitemap because their local token cannot make a request to the endpoint. Since the generation will happen on entering the `/sitemap.xml` public route the generation endpoint should be public too.

https://github.com/vtex-apps/store-discussion/issues/381