### PR TITLE
Optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Optimization with the new product list API
 
 ## [2.9.5] - 2020-08-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Optimization with the new product list API
+- Bindings index improvements
 
 ## [2.9.5] - 2020-08-14
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.9.5",
+  "version": "2.9.6-beta.12",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -29,9 +29,11 @@ export class Catalog extends ExternalClient {
     )
   }
 
-  public getProductsIds (page: number): Promise<GetProductsAndSkuIdsReponse> {
+  public getProductsIds (page: number, salesChannels?: string[]): Promise<GetProductsAndSkuIdsReponse> {
     return this.http.get('/api/catalog_system/pvt/products/GetProductsIds', {
       params: {
+        ...(salesChannels ? { SalesChannelId: salesChannels.join(',')} : {}),
+        Active: true,
         Page: page,
         pageSize: PAGE_SIZE,
       },

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -9,7 +9,7 @@ import { RobotsGC } from './robotsGC'
 import { CVBase } from './vbase'
 
 export class Clients extends IOClients {
-  public get vbsae() {
+  public get vbase() {
     return this.getOrSet('vbase', CVBase)
   }
   public get robots() {

--- a/node/middlewares/generateMiddlewares/generateAppsRoutes.test.ts
+++ b/node/middlewares/generateMiddlewares/generateAppsRoutes.test.ts
@@ -128,11 +128,11 @@ describe('Test rewriter routes generation', () => {
       }
     }
     context = {
+      ...contextMock.object,
       body: {
         generationId: '1',
       },
       clients: new ClientsImpl({}, ioContext.object),
-      ...contextMock.object,
       state: {
         ...state.object,
       },

--- a/node/middlewares/generateMiddlewares/generateProductRoutes.test.ts
+++ b/node/middlewares/generateMiddlewares/generateProductRoutes.test.ts
@@ -249,14 +249,14 @@ describe('Test product routes generation', () => {
       }
     }
     context = {
+      ...contextMock.object,
       body: {
-        page: 1,
         generationId: '1',
         invalidProducts: 0,
+        page: 1,
         processedProducts: 0,
       },
       clients: new ClientsImpl({}, ioContext.object),
-      ...contextMock.object,
       state: {
         ...state.object,
       },

--- a/node/middlewares/generateMiddlewares/generateProductRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateProductRoutes.ts
@@ -10,6 +10,7 @@ import {
   currentDate,
   filterBindingsBySalesChannel,
   GENERATE_PRODUCT_ROUTES_EVENT,
+  getAccountSalesChannels,
   GROUP_ENTRIES_EVENT,
   initializeSitemap,
   Message,
@@ -178,7 +179,8 @@ export async function generateProductRoutes(ctx: EventContext, next: () => Promi
     invalidProducts,
   }: ProductRoutesGenerationEvent = body!
 
-  const { items, paging: { pages: totalPages, total } } = await catalog.getProductsIds(page)
+  const salesChannels = getAccountSalesChannels(tenantInfo)
+  const { items, paging: { pages: totalPages, total } } = await catalog.getProductsIds(page, salesChannels)
 
   const getProductInfoFn = getProductInfo(tenantInfo, ctx)
   const productsInfo = await Promise.all(items.map(productId => getProductInfoFn(productId.toString())))

--- a/node/middlewares/generateMiddlewares/generateRewriterRoutes.test.ts
+++ b/node/middlewares/generateMiddlewares/generateRewriterRoutes.test.ts
@@ -156,6 +156,7 @@ describe('Test rewriter routes generation', () => {
       }
     }
     context = {
+      ...contextMock.object,
       body: {
         count: 0,
         generationId: '1',
@@ -163,7 +164,6 @@ describe('Test rewriter routes generation', () => {
         report: {},
       },
       clients: new ClientsImpl({}, ioContext.object),
-      ...contextMock.object,
       state: {
         ...state.object,
       },

--- a/node/middlewares/generateMiddlewares/generateSitemap.test.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.test.ts
@@ -58,11 +58,11 @@ describe('Test generate sitemap', () => {
     jest.clearAllMocks()
 
     context = {
+      ...contextMock.object,
       body: {
         generationId: '1',
       },
       clients: new ClientsImpl({}, ioContext.object),
-      ...contextMock.object,
       state: {
         ...state.object,
         settings: {

--- a/node/middlewares/generateMiddlewares/groupEntries.test.ts
+++ b/node/middlewares/generateMiddlewares/groupEntries.test.ts
@@ -114,8 +114,8 @@ describe('Test group entries', () => {
     jest.clearAllMocks()
 
     context = {
-      clients: new ClientsImpl({}, ioContext.object),
       ...contextMock.object,
+      clients: new ClientsImpl({}, ioContext.object),
       state: {
         ...state.object,
         enabledIndexFiles: [REWRITER_ROUTES_INDEX, PRODUCT_ROUTES_INDEX],

--- a/node/middlewares/generateMiddlewares/prepare.test.ts
+++ b/node/middlewares/generateMiddlewares/prepare.test.ts
@@ -53,11 +53,11 @@ describe('Test generation prepare', () => {
       }
     }
     context = {
+      ...contextMock.object,
       body: {
         generationId: '1',
       },
       clients: new ClientsImpl({}, ioContext.object),
-      ...contextMock.object,
       state: {
         ...state.object,
       },

--- a/node/middlewares/generateMiddlewares/utils.ts
+++ b/node/middlewares/generateMiddlewares/utils.ts
@@ -1,5 +1,5 @@
 import { LINKED, Logger, Tenant, VBase } from '@vtex/api'
-import { all, uniqBy } from 'ramda'
+import { uniqBy } from 'ramda'
 import { Product, SalesChannel } from 'vtex.catalog-graphql'
 
 import { Messages } from '../../clients/messages'
@@ -141,7 +141,7 @@ export const isSitemapComplete = async (enabledIndexFiles: string[], vbase: VBas
     enabledIndexFiles,
     indexFiles,
   })
-  return all(Boolean, indexFiles)
+  return allTruthy(indexFiles)
 }
 
 export const completeRoutes = async (file: string, vbase: VBase) =>
@@ -152,3 +152,5 @@ export const cleanConfigBucket = async (enabledIndexFiles: string[], vbase: VBas
     ...enabledIndexFiles.map(
     indexFile => vbase.deleteFile(CONFIG_BUCKET, indexFile)),
   ])
+
+const allTruthy = <T>(array: T[]) => !array.some(e => !e)

--- a/node/middlewares/generateMiddlewares/utils.ts
+++ b/node/middlewares/generateMiddlewares/utils.ts
@@ -1,5 +1,5 @@
 import { LINKED, Logger, Tenant, VBase } from '@vtex/api'
-import { all } from 'ramda'
+import { all, uniqBy } from 'ramda'
 import { Product, SalesChannel } from 'vtex.catalog-graphql'
 
 import { Messages } from '../../clients/messages'
@@ -61,6 +61,21 @@ export const initializeSitemap = async (ctx: EventContext, indexFile: string) =>
   ))
 }
 
+export const getAccountSalesChannels = (
+  tenantInfo: Tenant
+): string[] | undefined => {
+  const salesChannels = tenantInfo.bindings.reduce((acc, binding) => {
+    if (binding.targetProduct === STORE_PRODUCT) {
+      const bindingSC: number | undefined =
+        binding.extraContext.portal?.salesChannel
+      if (bindingSC) {
+        acc.push(bindingSC.toString())
+      }
+    }
+    return acc
+  }, [] as string[])
+  return uniqBy(i => i, salesChannels)
+}
 
 export const filterBindingsBySalesChannel = (
   tenantInfo: Tenant,

--- a/node/middlewares/prepare.ts
+++ b/node/middlewares/prepare.ts
@@ -17,6 +17,9 @@ export async function prepare(ctx: Context, next: () => Promise<void>) {
   if (rootPath && !rootPath.startsWith('/')) {
     rootPath = `/${rootPath}`
   }
+  if (rootPath === '/') {
+    rootPath = ''
+  }
   const [forwardedPath, queryString] = ctx.get('x-forwarded-path').split('?')
   const matchingBindings = await getMatchingBindings(forwardedHost, tenant)
   const bindingResolver = new BindingResolver()

--- a/node/middlewares/settings.test.ts
+++ b/node/middlewares/settings.test.ts
@@ -39,8 +39,8 @@ describe('Test settings middleware', () => {
     }
 
     context = {
-      clients: new ClientsImpl({}, ioContext.object),
       ...contextMock.object,
+      clients: new ClientsImpl({}, ioContext.object),
       state: {
         ...state.object,
       },

--- a/node/middlewares/sitemap.test.ts
+++ b/node/middlewares/sitemap.test.ts
@@ -107,7 +107,7 @@ describe('Test sitemap middleware', () => {
       }
     })
 
-   it('Should return binding index if it hasmultiple bindings', async () => {
+   it('Should return binding index if it has multiple bindings', async () => {
      const thisContext = {
        ...context,
        state: {
@@ -126,6 +126,32 @@ describe('Test sitemap middleware', () => {
        '<loc>https://www.host.com/sitemap.xml?__bindingAddress=www.host.com/de</loc>'
      )).toBeTruthy()
    })
+
+   it('Should return binding index with canonical if it has multiple bindings in production', async () => {
+    const thisContext = {
+      ...context,
+      state: {
+        ...context.state,
+        matchingBindings,
+      },
+       vtex: {
+         ...context.vtex,
+         production: true,
+       },
+    }
+
+    await sitemap(thisContext, next)
+    expect(thisContext.body.includes(
+      '<loc>https://www.host.com/sitemap.xml</loc>'
+    )).toBeTruthy()
+    expect(thisContext.body.includes(
+      '<loc>https://www.host.com/br/sitemap.xml</loc>'
+    )).toBeTruthy()
+    expect(thisContext.body.includes(
+      '<loc>https://www.host.com/de/sitemap.xml</loc>'
+    )).toBeTruthy()
+  })
+
 
     it('Should return index if it doesnt have multiple bindings', async () => {
       await sitemap(context, next)

--- a/node/middlewares/sitemap.test.ts
+++ b/node/middlewares/sitemap.test.ts
@@ -79,8 +79,8 @@ describe('Test sitemap middleware', () => {
       }
 
       context = {
-        clients: new ClientsImpl({}, ioContext.object),
         ...contextMock.object,
+        clients: new ClientsImpl({}, ioContext.object),
         state: {
           ...state.object,
           binding: {

--- a/node/middlewares/sitemapEntry.test.ts
+++ b/node/middlewares/sitemapEntry.test.ts
@@ -69,8 +69,8 @@ describe('Test sitemap entry', () => {
     }
 
     context = {
-      clients: new ClientsImpl({}, ioContext.object),
       ...contextMock.object,
+      clients: new ClientsImpl({}, ioContext.object),
       state: {
         ...state.object,
         binding: {

--- a/node/middlewares/sitemapEntry.ts
+++ b/node/middlewares/sitemapEntry.ts
@@ -77,7 +77,7 @@ export async function sitemapEntry(ctx: Context, next: () => Promise<void>) {
   const { path } = sitemapParams
 
   const $: any = cheerio.load(
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/TR/xhtml11/xhtml11_schema.html">',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
     {
       xmlMode: true,
     }

--- a/node/package.json
+++ b/node/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^12.0.0",
     "@types/ramda": "^0.26.8",
     "@types/route-parser": "^0.1.2",
-    "@vtex/api": "6.36.0",
+    "@vtex/api": "6.36.1",
     "gocommerce.sitemap-app": "http://gocommerce.vtexassets.com/_v/public/typings/v1/gocommerce.sitemap-app@1.2.1/public/_types/react",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1",

--- a/node/utils.test.ts
+++ b/node/utils.test.ts
@@ -80,8 +80,8 @@ describe('Test startSitemapGeneration', () => {
       }
 
       context = {
-        clients: new ClientsImpl({}, ioContext.object),
         ...contextMock.object,
+        clients: new ClientsImpl({}, ioContext.object),
         query: {},
         state: {
           ...state.object,

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -700,10 +700,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.36.0":
-  version "6.36.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.36.0.tgz#debc0462cae4196a6580ded8ed88359dcb6ce31d"
-  integrity sha512-kEIHIOA6oXCGq65TpQG6ZBA2r3qQ9SAgoMpjo87dZvbybvxTPI7mz8URKy4jKuArf1mkhzLu9EqsJ+xwljFySg==
+"@vtex/api@6.36.1":
+  version "6.36.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.36.1.tgz#7de05462227cb9619e93fb38767ae9adb906ead2"
+  integrity sha512-DwULwOhK8BULNmZFAZXFIK1u+YvGkbl8zPt2f3DkXXI0PSnWPUkTVt1fANgYbeOtiepGNA+ibssCAGUFHFy0zg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
With the new product list API is possible to do some optimizations. This PR filters the product list request by active products and by the account's salesChannels. Making the response smaller and the processing faster.

This PR also changes some behavior in accounts with multiple bindings:
1. In production it uses the bindings' canonical base address instead of adding it as a querystring
2. Fixes bug where the rootPath is `/`