### PR TITLE
Fix: prevents using the wrong version from robots.txt

### DIFF
--- a/node/middlewares/robots.ts
+++ b/node/middlewares/robots.ts
@@ -1,5 +1,7 @@
 import { Apps } from '@vtex/api'
 
+import { notFound } from '../utils'
+
 const TEN_MINUTES_S = 10 * 60
 
 interface RobotsFile {
@@ -18,7 +20,7 @@ const getRobotForBinding = async (
   try {
     await apps.getApp(appId)
   } catch (err) {
-    return
+    notFound(undefined)(err)
   }
 
   const buildFile = await apps.getAppJSON<Partial<RobotsFile> | null>(


### PR DESCRIPTION
#### What does this PR do?

This PR improves the `getRobotForBinding` function by adding a check to ensure the correct version of the `robots.txt` is used. It uses the `apps.getApp()` method to confirm that the `robots@0.x` app is installed before attempting to retrieve t`he robots.txt` file. This prevents the usage of an incorrect or outdated version of the file.

This is the return of `apps.getApp()` when the appId passed as a parameter is not installed on the account:

<img width="770" alt="image" src="https://github.com/user-attachments/assets/8b29e37c-e068-4337-8868-3dae29f2dff0">
