### PR TITLE
Handles one binding and one SC case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Checks if account has one binding and one SC
 
 ## [2.13.3] - 2020-11-17
 

--- a/node/middlewares/generateMiddlewares/utils.ts
+++ b/node/middlewares/generateMiddlewares/utils.ts
@@ -72,6 +72,10 @@ export const getAccountSalesChannels = (
     }
     return acc
   }, [] as string[])
+  // Has one binding with one sales channel
+  if (bindings.length === 1 && salesChannels.length === 1) {
+    return
+  }
   return uniqBy(i => i, salesChannels)
 }
 

--- a/node/package.json
+++ b/node/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^12.0.0",
     "@types/ramda": "^0.26.8",
     "@types/route-parser": "^0.1.2",
-    "@vtex/api": "6.36.3",
+    "@vtex/api": "6.37.0",
     "gocommerce.sitemap-app": "http://gocommerce.vtexassets.com/_v/public/typings/v1/gocommerce.sitemap-app@1.2.1/public/_types/react",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -700,10 +700,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.36.3":
-  version "6.36.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.36.3.tgz#d827944829fb289d3a826cac12874f8e33ce62f5"
-  integrity sha512-i7zZ0Mj5pGEr6wd8VCK/hhiKTmmiuTn44v9MlWn36MRvtfBfOsKlhMFUEv3HBT1MH+fQTNM9vY08uSy7BsG44w==
+"@vtex/api@6.37.0":
+  version "6.37.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.0.tgz#a07e6adbfc02866f901cf0cfff2155f2c279adc5"
+  integrity sha512-Vy970ZfgOttrxeiJW2oM8rQ0E8t/HE5cQhbGIawfJsu35HEWA9NnWRSR3bdLMczT9oYIY9QwE8IfdU4b44dhKw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4551,7 +4551,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
Checks if account has one binding with one sales channel to avoid filtering product list API and causing the bug where the API doesn't return all products.