### PR TITLE
Publishing the store-sitemap app

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ For more information about generating a sitemap, check the following sections.
 
 This app is available to stores using `vtex.edition-store@3.x` or a later version of the [Edition App](https://developers.vtex.com/docs/guides/vtex-io-documentation-edition-app). To check which Edition App is installed on your account, run `vtex edition get`. If it is an older Edition, please [open a ticket](https://help-tickets.vtex.com/smartlink/sso/login/zendesk) with VTEX Support asking for the installation of the `vtex.edition-store@3.x` Edition App or a newer version.
 
-Before generating your store's sitemap, you might want to adjust if products, navigation, app and/or custom routes will be included in it or not. If that is the case, check the [Advanced Configuration section](#advanced-configuration) for more information.
+Before generating your store's sitemap, you might want to adjust whether products, navigation, apps, or custom routes will be included. If that is the case, check the [Advanced Configuration section](#advanced-configuration) for more information.
 
 ## Instructions
 


### PR DESCRIPTION
In the PR [#158](https://github.com/vtex-apps/store-sitemap/pull/158), the app publishing failed. This PR is to publish the app again.