### PR TITLE
Doc: Updating README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,15 +18,11 @@ Before generating your store's sitemap, you might want to adjust if products, na
    
 2. Run `vtex use {workspaceName} --production` to use a production workspace or [create a production workspace](https://vtex.io/docs/recipes/development/creating-a-production-workspace/) from scratch.
 
-> ℹ️ **Info**
->
-> Remember to replace the values between the curly brackets according to your scenario.
+> ℹ️ Remember to replace the values between the curly brackets according to your scenario.
 
 3. Run `vtex install vtex.store-sitemap@2.x` to install the Sitemap app.
 
-> ℹ️ **Info**
->
-> If you are using `vtex.edition-store@5.x`, skip step 3, as the `vtex.store-sitemap@2.x` app is installed by default in this version. Check out our [Edition App documentation](https://developers.vtex.com/docs/guides/vtex-io-documentation-edition-app) to know more about its different versions.
+> ℹ️ If you are using `vtex.edition-store@5.x`, skip step 3, as the `vtex.store-sitemap@2.x` app is installed by default in this version. Check out our [Edition App documentation](https://developers.vtex.com/docs/guides/vtex-io-documentation-edition-app) to know more about its different versions.
 
 4. Run `vtex install vtex.admin-graphql-ide@3.x` to install the GraphQL admin IDE.
    
@@ -36,7 +32,7 @@ Before generating your store's sitemap, you might want to adjust if products, na
 
 6. From the dropdown list, choose the `vtex.routes-bootstrap@0.x` app.
 
-7. If this is **not** the **first time** you are generating your store's sitemap or if your store's routes **did not suffer any changes** since the last time you generated your store's sitemap, go to step 8. Otherwise, run the following query:
+7. If this is **not the first time** you are generating your store's sitemap or if your store's routes **did not suffer any changes** since the last time you generated your store's sitemap, go to step 8. Otherwise, run the following query:
 
 ```
 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,77 +18,73 @@ Before generating your store's sitemap, you might want to adjust if products, na
    
 2. Run `vtex use {workspaceName} --production` to use a production workspace or [create a production workspace](https://vtex.io/docs/recipes/development/creating-a-production-workspace/) from scratch.
 
-> ℹ️ Remember to replace the values between the curly brackets according to your scenario.
+   >⚠️ Remember to replace the values between the curly brackets according to your scenario.
 
 3. Run `vtex install vtex.store-sitemap@2.x` to install the Sitemap app.
 
-> ℹ️ If you are using `vtex.edition-store@5.x`, skip step 3, as the `vtex.store-sitemap@2.x` app is installed by default in this version. Check out our [Edition App documentation](https://developers.vtex.com/docs/guides/vtex-io-documentation-edition-app) to know more about its different versions.
+   > ℹ️ If you are using `vtex.edition-store@5.x`, skip step 3, as the `vtex.store-sitemap@2.x` app is installed by default in this version. Check out our [Edition App documentation](https://developers.vtex.com/docs/guides/vtex-io-documentation-edition-app) to know more about its different versions.
 
 4. Run `vtex install vtex.admin-graphql-ide@3.x` to install the GraphQL admin IDE.
    
 5. In your browser, access the account's administrative panel and select the **GraphQL IDE**.
 
-![adminsidebarmenu](https://user-images.githubusercontent.com/52087100/66516950-95d29a00-eab8-11e9-8cea-080fbdab84d5.png)
+   ![adminsidebarmenu](https://user-images.githubusercontent.com/52087100/66516950-95d29a00-eab8-11e9-8cea-080fbdab84d5.png)
 
 6. From the dropdown list, choose the `vtex.routes-bootstrap@0.x` app.
 
 7. If this is **not the first time** you are generating your store's sitemap or if your store's routes **did not suffer any changes** since the last time you generated your store's sitemap, go to step 8. Otherwise, run the following query:
 
-```
-{
-  bootstrap {
-    brands
-    categories
-  }
-}
-```
+   ```gql
+   {
+     bootstrap {
+       brands
+       categories
+     }
+   }
+   ```
 
-The expected response is a `JSON` object containing the number of brand routes under the `brands` property; and the number of department, category, and subcategory routes under `categories`.
+   The expected response is a `JSON` object containing the number of brand routes under the `brands` property; and the number of department, category, and subcategory routes under `categories`.
 
 8. Now, from the GraphQL IDE dropdown list, choose the `vtex.store-sitemap@2.x` app.
 
 9. Run the following query:
 
-```
-{
-  generateSitemap
-}
-```
+   ```gql
+   {
+     generateSitemap
+   }
+   ```
 
-The expected response body is
+   The expected response body is
 
-```
-{
-  "data": {
-    "generateSitemap": true
-  }
-}
-```
+   ```json
+   {
+     "data": {
+       "generateSitemap": true
+     }
+   }
+   ```
 
-This means your sitemap will be available in some minutes, after being processed and saved on our database.
+   This means your sitemap will be available in some minutes, after being processed and saved on our database.
 
-> ℹ️ **Info**
->
-> Keep in mind that the time taken to generate a sitemap is proportional to the number of products. For example, the average time to generate a sitemap for a store with 60k products is 30 minutes. For 5k products, the duration should be about 5 minutes.
+   >ℹ️ Keep in mind that the time taken to generate a sitemap is proportional to the number of products. For example, the average time to generate a sitemap for a store with 60k products is 30 minutes. For 5k products, the duration should be about 5 minutes.
+   
+   If you attempt to send a new request to the Sitemap API while your store's sitemap generation is already taking place, the following message will be displayed:
 
-⚠️ If you attempt to send a new request to the Sitemap API while your store's sitemap generation is already taking place, the following message will be displayed:
-
-```
-Sitemap generation already in place
-Next generation available: <End-date>
-```
-
-To make a force restart, add the `force` argument to the query, as in: `generateSitemap(force: true)`. But, be aware that this will cancel the previous process.
+   ```
+   Sitemap generation already in place
+   Next generation available: <End-date>
+   ```
+   
+   To make a force restart, add the `force` argument to the query, as in: `generateSitemap(force: true)`. But, be aware that this will cancel the previous process.
 
 10. Check the sitemap generated for the current workspace you are working on by accessing `https://{workspace}--{account}.myvtex.com/sitemap.xml` on your browser. Notice that if your store is a cross-border one, you will first see an index containing a website's sitemap for each locale.
 
-> ℹ️ **Info**
->
-> Notice that different `.xml` files are generated according to their entity type (product, category, subcategory, user routes, brand and department) and that each `.xml` file supports a maximum of 5k routes.
+    >ℹ️ Notice that different `.xml` files are generated according to their entity type (product, category, subcategory, user routes, brand and department) and that each `.xml` file supports a maximum of 5k routes.
 
 11. If you are happy with the results, run `vtex promote` to promote your workspace and to have your sitemap in your master workspace.
 
-Once you promoted your workspace, no further actions are needed on your part: you are ready to check out your store's sitemap by accessing `https://{account}.myvtex.com/sitemap.xml` on your browser.
+    Once you promoted your workspace, no further actions are needed on your part: you are ready to check out your store's sitemap by accessing `https://{account}.myvtex.com/sitemap.xml` on your browser.
 
 ### Advanced configuration
 
@@ -102,20 +98,20 @@ You can manage if you want to include product, navigation, apps and/or routes co
 
 3. Enable or disable product, navigation, app or routes containing your specific term according to your scenario.
 
-![sitemap-admin](https://user-images.githubusercontent.com/36925076/171218096-ceb6d01c-a5c0-4f07-ae19-adfa1938bea4.png)
+   ![sitemap-admin](https://github.com/vtexdocs/dev-portal-content/assets/112641072/649f7dcf-583d-497f-a69c-4cfc3d8a805a)
 
 #### Enabling custom routes
 
 If you have [custom pages](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-creating-a-new-custom-page) configured in a `routes.json` file and want them to be included in your store's sitemap, add `isSitemapEntry=true` as a prop of the routes you want to include in the sitemap. Take the following example:
 
-```
-{
-    "store.custom#about-us": {
-      "path": "/about-us",
-      "isSitemapEntry": true
-  }
-}
-```
+   ```json
+   {
+       "store.custom#about-us": {
+         "path": "/about-us",
+         "isSitemapEntry": true
+     }
+   }
+   ```
 
 Once everything is set up, go back to the **step 4** of the [Configuration section](#configuration).
 
@@ -127,9 +123,7 @@ For implementation details, check the following step by step.
 
 1. Create or modify your app to respond to the following route `/sitemap/{index-name}.xml` and to return an XML file containing the data that you want the search engine (e.g., Google) to index. Remember to replace the values between the curly brackets according to your scenario.
 
-> ℹ️ **Info**
->
-> We recommend that you use a pre-created XML file. Otherwise, for every request, the XML file will be built from scratch, consuming more time to complete the task.
+   >ℹ️ We recommend that you use a pre-created XML file. Otherwise, the XML file will be built from scratch for every request, consuming more time to complete the task.
 
 2. [Publish](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-publishing-an-app) and install your app in a production workspace.
 
@@ -137,15 +131,13 @@ For implementation details, check the following step by step.
 
 4. From the dropdown list, choose the `vtex.store-sitemap@2.x` app and perform the following mutation, adapting it to your scenario:
 
-```gql
-mutation {
-  saveIndex(index: "{index-name}")
-}
-```
+   ```gql
+   mutation {
+     saveIndex(index: "{index-name}")
+   }
+   ```
 
-> ℹ️ **Info**
->
-> **If your store is a cross-border one**, keep in mind that the `saveIndex` mutation also accepts the `binding` id as an argument. That means that, by specifying the `binding` id, you can add your new index to the sitemap of the desired binding. If the `binding` id is not specified, the mutation will consider the store's default binding.
+   >ℹ️ **If your store is a cross-border one**, keep in mind that the `saveIndex` mutation also accepts the `binding` id as an argument. That means that, by specifying the `binding` id, you can add your new index to the sitemap of the desired binding. If the `binding` id is not specified, the mutation will consider the store's default binding.
 
 5. Check the updated sitemap for the current workspace you are working on by accessing `https://{workspace}--{account}.myvtex.com/sitemap.xml` in your browser.
 
@@ -155,8 +147,8 @@ mutation {
 
 If it is ever desired to remove a custom route, you may execute the following mutation, which takes the same arguments as `saveIndex`:
 
-```gql
-mutation {
-  deleteIndex(index: "{index-name}")
-}
-```
+   ```gql
+   mutation {
+      deleteIndex(index: "{index-name}")
+   }
+   ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,11 +18,15 @@ Before generating your store's sitemap, you might want to adjust if products, na
    
 2. Run `vtex use {workspaceName} --production` to use a production workspace or [create a production workspace](https://vtex.io/docs/recipes/development/creating-a-production-workspace/) from scratch.
 
-> ⚠️ **Warning**
+> ℹ️ **Info**
 >
 > Remember to replace the values between the curly brackets according to your scenario.
 
 3. Run `vtex install vtex.store-sitemap@2.x` to install the Sitemap app.
+
+> ℹ️ **Info**
+>
+> If you are using `vtex.edition-store@5.x`, skip step 3, as the `vtex.store-sitemap@2.x` app is installed by default in this version. Check out our [Edition App documentation](https://developers.vtex.com/docs/guides/vtex-io-documentation-edition-app) to know more about its different versions.
 
 4. Run `vtex install vtex.admin-graphql-ide@3.x` to install the GraphQL admin IDE.
    
@@ -32,7 +36,7 @@ Before generating your store's sitemap, you might want to adjust if products, na
 
 6. From the dropdown list, choose the `vtex.routes-bootstrap@0.x` app.
 
-7. If this is **not** the **first time** you're generating your store's sitemap or if your store's routes **did not suffer any changes** since the last time you generated your store's sitemap, go to step 8. Otherwise, run the following query:
+7. If this is **not** the **first time** you are generating your store's sitemap or if your store's routes **did not suffer any changes** since the last time you generated your store's sitemap, go to step 8. Otherwise, run the following query:
 
 ```
 {
@@ -80,13 +84,13 @@ Next generation available: <End-date>
 
 To make a force restart, add the `force` argument to the query, as in: `generateSitemap(force: true)`. But, be aware that this will cancel the previous process.
 
-10. Check the sitemap generated for the current workspace you are working on by accessing `https://{workspace}--{account}.myvtex.com/sitemap.xml` on your browser. Notice that if your store is a cross-border one, you'll first see an index containing a website's sitemap for each locale.
+10. Check the sitemap generated for the current workspace you are working on by accessing `https://{workspace}--{account}.myvtex.com/sitemap.xml` on your browser. Notice that if your store is a cross-border one, you will first see an index containing a website's sitemap for each locale.
 
 > ℹ️ **Info**
 >
 > Notice that different `.xml` files are generated according to their entity type (product, category, subcategory, user routes, brand and department) and that each `.xml` file supports a maximum of 5k routes.
 
-11. If you're happy with the results, run `vtex promote` to promote your workspace and to have your sitemap in your master workspace.
+11. If you are happy with the results, run `vtex promote` to promote your workspace and to have your sitemap in your master workspace.
 
 Once you promoted your workspace, no further actions are needed on your part: you are ready to check out your store's sitemap by accessing `https://{account}.myvtex.com/sitemap.xml` on your browser.
 


### PR DESCRIPTION
- Information about step 3 was added, because if the store uses vtex.edition-store@5.x, it is unnecessary to install the sitemap app, as it is already installed by default in this version.

- A link to know more about the differences between edition versions was added.
