### PR TITLE
Support for excluding /_draft/ routes from sitemap.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Support for excluding `/_draft/` routes from sitemap. New setting `disableDraftRoutes` added.
+- Support for excluding routes that contain the saved string from the sitemap. New setting `disableStringRoutes` added.
 
 ## [2.14.0] - 2022-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for excluding `/_draft/` routes from sitemap. New setting `disableDraftRoutes` added.
+
 ## [2.14.0] - 2022-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Support for excluding routes that contain the saved string from the sitemap. New setting `disableStringRoutes` added.
+- Support for excluding routes that contain the saved string from the sitemap. New setting `disableRoutesTerm` added.
 
 ## [2.14.0] - 2022-05-11
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,13 +91,13 @@ Once you promoted your workspace, no further actions are needed on your part: yo
 
 #### Managing routes
 
-You can manage if you want to include product, navigation and/or apps routes in your sitemap or not. To do that, check the following step by step.
+You can manage if you want to include product, navigation, apps and/or draft routes in your sitemap or not. To do that, check the following step by step.
 
 1. In your browser, access the the account's Admin in which you are working using the Production workspace used in the **step 2** of the [Configuration section](#configuration) (`{workspaceName}--{accountName}.myvtex.com/admin`).
 2. Go to **Account settings > Apps > My apps** and search for **Sitemap** app.
-3. Enable or disable product, navigation, or app routes according to your scenario.
+3. Enable or disable product, navigation, app or draft routes according to your scenario.
 
-![sitemap-admin](https://user-images.githubusercontent.com/60782333/87038950-d6d11980-c1c4-11ea-8c73-b4569081fb1d.png)
+![sitemap-admin](https://user-images.githubusercontent.com/36925076/171218096-ceb6d01c-a5c0-4f07-ae19-adfa1938bea4.png)
 
 #### Enabling custom routes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,11 +91,11 @@ Once you promoted your workspace, no further actions are needed on your part: yo
 
 #### Managing routes
 
-You can manage if you want to include product, navigation, apps and/or draft routes in your sitemap or not. To do that, check the following step by step.
+You can manage if you want to include product, navigation, apps and/or routes containing your specific term in your sitemap or not. To do that, check the following step by step.
 
 1. In your browser, access the the account's Admin in which you are working using the Production workspace used in the **step 2** of the [Configuration section](#configuration) (`{workspaceName}--{accountName}.myvtex.com/admin`).
 2. Go to **Account settings > Apps > My apps** and search for **Sitemap** app.
-3. Enable or disable product, navigation, app or draft routes according to your scenario.
+3. Enable or disable product, navigation, app or routes containing your specific term according to your scenario.
 
 ![sitemap-admin](https://user-images.githubusercontent.com/36925076/171218096-ceb6d01c-a5c0-4f07-ae19-adfa1938bea4.png)
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.14.0",
+  "version": "2.14.0-hkignore.europe.0",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.14.0-hkignore.europe.0",
+  "version": "2.14.0-hkignore.europe.3",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/manifest.json
+++ b/manifest.json
@@ -124,9 +124,10 @@
         "type": "boolean",
         "default": false
       },
-      "disableTestTest": {
-        "title": "Disable draft routes from userRoutes",
-        "default": "####",
+      "disableStringRoutes": {
+        "title": "Disable routes from userRoutes with then following string",
+        "description": "Routes that include with the string below will be excluded from the sitemap. Useful for selecting which pages will be in that folder.",
+        "default": "",
         "type": "string"
       }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -123,6 +123,11 @@
         "description": "This will exclude the /_draft/ routes from the userRoutes sitemap. Useful for placing draft pages in that folder.",
         "type": "boolean",
         "default": false
+      },
+      "disableTestTest": {
+        "title": "Disable draft routes from userRoutes",
+        "default": "####",
+        "type": "string"
       }
     }
   }

--- a/manifest.json
+++ b/manifest.json
@@ -118,15 +118,9 @@
         "type": "boolean",
         "default": true
       },
-      "disableDraftRoutes": {
-        "title": "Disable draft routes from userRoutes",
-        "description": "This will exclude the /_draft/ routes from the userRoutes sitemap. Useful for placing draft pages in that folder.",
-        "type": "boolean",
-        "default": false
-      },
       "disableStringRoutes": {
-        "title": "Disable routes from userRoutes with then following string",
-        "description": "Routes that include with the string below will be excluded from the sitemap. Useful for selecting which pages will be in that folder.",
+        "title": "Disable routes from userRoutes with the following string",
+        "description": "Routes that include the string below will be excluded from the sitemap. Useful for selecting which pages will be in that folder.",
         "default": "",
         "type": "string"
       }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.14.0-hkignore.europe.3",
+  "version": "2.14.0",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",
@@ -118,7 +118,7 @@
         "type": "boolean",
         "default": true
       },
-      "disableStringRoutes": {
+      "disableRoutesTerm": {
         "title": "Disable routes from userRoutes with the following string",
         "description": "Routes that include the string below will be excluded from the sitemap. Useful for selecting which pages will be in that folder.",
         "default": "",

--- a/manifest.json
+++ b/manifest.json
@@ -117,6 +117,12 @@
         "description": "This will enable the app routes source, adding to the final sitemap routes defined and exported by the routes.json files from apps built by the store@0.x builder.",
         "type": "boolean",
         "default": true
+      },
+      "disableDraftRoutes": {
+        "title": "Disable draft routes from userRoutes",
+        "description": "This will exclude the /_draft/ routes from the userRoutes sitemap. Useful for placing draft pages in that folder.",
+        "type": "boolean",
+        "default": false
       }
     }
   }

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -76,7 +76,6 @@ declare global {
     next: Maybe<string>
     report: Record<string, number>
     count: number
-    disableDraftRoutes: boolean
     disableStringRoutes: string
   }
 

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -76,6 +76,8 @@ declare global {
     next: Maybe<string>
     report: Record<string, number>
     count: number
+    disableDraftRoutes: boolean
+    disableStringRoutes: string
   }
 
   interface ProductRoutesGenerationEvent extends DefaultEvent   {

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -76,7 +76,7 @@ declare global {
     next: Maybe<string>
     report: Record<string, number>
     count: number
-    disableStringRoutes: string
+    disableRoutesTerm: string
   }
 
   interface ProductRoutesGenerationEvent extends DefaultEvent   {

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -76,6 +76,7 @@ declare global {
     next: Maybe<string>
     report: Record<string, number>
     count: number
+    disableDraftRoutes: boolean
   }
 
   interface ProductRoutesGenerationEvent extends DefaultEvent   {

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -76,7 +76,6 @@ declare global {
     next: Maybe<string>
     report: Record<string, number>
     count: number
-    disableDraftRoutes: boolean
   }
 
   interface ProductRoutesGenerationEvent extends DefaultEvent   {

--- a/node/middlewares/generateMiddlewares/generateRewriterRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateRewriterRoutes.ts
@@ -32,7 +32,7 @@ const createRoutesByBinding = (routes: Internal[], report: Record<string, number
         !internal.disableSitemapEntry &&
         storeBindingsIds.includes(internal.binding)
       if (disableRoutesTerm) {
-        validRoute = validRoute && !internal.from.includes('/' + disableRoutesTerm)
+        validRoute = validRoute && !internal.from.includes(disableRoutesTerm)
       }
       if (validRoute) {
         const { binding } = internal

--- a/node/middlewares/generateMiddlewares/generateRewriterRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateRewriterRoutes.ts
@@ -21,7 +21,7 @@ const LIST_LIMIT = 300
 
 type RoutesByBinding = Record<string, Record<string, Route[]>>
 
-const createRoutesByBinding = (routes: Internal[], report: Record<string, number>, storeBindings: Binding[], disableStringRoutes: string) => {
+const createRoutesByBinding = (routes: Internal[], report: Record<string, number>, storeBindings: Binding[], disableRoutesTerm: string) => {
   const storeBindingsIds = storeBindings.map(({ id }) => id)
   return routes.reduce(
     (acc, internal) => {
@@ -31,8 +31,8 @@ const createRoutesByBinding = (routes: Internal[], report: Record<string, number
         internal.type !== 'product' &&
         !internal.disableSitemapEntry &&
         storeBindingsIds.includes(internal.binding)
-      if (disableStringRoutes !== '') {
-        validRoute = validRoute && !internal.from.includes('/' + disableStringRoutes)
+      if (disableRoutesTerm) {
+        validRoute = validRoute && !internal.from.includes('/' + disableRoutesTerm)
       }
       if (validRoute) {
         const { binding } = internal
@@ -98,7 +98,7 @@ export async function generateRewriterRoutes(ctx: EventContext, nextMiddleware: 
   const { clients: { rewriter, tenant } , body } = ctx
   const {
     count,
-    disableStringRoutes,
+    disableRoutesTerm,
     generationId,
     next,
     report,
@@ -109,7 +109,7 @@ export async function generateRewriterRoutes(ctx: EventContext, nextMiddleware: 
   const responseNext = response.next
 
   const storeBindings = await getStoreBindings(tenant)
-  const routesByBinding = createRoutesByBinding(routes, report, storeBindings, disableStringRoutes)
+  const routesByBinding = createRoutesByBinding(routes, report, storeBindings, disableRoutesTerm)
 
   await Promise.all(
     Object.keys(routesByBinding).map(saveRoutes(routesByBinding, count, ctx.clients))
@@ -118,7 +118,7 @@ export async function generateRewriterRoutes(ctx: EventContext, nextMiddleware: 
   if (responseNext) {
     const payload: RewriterRoutesGenerationEvent = {
       count: count + 1,
-      disableStringRoutes,
+      disableRoutesTerm,
       generationId,
       next: responseNext,
       report,

--- a/node/middlewares/generateMiddlewares/generateRewriterRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateRewriterRoutes.ts
@@ -99,7 +99,6 @@ export async function generateRewriterRoutes(ctx: EventContext, nextMiddleware: 
   const {
     count,
     generationId,
-    disableDraftRoutes,
     next,
     report,
   }: RewriterRoutesGenerationEvent = body!
@@ -110,6 +109,7 @@ export async function generateRewriterRoutes(ctx: EventContext, nextMiddleware: 
 
   const storeBindings = await getStoreBindings(tenant)
 
+  const disableDraftRoutes = ctx.state.settings.disableDraftRoutes
   const routesByBinding = createRoutesByBinding(routes, report, storeBindings, disableDraftRoutes)
 
   await Promise.all(
@@ -121,7 +121,6 @@ export async function generateRewriterRoutes(ctx: EventContext, nextMiddleware: 
       count: count + 1,
       generationId,
       next: responseNext,
-      disableDraftRoutes,
       report,
     }
     ctx.state.nextEvent = {
@@ -139,7 +138,6 @@ export async function generateRewriterRoutes(ctx: EventContext, nextMiddleware: 
       payload: {
         from: 0,
         generationId,
-        disableDraftRoutes,
         indexFile: REWRITER_ROUTES_INDEX,
       },
     }

--- a/node/middlewares/generateMiddlewares/generateSitemap.test.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.test.ts
@@ -66,10 +66,11 @@ describe('Test generate sitemap', () => {
       state: {
         ...state.object,
         settings: {
+          disableDraftRoutes: false,
+          disableStringRoutes: '',
           enableAppsRoutes: true,
           enableNavigationRoutes: true,
           enableProductRoutes: true,
-          disableDraftRoutes: false,
         },
       },
       vtex: {
@@ -88,10 +89,11 @@ describe('Test generate sitemap', () => {
 
   it('Should send only enabled events', async () => {
     context.state.settings = {
+      disableDraftRoutes: false,
+      disableStringRoutes: '',
       enableAppsRoutes: true,
       enableNavigationRoutes: true,
       enableProductRoutes: false,
-      disableDraftRoutes: false,
     }
 
     await generateSitemap(context)
@@ -101,10 +103,11 @@ describe('Test generate sitemap', () => {
 
     jest.clearAllMocks()
     context.state.settings = {
+      disableDraftRoutes: false,
+      disableStringRoutes:'',
       enableAppsRoutes: false,
       enableNavigationRoutes: false,
       enableProductRoutes: true,
-      disableDraftRoutes: false,
     }
 
     await generateSitemap(context)

--- a/node/middlewares/generateMiddlewares/generateSitemap.test.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.test.ts
@@ -69,6 +69,7 @@ describe('Test generate sitemap', () => {
           enableAppsRoutes: true,
           enableNavigationRoutes: true,
           enableProductRoutes: true,
+          disableDraftRoutes: false,
         },
       },
       vtex: {
@@ -90,6 +91,7 @@ describe('Test generate sitemap', () => {
       enableAppsRoutes: true,
       enableNavigationRoutes: true,
       enableProductRoutes: false,
+      disableDraftRoutes: false,
     }
 
     await generateSitemap(context)
@@ -102,6 +104,7 @@ describe('Test generate sitemap', () => {
       enableAppsRoutes: false,
       enableNavigationRoutes: false,
       enableProductRoutes: true,
+      disableDraftRoutes: false,
     }
 
     await generateSitemap(context)

--- a/node/middlewares/generateMiddlewares/generateSitemap.test.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.test.ts
@@ -66,7 +66,7 @@ describe('Test generate sitemap', () => {
       state: {
         ...state.object,
         settings: {
-          disableStringRoutes: '',
+          disableRoutesTerm: '',
           enableAppsRoutes: true,
           enableNavigationRoutes: true,
           enableProductRoutes: true,
@@ -88,7 +88,7 @@ describe('Test generate sitemap', () => {
 
   it('Should send only enabled events', async () => {
     context.state.settings = {
-      disableStringRoutes: '',
+      disableRoutesTerm: '',
       enableAppsRoutes: true,
       enableNavigationRoutes: true,
       enableProductRoutes: false,
@@ -101,7 +101,7 @@ describe('Test generate sitemap', () => {
 
     jest.clearAllMocks()
     context.state.settings = {
-      disableStringRoutes:'',
+      disableRoutesTerm:'',
       enableAppsRoutes: false,
       enableNavigationRoutes: false,
       enableProductRoutes: true,

--- a/node/middlewares/generateMiddlewares/generateSitemap.test.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.test.ts
@@ -66,7 +66,6 @@ describe('Test generate sitemap', () => {
       state: {
         ...state.object,
         settings: {
-          disableDraftRoutes: false,
           disableStringRoutes: '',
           enableAppsRoutes: true,
           enableNavigationRoutes: true,
@@ -89,7 +88,6 @@ describe('Test generate sitemap', () => {
 
   it('Should send only enabled events', async () => {
     context.state.settings = {
-      disableDraftRoutes: false,
       disableStringRoutes: '',
       enableAppsRoutes: true,
       enableNavigationRoutes: true,
@@ -103,7 +101,6 @@ describe('Test generate sitemap', () => {
 
     jest.clearAllMocks()
     context.state.settings = {
-      disableDraftRoutes: false,
       disableStringRoutes:'',
       enableAppsRoutes: false,
       enableNavigationRoutes: false,

--- a/node/middlewares/generateMiddlewares/generateSitemap.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.ts
@@ -30,11 +30,13 @@ const DEFAULT_REWRITER_ROUTES_PAYLOAD = {
 export async function generateSitemap(ctx: EventContext) {
   const { clients: { events }, body: { generationId }, state: { settings } }  = ctx
   const disableDraftRoutes = settings.disableDraftRoutes
+  const disableStringRoutes = settings.disableStringRoutes
   if (settings.enableNavigationRoutes) {
     events.sendEvent('', GENERATE_REWRITER_ROUTES_EVENT, {
       ...DEFAULT_REWRITER_ROUTES_PAYLOAD,
-      generationId,
       disableDraftRoutes,
+      disableStringRoutes,
+      generationId,
     } as RewriterRoutesGenerationEvent)
   }
 

--- a/node/middlewares/generateMiddlewares/generateSitemap.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.ts
@@ -29,10 +29,12 @@ const DEFAULT_REWRITER_ROUTES_PAYLOAD = {
 
 export async function generateSitemap(ctx: EventContext) {
   const { clients: { events }, body: { generationId }, state: { settings } }  = ctx
+  const disableDraftRoutes = settings.disableDraftRoutes
   if (settings.enableNavigationRoutes) {
     events.sendEvent('', GENERATE_REWRITER_ROUTES_EVENT, {
       ...DEFAULT_REWRITER_ROUTES_PAYLOAD,
       generationId,
+      disableDraftRoutes,
     } as RewriterRoutesGenerationEvent)
   }
 

--- a/node/middlewares/generateMiddlewares/generateSitemap.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.ts
@@ -29,11 +29,11 @@ const DEFAULT_REWRITER_ROUTES_PAYLOAD = {
 
 export async function generateSitemap(ctx: EventContext) {
   const { clients: { events }, body: { generationId }, state: { settings } }  = ctx
-  const disableStringRoutes = settings.disableStringRoutes
+  const disableRoutesTerm = settings.disableRoutesTerm
   if (settings.enableNavigationRoutes) {
     events.sendEvent('', GENERATE_REWRITER_ROUTES_EVENT, {
       ...DEFAULT_REWRITER_ROUTES_PAYLOAD,
-      disableStringRoutes,
+      disableRoutesTerm,
       generationId,
     } as RewriterRoutesGenerationEvent)
   }

--- a/node/middlewares/generateMiddlewares/generateSitemap.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.ts
@@ -29,12 +29,10 @@ const DEFAULT_REWRITER_ROUTES_PAYLOAD = {
 
 export async function generateSitemap(ctx: EventContext) {
   const { clients: { events }, body: { generationId }, state: { settings } }  = ctx
-  const disableDraftRoutes = settings.disableDraftRoutes
   const disableStringRoutes = settings.disableStringRoutes
   if (settings.enableNavigationRoutes) {
     events.sendEvent('', GENERATE_REWRITER_ROUTES_EVENT, {
       ...DEFAULT_REWRITER_ROUTES_PAYLOAD,
-      disableDraftRoutes,
       disableStringRoutes,
       generationId,
     } as RewriterRoutesGenerationEvent)

--- a/node/middlewares/settings.ts
+++ b/node/middlewares/settings.ts
@@ -6,23 +6,26 @@ export interface Settings {
   enableProductRoutes: boolean
   enableNavigationRoutes: boolean
   disableDraftRoutes: boolean
+  disableStringRoutes: string
 }
 
 const VTEX_APP_ID = process.env.VTEX_APP_ID!
 const VTEX_APP_AT_MAJOR = appIdToAppAtMajor(VTEX_APP_ID)
 
 const DEFAULT_SETTINGS = {
+  disableDraftRoutes: false,
+  disableStringRoutes: '',
   enableAppsRoutes: true,
   enableNavigationRoutes: true,
   enableProductRoutes: true,
-  disableDraftRoutes: false
 }
 
 const INDEX_MAP = {
+  disableDraftRoutes: '',
+  disableStringRoutes: '',
   enableAppsRoutes: APPS_ROUTES_INDEX,
   enableNavigationRoutes: REWRITER_ROUTES_INDEX,
   enableProductRoutes: PRODUCT_ROUTES_INDEX,
-  disableDraftRoutes: ""
 }
 
 export async function settings(ctx: Context | EventContext, next: () => Promise<void>) {

--- a/node/middlewares/settings.ts
+++ b/node/middlewares/settings.ts
@@ -5,6 +5,7 @@ export interface Settings {
   enableAppsRoutes: boolean
   enableProductRoutes: boolean
   enableNavigationRoutes: boolean
+  disableDraftRoutes: boolean
 }
 
 const VTEX_APP_ID = process.env.VTEX_APP_ID!
@@ -14,12 +15,14 @@ const DEFAULT_SETTINGS = {
   enableAppsRoutes: true,
   enableNavigationRoutes: true,
   enableProductRoutes: true,
+  disableDraftRoutes: false
 }
 
 const INDEX_MAP = {
   enableAppsRoutes: APPS_ROUTES_INDEX,
   enableNavigationRoutes: REWRITER_ROUTES_INDEX,
   enableProductRoutes: PRODUCT_ROUTES_INDEX,
+  disableDraftRoutes: ""
 }
 
 export async function settings(ctx: Context | EventContext, next: () => Promise<void>) {

--- a/node/middlewares/settings.ts
+++ b/node/middlewares/settings.ts
@@ -5,21 +5,21 @@ export interface Settings {
   enableAppsRoutes: boolean
   enableProductRoutes: boolean
   enableNavigationRoutes: boolean
-  disableStringRoutes: string
+  disableRoutesTerm: string
 }
 
 const VTEX_APP_ID = process.env.VTEX_APP_ID!
 const VTEX_APP_AT_MAJOR = appIdToAppAtMajor(VTEX_APP_ID)
 
 const DEFAULT_SETTINGS = {
-  disableStringRoutes: '',
+  disableRoutesTerm: '',
   enableAppsRoutes: true,
   enableNavigationRoutes: true,
   enableProductRoutes: true,
 }
 
 const INDEX_MAP = {
-  disableStringRoutes: '',
+  disableRoutesTerm: '',
   enableAppsRoutes: APPS_ROUTES_INDEX,
   enableNavigationRoutes: REWRITER_ROUTES_INDEX,
   enableProductRoutes: PRODUCT_ROUTES_INDEX,

--- a/node/middlewares/settings.ts
+++ b/node/middlewares/settings.ts
@@ -5,7 +5,6 @@ export interface Settings {
   enableAppsRoutes: boolean
   enableProductRoutes: boolean
   enableNavigationRoutes: boolean
-  disableDraftRoutes: boolean
   disableStringRoutes: string
 }
 
@@ -13,7 +12,6 @@ const VTEX_APP_ID = process.env.VTEX_APP_ID!
 const VTEX_APP_AT_MAJOR = appIdToAppAtMajor(VTEX_APP_ID)
 
 const DEFAULT_SETTINGS = {
-  disableDraftRoutes: false,
   disableStringRoutes: '',
   enableAppsRoutes: true,
   enableNavigationRoutes: true,
@@ -21,7 +19,6 @@ const DEFAULT_SETTINGS = {
 }
 
 const INDEX_MAP = {
-  disableDraftRoutes: '',
   disableStringRoutes: '',
   enableAppsRoutes: APPS_ROUTES_INDEX,
   enableNavigationRoutes: REWRITER_ROUTES_INDEX,

--- a/node/middlewares/sitemap.test.ts
+++ b/node/middlewares/sitemap.test.ts
@@ -104,7 +104,6 @@ describe('Test sitemap middleware', () => {
           ],
           rootPath: '',
           settings: {
-            disableDraftRoutes: false,
             disableStringRoutes: '',
             enableAppsRoutes: true,
             enableNavigationRoutes: true,

--- a/node/middlewares/sitemap.test.ts
+++ b/node/middlewares/sitemap.test.ts
@@ -107,6 +107,7 @@ describe('Test sitemap middleware', () => {
             enableAppsRoutes: true,
             enableNavigationRoutes: true,
             enableProductRoutes: true,
+            disableDraftRoutes: false,
           },
         },
         vtex: {

--- a/node/middlewares/sitemap.test.ts
+++ b/node/middlewares/sitemap.test.ts
@@ -104,10 +104,11 @@ describe('Test sitemap middleware', () => {
           ],
           rootPath: '',
           settings: {
+            disableDraftRoutes: false,
+            disableStringRoutes: '',
             enableAppsRoutes: true,
             enableNavigationRoutes: true,
             enableProductRoutes: true,
-            disableDraftRoutes: false,
           },
         },
         vtex: {

--- a/node/middlewares/sitemap.test.ts
+++ b/node/middlewares/sitemap.test.ts
@@ -104,7 +104,7 @@ describe('Test sitemap middleware', () => {
           ],
           rootPath: '',
           settings: {
-            disableStringRoutes: '',
+            disableRoutesTerm: '',
             enableAppsRoutes: true,
             enableNavigationRoutes: true,
             enableProductRoutes: true,

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4560,7 +4560,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
New setting to allow excluding the `/_draft/` routes from the sitemap.
This prevents indexing draft pages by crawlers.

The app with this improvement is linked in the `vtexspain` account and `miguelcarrera` workspace.
For example this URL should not be included in the sitemap if the setting is enabled
[https://miguelcarrera--vtexspain.myvtex.com/_draft/pillows1234](https://miguelcarrera--vtexspain.myvtex.com/_draft/pillows1234)
