### PR TITLE
Fix cache for multi-binding sites

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.14.0",
+  "version": "2.14.1-beta.0",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/node/middlewares/prepare.ts
+++ b/node/middlewares/prepare.ts
@@ -6,6 +6,7 @@ import { DEFAULT_CONFIG } from './generateMiddlewares/utils'
 
 const ONE_DAY_S = 24 * 60 * 60
 const FORWARDED_HOST_HEADER = 'x-forwarded-host'
+const VTEX_ROOT_PATH_HEADER = 'x-vtex-root-path'
 
 export async function prepare(ctx: Context, next: () => Promise<void>) {
   const {
@@ -58,6 +59,7 @@ export async function prepare(ctx: Context, next: () => Promise<void>) {
     startSitemapGeneration(ctx)
   }
   ctx.vary(FORWARDED_HOST_HEADER)
+  ctx.vary(VTEX_ROOT_PATH_HEADER)
 
   return
 }

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1,10 +1,10 @@
 import { startSitemapGeneration } from '../utils'
-import { saveIndex, deleteIndex } from './mutations'
+import { deleteIndex, saveIndex } from './mutations'
 
 export const resolvers = {
   Mutation: {
-    saveIndex,
     deleteIndex,
+    saveIndex,
   },
   Query: {
     generateSitemap: async (

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4560,7 +4560,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
I saw an escalation earlier regarding incorrect sitemaps on sites with multiple bindings, where the binding is handled via the path instead of the host. I believe that the issue is that the cache is only set to vary on the host.

I haven't figured out a good way to test this locally besides observing that it didn't error, but figured I would save you the trouble and give the code that I believe will fix the issue.