### PR TITLE
Filters store bindings in internal routes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Filters store bindings from rewriter routes
 
 ## [2.12.0] - 2020-09-28
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.12.1-beta.0",
+  "version": "2.12.1-beta.2",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.12.0",
+  "version": "2.12.1-beta.0",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/node/clients/vbase.ts
+++ b/node/clients/vbase.ts
@@ -29,7 +29,7 @@ export class CVBase extends VBase {
       headers, inflightKey, metric, nullIfNotFound, tracing: {
         requestSpanNameSuffix: metric,
         ...tracingConfig?.tracing,
-      }
+      },
     } as IgnoreNotFoundRequestConfig)
       .catch(async (error: AxiosError<T>) => {
         const { response } = error

--- a/node/middlewares/generateMiddlewares/generateRewriterRoutes.test.ts
+++ b/node/middlewares/generateMiddlewares/generateRewriterRoutes.test.ts
@@ -72,6 +72,7 @@ describe('Test rewriter routes generation', () => {
         bindings: [
         {
           id: '1',
+          targetProduct: 'vtex-storefront',
         },
         {
           id: '2',
@@ -105,6 +106,12 @@ describe('Test rewriter routes generation', () => {
               },
               {
                 binding: '1',
+                from: '/coconut-water',
+                id: '2',
+                type: 'brand',
+              },
+              {
+                binding: '2',
                 from: '/coconut-water',
                 id: '2',
                 type: 'brand',

--- a/node/middlewares/generateMiddlewares/generateRewriterRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateRewriterRoutes.ts
@@ -1,10 +1,10 @@
-import { Clients } from './../../clients/index'
-import { Rewriter } from './../../clients/rewriter'
-
 import { Binding } from '@vtex/api'
 import { path as Rpath, startsWith } from 'ramda'
 import { Internal } from 'vtex.rewriter'
-import { getBucket, hashString, STORE_PRODUCT, TENANT_CACHE_TTL_S } from '../../utils'
+
+import { getBucket, getStoreBindings, hashString } from '../../utils'
+import { Clients } from './../../clients/index'
+import { Rewriter } from './../../clients/rewriter'
 import {
   createFileName,
   currentDate,
@@ -92,7 +92,7 @@ export async function generateRewriterRoutes(ctx: EventContext, nextMiddleware: 
   if (!ctx.body.count) {
     await initializeSitemap(ctx, REWRITER_ROUTES_INDEX)
   }
-  const { clients: { rewriter, tenant }, body } = ctx
+  const { clients: { rewriter, tenant } , body } = ctx
   const {
     count,
     generationId,
@@ -104,10 +104,7 @@ export async function generateRewriterRoutes(ctx: EventContext, nextMiddleware: 
   const routes: Internal[] = response.routes || []
   const responseNext = response.next
 
-  const { bindings } = await tenant.info({
-    forceMaxAge: TENANT_CACHE_TTL_S,
-  })
-  const storeBindings = bindings.filter(binding => binding.targetProduct === STORE_PRODUCT)
+  const storeBindings = await getStoreBindings(tenant)
 
   const routesByBinding = createRoutesByBinding(routes, report, storeBindings)
 

--- a/node/middlewares/generateMiddlewares/generateRewriterRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateRewriterRoutes.ts
@@ -1,9 +1,10 @@
 import { Clients } from './../../clients/index'
 import { Rewriter } from './../../clients/rewriter'
 
+import { Binding } from '@vtex/api'
 import { path as Rpath, startsWith } from 'ramda'
 import { Internal } from 'vtex.rewriter'
-import { getBucket, hashString } from '../../utils'
+import { getBucket, hashString, STORE_PRODUCT, TENANT_CACHE_TTL_S } from '../../utils'
 import {
   createFileName,
   currentDate,
@@ -20,38 +21,42 @@ const LIST_LIMIT = 300
 
 type RoutesByBinding = Record<string, Record<string, Route[]>>
 
-const createRoutesByBinding = (routes: Internal[], report: Record<string, number>) => routes.reduce(
-  (acc, internal) => {
-    report[internal.type] = (report[internal.type] || 0) + 1
-    const validRoute =
-      !startsWith('notFound', internal.type) &&
-      internal.type !== 'product' &&
-      !internal.disableSitemapEntry
-    if (validRoute) {
-      const { binding } = internal
-      const bindingRoutes: Route[] = Rpath([binding, internal.type], acc) || []
-      const route: Route = {
-        id: internal.id,
-        imagePath: internal.imagePath || undefined,
-        imageTitle: internal.imageTitle || undefined,
-        path: internal.from,
+const createRoutesByBinding = (routes: Internal[], report: Record<string, number>, storeBindings: Binding[]) => {
+  const storeBindingsIds = storeBindings.map(({ id }) => id)
+  return routes.reduce(
+    (acc, internal) => {
+      report[internal.type] = (report[internal.type] || 0) + 1
+      const validRoute =
+        !startsWith('notFound', internal.type) &&
+        internal.type !== 'product' &&
+        !internal.disableSitemapEntry &&
+        storeBindingsIds.includes(internal.binding)
+      if (validRoute) {
+        const { binding } = internal
+        const bindingRoutes: Route[] = Rpath([binding, internal.type], acc) || []
+        const route: Route = {
+          id: internal.id,
+          imagePath: internal.imagePath || undefined,
+          imageTitle: internal.imageTitle || undefined,
+          path: internal.from,
+        }
+        acc[binding] = {
+          ...acc[binding] || {},
+          [internal.type]: bindingRoutes.concat(route),
+        }
       }
-      acc[binding] = {
-        ...acc[binding] || {},
-        [internal.type]: bindingRoutes.concat(route),
-      }
-    }
-    return acc
-  },
-  {} as RoutesByBinding
-)
+      return acc
+    },
+    {} as RoutesByBinding
+  )
+}
 
 const completeRoute = (rewriter: Rewriter, type: string) => async (route: Route) => {
   const routesById = await rewriter.routesById({
     id: route.id,
     type,
   })
-  const alternates = routesById.map(({ route: path, binding: bindingId}) => ({ path, bindingId}))
+  const alternates = routesById.map(({ route: path, binding: bindingId }) => ({ path, bindingId }))
   return {
     ...route,
     alternates,
@@ -70,8 +75,8 @@ const saveRoutes = (routesByBinding: RoutesByBinding, count: number, clients: Cl
       const entry = createFileName(entityType, count)
       const lastUpdated = currentDate()
       await vbase.saveJSON<SitemapEntry>(bucket, entry, {
-          lastUpdated,
-          routes: entityRoutes,
+        lastUpdated,
+        routes: entityRoutes,
       })
       return entry
     })
@@ -87,7 +92,7 @@ export async function generateRewriterRoutes(ctx: EventContext, nextMiddleware: 
   if (!ctx.body.count) {
     await initializeSitemap(ctx, REWRITER_ROUTES_INDEX)
   }
-  const { clients: { rewriter }, body } = ctx
+  const { clients: { rewriter, tenant }, body } = ctx
   const {
     count,
     generationId,
@@ -99,7 +104,12 @@ export async function generateRewriterRoutes(ctx: EventContext, nextMiddleware: 
   const routes: Internal[] = response.routes || []
   const responseNext = response.next
 
-  const routesByBinding = createRoutesByBinding(routes, report)
+  const { bindings } = await tenant.info({
+    forceMaxAge: TENANT_CACHE_TTL_S,
+  })
+  const storeBindings = bindings.filter(binding => binding.targetProduct === STORE_PRODUCT)
+
+  const routesByBinding = createRoutesByBinding(routes, report, storeBindings)
 
   await Promise.all(
     Object.keys(routesByBinding).map(saveRoutes(routesByBinding, count, ctx.clients))

--- a/node/package.json
+++ b/node/package.json
@@ -43,7 +43,7 @@
     "tslint": "^5.11.0",
     "tslint-config-vtex": "^2.1.0",
     "typemoq": "^2.1.0",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.catalog-api-proxy": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.9.0/public/_types/react",
     "vtex.catalog-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.80.1/public/@types/vtex.catalog-graphql",
     "vtex.graphql-server": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.graphql-server@1.62.3/public/_types/react",

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -81,3 +81,11 @@ export const validDate = (endDate: string) => {
   }
   return true
 }
+
+export const getStoreBindings = async (tenant: TenantClient) => {
+  const { bindings } = await tenant.info({
+    forceMaxAge: TENANT_CACHE_TTL_S,
+  })
+  const storeBindings = bindings.filter(binding => binding.targetProduct === STORE_PRODUCT)
+  return storeBindings
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4970,10 +4970,10 @@ typemoq@^2.1.0:
     lodash "^4.17.4"
     postinstall-build "^5.0.1"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Currently if an internal route from rewriter has an invalid binding it returns an error and stops the sitemap generation. This PR filters the internal routes with valid binding.