### PR TITLE
[SFS-2178] - Fetch Sitemap From Catalog if Single Tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Fetches sitemap.xml file from Catalog in Single Tenant Stores
+
 ## [2.16.6] - 2025-01-30
 
 ## [2.16.5] - 2025-01-23

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -39,4 +39,8 @@ export class Catalog extends ExternalClient {
       },
     })
   }
+
+  public getSitemap () {
+    return this.http.get('/sitemap.xml');
+  }
 }

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -20,6 +20,7 @@ declare global {
     rootPath: string
     matchingBindings: Binding[]
     bindingAddress?: string
+    isCrossBorder: boolean
     nextEvent:  {
       event: string,
       payload: Events

--- a/node/index.ts
+++ b/node/index.ts
@@ -22,7 +22,7 @@ import {
   generateSitemapFromREST,
 } from './middlewares/generateMiddlewares/generateSitemap'
 import { groupEntries } from './middlewares/generateMiddlewares/groupEntries'
-import { handleCrossBorder } from './middlewares/generateMiddlewares/handleCrossBorder'
+import { isCrossBorder } from './middlewares/generateMiddlewares/isCrossBorder'
 import { prepare as generationPrepare } from './middlewares/generateMiddlewares/prepare'
 import { sendNextEvent } from './middlewares/generateMiddlewares/sendNextEvent'
 import { methodNotAllowed } from './middlewares/methods'
@@ -86,7 +86,7 @@ const clients: ClientsConfig<Clients> = {
     },
   },
 }
-const sitemapPipeline = [settings, handleCrossBorder, prepare, sitemap]
+const sitemapPipeline = [settings, isCrossBorder, prepare, sitemap]
 const sitemapEntryPipeline = [prepare, sitemapEntry]
 
 export default new Service<Clients, State, ParamsContext>({
@@ -95,7 +95,7 @@ export default new Service<Clients, State, ParamsContext>({
     generateAppsRoutes: [throttle, errors, generationPrepare, generateAppsRoutes],
     generateProductRoutes: [throttle, errors, generationPrepare, tenant, generateProductRoutes, sendNextEvent],
     generateRewriterRoutes: [throttle, errors, generationPrepare, generateRewriterRoutes, sendNextEvent],
-    generateSitemap: [settings, handleCrossBorder, generationPrepare, generateSitemap],
+    generateSitemap: [settings, isCrossBorder, generationPrepare, generateSitemap],
     groupEntries: [throttle, errors, settings, generationPrepare, groupEntries, sendNextEvent],
   },
   graphql: {

--- a/node/index.ts
+++ b/node/index.ts
@@ -86,7 +86,7 @@ const clients: ClientsConfig<Clients> = {
     },
   },
 }
-const sitemapPipeline = [settings, prepare, sitemap]
+const sitemapPipeline = [settings, handleCrossBorder, prepare, sitemap]
 const sitemapEntryPipeline = [prepare, sitemapEntry]
 
 export default new Service<Clients, State, ParamsContext>({

--- a/node/index.ts
+++ b/node/index.ts
@@ -22,6 +22,7 @@ import {
   generateSitemapFromREST,
 } from './middlewares/generateMiddlewares/generateSitemap'
 import { groupEntries } from './middlewares/generateMiddlewares/groupEntries'
+import { handleCrossBorder } from './middlewares/generateMiddlewares/handleCrossBorder'
 import { prepare as generationPrepare } from './middlewares/generateMiddlewares/prepare'
 import { sendNextEvent } from './middlewares/generateMiddlewares/sendNextEvent'
 import { methodNotAllowed } from './middlewares/methods'
@@ -94,7 +95,7 @@ export default new Service<Clients, State, ParamsContext>({
     generateAppsRoutes: [throttle, errors, generationPrepare, generateAppsRoutes],
     generateProductRoutes: [throttle, errors, generationPrepare, tenant, generateProductRoutes, sendNextEvent],
     generateRewriterRoutes: [throttle, errors, generationPrepare, generateRewriterRoutes, sendNextEvent],
-    generateSitemap: [settings, generationPrepare, generateSitemap],
+    generateSitemap: [settings, handleCrossBorder, generationPrepare, generateSitemap],
     groupEntries: [throttle, errors, settings, generationPrepare, groupEntries, sendNextEvent],
   },
   graphql: {

--- a/node/middlewares/generateMiddlewares/handleCrossBorder.ts
+++ b/node/middlewares/generateMiddlewares/handleCrossBorder.ts
@@ -1,0 +1,11 @@
+export async function handleCrossBorder(ctx: EventContext) {
+  const {
+    clients: { tenant },
+    state,
+  } = ctx
+
+  const { bindings } = await tenant.info()
+  const storefrontsBindings = bindings.filter(({targetProduct}) => targetProduct !== 'vtex-admin')
+
+  state.isCrossBorder = storefrontsBindings?.length > 1
+}

--- a/node/middlewares/generateMiddlewares/handleCrossBorder.ts
+++ b/node/middlewares/generateMiddlewares/handleCrossBorder.ts
@@ -1,4 +1,4 @@
-export async function handleCrossBorder(ctx: EventContext) {
+export async function handleCrossBorder(ctx: Context | EventContext, next: () => Promise<void>) {
   const {
     clients: { tenant },
     state,
@@ -8,4 +8,6 @@ export async function handleCrossBorder(ctx: EventContext) {
   const storefrontsBindings = bindings.filter(({targetProduct}) => targetProduct !== 'vtex-admin')
 
   state.isCrossBorder = storefrontsBindings?.length > 1
+
+  await next();
 }

--- a/node/middlewares/generateMiddlewares/isCrossBorder.ts
+++ b/node/middlewares/generateMiddlewares/isCrossBorder.ts
@@ -1,13 +1,18 @@
-export async function isCrossBorder(ctx: Context | EventContext, next: () => Promise<void>) {
+export async function isCrossBorder(
+  ctx: Context | EventContext,
+  next: () => Promise<void>
+) {
   const {
     clients: { tenant },
     state,
   } = ctx
 
   const { bindings } = await tenant.info()
-  const storefrontsBindings = bindings.filter(({targetProduct}) => targetProduct !== 'vtex-admin')
+  const storefrontsBindings = bindings.filter(
+    ({ targetProduct }) => targetProduct !== 'vtex-admin'
+  )
 
   state.isCrossBorder = storefrontsBindings?.length > 1
 
-  await next();
+  await next()
 }

--- a/node/middlewares/generateMiddlewares/isCrossBorder.ts
+++ b/node/middlewares/generateMiddlewares/isCrossBorder.ts
@@ -1,3 +1,5 @@
+import { getStoreBindings } from '../../utils'
+
 export async function isCrossBorder(
   ctx: Context | EventContext,
   next: () => Promise<void>
@@ -7,11 +9,7 @@ export async function isCrossBorder(
     state,
   } = ctx
 
-  const { bindings } = await tenant.info()
-  const storefrontsBindings = bindings.filter(
-    ({ targetProduct }) => targetProduct !== 'vtex-admin'
-  )
-
+  const storefrontsBindings = await getStoreBindings(tenant)
   state.isCrossBorder = storefrontsBindings?.length > 1
 
   await next()

--- a/node/middlewares/generateMiddlewares/isCrossBorder.ts
+++ b/node/middlewares/generateMiddlewares/isCrossBorder.ts
@@ -1,4 +1,4 @@
-export async function handleCrossBorder(ctx: Context | EventContext, next: () => Promise<void>) {
+export async function isCrossBorder(ctx: Context | EventContext, next: () => Promise<void>) {
   const {
     clients: { tenant },
     state,

--- a/node/middlewares/sitemap.ts
+++ b/node/middlewares/sitemap.ts
@@ -129,6 +129,19 @@ const sitemapBindingIndex = async (ctx: Context) => {
 
 export async function sitemap(ctx: Context, next: () => Promise<void>) {
   const {
+    state: { isCrossBorder },
+  } = ctx
+
+  if(isCrossBorder) {
+    await legacySitemap(ctx);
+  } else {
+    await catalogSitemap(ctx);
+  }
+  next()
+}
+
+async function legacySitemap(ctx: Context) {
+  const {
     state: { matchingBindings, bindingAddress, rootPath, settings },
   } = ctx
 
@@ -158,5 +171,13 @@ export async function sitemap(ctx: Context, next: () => Promise<void>) {
   }
 
   ctx.body = $.xml()
-  next()
+}
+
+async function catalogSitemap(ctx: Context) {
+  const {
+    clients: { catalog },
+  } = ctx
+
+  const sitemap = await catalog.getSitemap()
+  ctx.body = sitemap
 }

--- a/node/middlewares/sitemap.ts
+++ b/node/middlewares/sitemap.ts
@@ -132,10 +132,10 @@ export async function sitemap(ctx: Context, next: () => Promise<void>) {
     state: { isCrossBorder },
   } = ctx
 
-  if(isCrossBorder) {
-    await legacySitemap(ctx);
+  if (isCrossBorder) {
+    await legacySitemap(ctx)
   } else {
-    await catalogSitemap(ctx);
+    await catalogSitemap(ctx)
   }
   next()
 }

--- a/node/package.json
+++ b/node/package.json
@@ -44,11 +44,13 @@
     "tslint-config-vtex": "^2.1.0",
     "typemoq": "^2.1.0",
     "typescript": "3.9.7",
-    "vtex.catalog-api-proxy": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.9.0/public/_types/react",
-    "vtex.catalog-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.80.1/public/@types/vtex.catalog-graphql",
-    "vtex.graphql-server": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.graphql-server@1.62.3/public/_types/react",
-    "vtex.messages": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.60.2/public/@types/vtex.messages",
-    "vtex.rewriter": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.47.0/public/@types/vtex.rewriter"
+    "vtex.catalog-api-proxy": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.10.4/public/_types/react",
+    "vtex.catalog-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.103.1/public/@types/vtex.catalog-graphql",
+    "vtex.graphql-server": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.graphql-server@1.69.0/public/_types/react",
+    "vtex.messages": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.69.0/public/@types/vtex.messages",
+    "vtex.rewriter": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.65.1/public/@types/vtex.rewriter",
+    "vtex.routes-bootstrap": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.routes-bootstrap@0.5.1/public/@types/vtex.routes-bootstrap",
+    "vtex.store-sitemap": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.16.6/public/@types/vtex.store-sitemap"
   },
   "resolutions": {
     "**/lodash": "^4.17.11"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4576,7 +4576,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -5114,25 +5114,33 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.catalog-api-proxy@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.9.0/public/_types/react":
+"vtex.catalog-api-proxy@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.10.4/public/_types/react":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.9.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.10.4/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.catalog-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.80.1/public/@types/vtex.catalog-graphql":
-  version "1.80.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.80.1/public/@types/vtex.catalog-graphql#a6f0bf42e5ca94fafe95ad239bc51af3acbe4369"
+"vtex.catalog-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.103.1/public/@types/vtex.catalog-graphql":
+  version "1.103.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.103.1/public/@types/vtex.catalog-graphql#c1b1caa413a7fc65b029814e67c944541daec337"
 
-"vtex.graphql-server@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.graphql-server@1.62.3/public/_types/react":
+"vtex.graphql-server@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.graphql-server@1.69.0/public/_types/react":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.graphql-server@1.62.3/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.graphql-server@1.69.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.messages@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.60.2/public/@types/vtex.messages":
-  version "1.60.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.60.2/public/@types/vtex.messages#e9b6005f11925e99ac3bb56d47d3ea6ad6d18280"
+"vtex.messages@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.69.0/public/@types/vtex.messages":
+  version "1.69.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.69.0/public/@types/vtex.messages#eb26abe34751bc87848cfb167a786c51abf20477"
 
-"vtex.rewriter@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.47.0/public/@types/vtex.rewriter":
-  version "1.47.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.47.0/public/@types/vtex.rewriter#946c41cdc4a9a0f3a9576c711580334f1290a4e9"
+"vtex.rewriter@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.65.1/public/@types/vtex.rewriter":
+  version "1.65.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.65.1/public/@types/vtex.rewriter#1175664e48318bf1fa03b1bb5fc1deacd5ed0809"
+
+"vtex.routes-bootstrap@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.routes-bootstrap@0.5.1/public/@types/vtex.routes-bootstrap":
+  version "0.5.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.routes-bootstrap@0.5.1/public/@types/vtex.routes-bootstrap#f5b86034711524674eb05b78cf0b0b5ba9fa90d6"
+
+"vtex.store-sitemap@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.16.6/public/@types/vtex.store-sitemap":
+  version "2.16.6"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.16.6/public/@types/vtex.store-sitemap#456b51fda313eb2d199ebd430517a260fcf26d08"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,17 @@
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "format": "prettier --write \"**/*.{ts,js,json}\""
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
   "lint-staged": {
     "*.{ts,js,tsx,jsx}": [
       "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,graphql,gql}": [
       "prettier --write"
     ],
     "*.json": [


### PR DESCRIPTION
# Purpose

This PR aims to provide an optimization to the Sitemap Generation of Single Tenant Stores by calling sitemap endpoint in the Catalog API.  
With this modification we can skip `store-sitemap` generation process in favor of a solution that is more optimized and with an always up to date sitemap

## Changes

* New middleware `isCrossBorder` was created to add a new boolean to the Context.state object. It was applied to:
  * `/sitemap.xml` route middleware pipeline
  * `generateSitemap` GraphQL query
* New route calling `/sitemap.xml` added to Catalog Client (so we can fetch Catalog sitemap)
* Modified `sitemap` middleware
  * Check if a store is single tenant and returns the catalog sitemap. Otherwise returns the "legacy" (store-sitemap)
  
## How to Test It

**Single Tenant Scenario:**

[Before](https://master--rihappynovo.myvtex.com/sitemap.xml)
[After](https://victormoura--rihappynovo.myvtex.com/sitemap.xml)

**Note:** Notable changes between versions:
*  The Catalog version has more pages for products and brands.
*  The Catalog version did not provide Subcategory and Departments sections

**Multiple Tenant Scenario**

No expected change in this scenario. Both versions should provide the "legacy" option for the Sitemap generation

[Before](https://master--storecomponents.myvtex.com/sitemap.xml)
[After](https://victormoura--storecomponents.myvtex.com/sitemap.xml)
  
## How does this PR make you feel?
![image](https://media1.tenor.com/m/WXUFUZ5g7uUAAAAC/speed.gif)
