### PR TITLE
Add caller in the generation log

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^12.0.0",
     "@types/ramda": "^0.26.8",
     "@types/route-parser": "^0.1.2",
-    "@vtex/api": "6.47.0",
+    "@vtex/api": "6.48.0",
     "gocommerce.sitemap-app": "http://gocommerce.vtexassets.com/_v/public/typings/v1/gocommerce.sitemap-app@1.2.1/public/_types/react",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1",

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -67,7 +67,8 @@ export const startSitemapGeneration = async (ctx: Context, force?: boolean) => {
     throw new MultipleSitemapGenerationError(config.endDate)
   }
   const generationId = (Math.random() * 10000).toString()
-  logger.info({ message: 'New generation starting', generationId })
+  const caller = ctx.request.header['x-vtex-caller']
+  logger.info({ message: `New generation started by ${caller}`, generationId })
   await vbase.saveJSON<GenerationConfig>(CONFIG_BUCKET, GENERATION_CONFIG_FILE, {
     endDate: fiveDaysFromNowMS(),
     generationId,

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -700,10 +700,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.47.0":
-  version "6.47.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.47.0.tgz#6910455d593d8bb76f1f4f2b7660023853fda35e"
-  integrity sha512-t9gt7Q89EMbSj3rLhho+49Fv+/lQgiy8EPVRgtmmXFp1J4v8hIAZF7GPjCPie111KVs4eG0gfZFpmhA5dafKNA==
+"@vtex/api@6.48.0":
+  version "6.48.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.48.0.tgz#67f9f11d197d543d4f854b057d31a8d6999241e9"
+  integrity sha512-mAdT7gbV0/BwiuqUkNH1E7KZqTUczT5NbBBZcPJq5kmTr73PUjbR9wh//70ryJo2EAdHlqIgqgwsCVpozenlhg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4576,7 +4576,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
In order to easily identify the caller of the generation I suggest we add the `x-vtex-caller` header that can be identification of an application or an user.

Example:
<img width="1177" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/4f43e94a-1255-4741-a2af-8d958251d814" />
