### PR TITLE
Handle missing sales channel case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Handles correctly 429 error 
 - Disables automatic sitemap generation
+- Handles cases where the bindings doesn't have associated sales channels
 
 ## [2.13.0] - 2020-10-20
 ### Added


### PR DESCRIPTION
Currently all binding must have an associated sales channel. However due to a bug in the catalog's product list API, some accounts do not have all products in the sitemap. More precisely accounts with one binding and one sales channel but not all products are directly associated to that sales channel. 