### PR TITLE
fix: sitemap now being showed due exceeding max call stack from js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+ 
+### Added
+
+- `MAX_CALL_STACK_SIZE` when appending entries to XML file
 
 ## [2.16.4] - 2024-09-11
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.16.4",
+  "version": "2.16.5-hkignore.1",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "store-sitemap",
   "vendor": "vtex",
-  "version": "2.16.5-hkignore.1",
+  "version": "2.16.4",
   "title": "Sitemap",
   "description": "Sitemap for vtex.store",
   "mustUpdateAt": "2019-08-01",

--- a/node/middlewares/sitemap.ts
+++ b/node/middlewares/sitemap.ts
@@ -97,7 +97,7 @@ const sitemapIndex = async (ctx: Context) => {
       lastUpdated,
       bindingAddress
     )
-  )  
+  )
   $('sitemapindex').append(indexXML.slice(0, MAX_CALL_STACK_SIZE).join('\n'))
   return $
 }

--- a/node/middlewares/sitemap.ts
+++ b/node/middlewares/sitemap.ts
@@ -3,7 +3,7 @@ import * as cheerio from 'cheerio'
 import { MultipleSitemapGenerationError } from '../errors'
 import {
   EXTENDED_INDEX_FILE,
-  MAX_CALL_STACK_SIZE,
+  xmlTruncateNodes,
   getBucket,
   hashString,
   SitemapNotFound,
@@ -98,7 +98,7 @@ const sitemapIndex = async (ctx: Context) => {
       bindingAddress
     )
   )
-  $('sitemapindex').append(indexXML.slice(0, MAX_CALL_STACK_SIZE).join('\n'))
+  $('sitemapindex').append(xmlTruncateNodes(indexXML))
   return $
 }
 
@@ -123,7 +123,7 @@ const sitemapBindingIndex = async (ctx: Context) => {
       production ? '' : binding.canonicalBaseAddress
     )
   )
-  $('sitemapindex').append(bindingsIndexXML.slice(0, MAX_CALL_STACK_SIZE).join('\n'))
+  $('sitemapindex').append(xmlTruncateNodes(bindingsIndexXML))
   return $
 }
 

--- a/node/middlewares/sitemap.ts
+++ b/node/middlewares/sitemap.ts
@@ -3,6 +3,7 @@ import * as cheerio from 'cheerio'
 import { MultipleSitemapGenerationError } from '../errors'
 import {
   EXTENDED_INDEX_FILE,
+  MAX_CALL_STACK_SIZE,
   getBucket,
   hashString,
   SitemapNotFound,
@@ -96,8 +97,8 @@ const sitemapIndex = async (ctx: Context) => {
       lastUpdated,
       bindingAddress
     )
-  )
-  $('sitemapindex').append(indexXML.join('\n'))
+  )  
+  $('sitemapindex').append(indexXML.slice(0, MAX_CALL_STACK_SIZE).join('\n'))
   return $
 }
 
@@ -122,7 +123,7 @@ const sitemapBindingIndex = async (ctx: Context) => {
       production ? '' : binding.canonicalBaseAddress
     )
   )
-  $('sitemapindex').append(bindingsIndexXML.join('\n'))
+  $('sitemapindex').append(bindingsIndexXML.slice(0, MAX_CALL_STACK_SIZE).join('\n'))
   return $
 }
 

--- a/node/package.json
+++ b/node/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^12.0.0",
     "@types/ramda": "^0.26.8",
     "@types/route-parser": "^0.1.2",
-    "@vtex/api": "6.47.0",
+    "@vtex/api": "6.48.0",
     "gocommerce.sitemap-app": "http://gocommerce.vtexassets.com/_v/public/typings/v1/gocommerce.sitemap-app@1.2.1/public/_types/react",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1",

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -8,6 +8,7 @@ export const CONFIG_BUCKET = `${LINKED ? 'linked' : ''}configuration`
 export const CONFIG_FILE = 'config.json'
 export const GENERATION_CONFIG_FILE = 'generation.json'
 export const EXTENDED_INDEX_FILE = 'extendedIndex.json'
+export const MAX_CALL_STACK_SIZE =  1000
 
 export const TENANT_CACHE_TTL_S = 60 * 10
 

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -26,9 +26,8 @@ const validBinding = (path: string) => (binding: Binding) => {
   return matchesPath && isStoreBinding
 }
 
-export const xmlTruncateNodes = ( xml: string[], limit: number = MAX_CALL_STACK_SIZE) => {
-  return xml.slice(0, limit).join('\n')
-}
+export const xmlTruncateNodes = ( xml: string[], limit: number = MAX_CALL_STACK_SIZE) => 
+  xml.slice(0, limit).join('\n')
 
 export const notFound = <T>(fallback: T) => (error: any): T => {
   if (error.response && error.response.status === 404) {

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -26,6 +26,10 @@ const validBinding = (path: string) => (binding: Binding) => {
   return matchesPath && isStoreBinding
 }
 
+export const xmlTruncateNodes = ( xml: string[], limit: number = MAX_CALL_STACK_SIZE) => {
+  return xml.slice(0, limit).join('\n')
+}
+
 export const notFound = <T>(fallback: T) => (error: any): T => {
   if (error.response && error.response.status === 404) {
     return fallback

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -700,10 +700,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.47.0":
-  version "6.47.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.47.0.tgz#6910455d593d8bb76f1f4f2b7660023853fda35e"
-  integrity sha512-t9gt7Q89EMbSj3rLhho+49Fv+/lQgiy8EPVRgtmmXFp1J4v8hIAZF7GPjCPie111KVs4eG0gfZFpmhA5dafKNA==
+"@vtex/api@6.48.0":
+  version "6.48.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.48.0.tgz#67f9f11d197d543d4f854b057d31a8d6999241e9"
+  integrity sha512-mAdT7gbV0/BwiuqUkNH1E7KZqTUczT5NbBBZcPJq5kmTr73PUjbR9wh//70ryJo2EAdHlqIgqgwsCVpozenlhg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4576,7 +4576,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
### Summary
The current store-sitemap generation process cannot efficiently handle stores with very large catalogs in Store Framework stores. When dealing with a high volume of products the generation breaks because of the size of the main file on the sitemap.

### Simulation
Open the site with a large catalog (e.g., millions of products and categories). eg: gandhi has the hkignore version of this fix

Trigger the sitemap generation process and try to access in myvtex domain.

Observe that the sitemap returns "Maximum call stack size exceeded"

**Before**
![image](https://github.com/user-attachments/assets/3ecca531-dee9-4893-bcdc-f4e8d1ef625c)

[After](https://gandhi.myvtex.com/sitemap.xml)

![image](https://github.com/user-attachments/assets/4a92eb7a-5020-4ab5-9193-48df750a0a40)



You can simply try to test the same behavior by removing the hkignore version of the sitemap in gandhi

### Relats to
KI: 1132723
FUP: inc-1654

