### PR TITLE
Handles correctly 429 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handles correctly 429 error 
 
 ## [2.13.0] - 2020-10-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Handles correctly 429 error 
+- Disables automatic sitemap generation
 
 ## [2.13.0] - 2020-10-20
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.13.0",
+  "version": "2.13.1-beta.1",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.13.1-beta.1",
+  "version": "2.13.2-beta.0",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -10,7 +10,7 @@ export interface GetProductsAndSkuIdsReponse {
   }
 }
 
-const PAGE_SIZE = 200
+const PAGE_SIZE = 100
 
 export class Catalog extends ExternalClient {
   constructor(protected context: IOContext, options?: InstanceOptions) {

--- a/node/index.ts
+++ b/node/index.ts
@@ -13,6 +13,7 @@ import { Clients } from './clients'
 import { Authorization } from './directives/auth'
 import { binding } from './middlewares/binding'
 import { cache } from './middlewares/cache'
+import { errors } from './middlewares/errors'
 import { generateAppsRoutes } from './middlewares/generateMiddlewares/generateAppsRoutes'
 import { generateProductRoutes } from './middlewares/generateMiddlewares/generateProductRoutes'
 import { generateRewriterRoutes } from './middlewares/generateMiddlewares/generateRewriterRoutes'
@@ -80,17 +81,17 @@ const clients: ClientsConfig<Clients> = {
     },
   },
 }
-const sitemapPipeline = [settings,prepare, sitemap]
+const sitemapPipeline = [settings, prepare, sitemap]
 const sitemapEntryPipeline = [prepare, sitemapEntry]
 
 export default new Service<Clients, State, ParamsContext>({
   clients,
   events: {
-    generateAppsRoutes: [throttle, generationPrepare, generateAppsRoutes],
-    generateProductRoutes: [throttle, generationPrepare, tenant, generateProductRoutes, sendNextEvent],
-    generateRewriterRoutes: [throttle, generationPrepare, generateRewriterRoutes, sendNextEvent],
+    generateAppsRoutes: [throttle, errors, generationPrepare, generateAppsRoutes],
+    generateProductRoutes: [throttle, errors, generationPrepare, tenant, generateProductRoutes, sendNextEvent],
+    generateRewriterRoutes: [throttle, errors, generationPrepare, generateRewriterRoutes, sendNextEvent],
     generateSitemap: [settings, generationPrepare, generateSitemap],
-    groupEntries: [throttle, settings, generationPrepare, groupEntries, sendNextEvent],
+    groupEntries: [throttle, errors, settings, generationPrepare, groupEntries, sendNextEvent],
   },
   graphql: {
     resolvers,

--- a/node/middlewares/errors.ts
+++ b/node/middlewares/errors.ts
@@ -4,6 +4,7 @@ import { any } from 'ramda'
 const ERROR_429 = 'E_HTTP_429'
 
 const isTooManyRequestError = (error: any) => {
+  // Checks if has one error and it is the TooManyRequestError
   if (error.graphQLErrors && error.graphQLErrors.length === 1) {
     return any((err: any )=> err.extensions?.exception?.code === ERROR_429 , error.graphQLErrors)
   }

--- a/node/middlewares/errors.ts
+++ b/node/middlewares/errors.ts
@@ -1,0 +1,22 @@
+import { TooManyRequestsError } from '@vtex/api'
+import { any } from 'ramda'
+
+const ERROR_429 = 'E_HTTP_429'
+
+const isTooManyRequestError = (error: any) => {
+  if (error.graphQLErrors && error.graphQLErrors.length === 1) {
+    return any((err: any )=> err.extensions?.exception?.code === ERROR_429 , error.graphQLErrors)
+  }
+  return false
+}
+
+export async function errors(_: EventContext, next: () => Promise<void>) {
+  try {
+    next()
+  } catch (error) {
+    if (isTooManyRequestError(error)) {
+      throw new TooManyRequestsError()
+    }
+    throw error
+  }
+}

--- a/node/middlewares/prepare.ts
+++ b/node/middlewares/prepare.ts
@@ -1,7 +1,7 @@
 import { parse } from 'query-string'
 
 import { BindingResolver } from '../resources/bindings'
-import { CONFIG_BUCKET, CONFIG_FILE, getBucket, getMatchingBindings, hashString, startSitemapGeneration } from '../utils'
+import { CONFIG_BUCKET, CONFIG_FILE, getBucket, getMatchingBindings, hashString } from '../utils'
 import { DEFAULT_CONFIG } from './generateMiddlewares/utils'
 
 const ONE_DAY_S = 24 * 60 * 60
@@ -53,9 +53,9 @@ export async function prepare(ctx: Context, next: () => Promise<void>) {
     'cache-control',
     production ? `public, max-age=${ONE_DAY_S}` : 'no-cache'
   )
-  if (production) {
-    startSitemapGeneration(ctx)
-  }
+  // if (production) {
+  //   startSitemapGeneration(ctx)
+  // }
 
   return
 }


### PR DESCRIPTION
Currently if any API return a 429 error, the sitemap app throws a 500 error and starts appearing in our alerts channel. This PR makes the system handle better this type of error, by returning to the event system a 429 error and using its retry feature.