### PR TITLE
Updates apps policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Adds correct policy for graphql calls
+- Remove authorization from saveIndex mutation
 
 ## [2.13.4] - 2020-12-01
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -3,5 +3,5 @@ type Query {
 }
 
 type Mutation {
-  saveIndex(index: String!, binding: String): Boolean! @requiresAuth
+  saveIndex(index: String!, binding: String): Boolean!
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.13.5-beta.0",
+  "version": "2.13.5-beta.2",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.13.4",
+  "version": "2.13.5-beta.0",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/policies.json
+++ b/policies.json
@@ -1,13 +1,13 @@
 [
   {
-    "name": "canonicals-read-write",
-    "description": "Allows read write access to canonical routes",
+    "name": "resolve-graphql",
+    "description": "Allows access to resolve a graphql request",
     "statements": [
       {
-        "actions": ["put", "get"],
+        "actions": ["post", "get"],
         "effect": "allow",
         "resources": [
-          "vrn:vtex.store-sitemap:{{region}}:{{account}}:{{workspace}}:/canonical"
+          "vrn:vtex.rewriter:{{region}}:{{account}}:{{workspace}}:/_v/graphql"
         ]
       }
     ]

--- a/policies.json
+++ b/policies.json
@@ -7,7 +7,7 @@
         "actions": ["post", "get"],
         "effect": "allow",
         "resources": [
-          "vrn:vtex.rewriter:{{region}}:{{account}}:{{workspace}}:/_v/graphql"
+          "vrn:vtex.store-sitemap:{{region}}:{{account}}:{{workspace}}:/_v/graphql"
         ]
       }
     ]


### PR DESCRIPTION
Creates correct policy for graphql calls and remove previous policy that was created for the major 1 of the app and does not makes sense to have for major 2. Moreover it creates a policy for the `/canonical` resource, a route that does not exist in the current major of the app.

Removes authorization from saveIndex mutation