### PR TITLE
Use cache setting provided or default them

### DIFF
--- a/node/middlewares/cache.ts
+++ b/node/middlewares/cache.ts
@@ -35,10 +35,12 @@ export async function cache(ctx: Context, next: () => Promise<void>) {
       : THIRTY_SECONDS + from0To30()
 
     if (shouldCache) {
-      ctx.set(
-        'cache-control',
-        `public, max-age=${maxAge}, stale-while-revalidate=${TEN_SECONDS_S}, stale-if-error=${TEN_MINUTES_S}`
-      )
+      if (ctx.get('cache-control') === '') { // cache-control is not set
+        ctx.set(
+          'cache-control',
+          `public, max-age=${maxAge}, stale-while-revalidate=${TEN_SECONDS_S}, stale-if-error=${TEN_MINUTES_S}`
+        )
+      }
     } else {
       ctx.set('cache-control', 'no-store, no-cache')
     }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4560,7 +4560,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
Noticed that the cache settings coming out for the robots.txt file had a max-age <= 60s. Upon investigation it seems that the cache middleware is overriding the cache-control that is being set in the robots middleware. This PR makes it so that if there is a cache-control already set that it won't override.