### PR TITLE
STR-28 - Add saveIndex entries to custom-routes endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Custom routes now have support for routes added/removed via saveIndex or deleteIndex mutations
+
 ## [2.17.0] - 2025-07-17
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ To learn how to generate a sitemap, follow the instructions below.
 
 7. If this isn't the first time you're generating the store sitemap or if no changes have been made to the store routes since the last time you generated the store sitemap, go to step 8. Otherwise, run the following query:
 
-   ```gql
+   ```gql  
    {
      bootstrap {
        brands
@@ -56,6 +56,9 @@ To learn how to generate a sitemap, follow the instructions below.
 8. Now, from the GraphQL IDE dropdown list, select the `vtex.store-sitemap@2.x` app.
 
 9. Run the following query:
+
+  > ℹ️ If your store is **not** cross-border, the sitemap will be automatically updated daily.  
+  > In this case, running this GraphQL query is not necessary and will have no effect on the sitemap generation.
 
    ```gql
    {

--- a/node/clients/vbase.ts
+++ b/node/clients/vbase.ts
@@ -1,7 +1,4 @@
 import { ConflictsResolver, inflightURL, InstanceOptions, IOContext, IOResponse, RequestTracingConfig, VBase } from '@vtex/api'
-import {
-  IgnoreNotFoundRequestConfig,
-} from '@vtex/api/lib/HttpClient/middlewares/notFound'
 import { AxiosError } from 'axios'
 
 interface Headers { [key: string]: string | number }
@@ -30,7 +27,7 @@ export class CVBase extends VBase {
         requestSpanNameSuffix: metric,
         ...tracingConfig?.tracing,
       },
-    } as IgnoreNotFoundRequestConfig)
+    })
       .catch(async (error: AxiosError<T>) => {
         const { response } = error
         if (response && response.status === 409 && conflictsResolver) {

--- a/node/services/routes.ts
+++ b/node/services/routes.ts
@@ -44,7 +44,7 @@ async function fetchExtendedRoutes(ctx: Context) {
   )
 
   const extendedEntries = extendedIndex?.index.map(entry =>
-    entry.startsWith('/') ? `${entry}.xml` : `/${entry}.xml`
+    entry.startsWith('/') ? `/sitemap${entry}.xml` : `/sitemap/${entry}.xml`
   )
 
   return extendedEntries || []

--- a/node/services/routes.ts
+++ b/node/services/routes.ts
@@ -44,7 +44,7 @@ async function fetchExtendedRoutes(ctx: Context) {
   )
 
   const extendedEntries = extendedIndex?.index.map(entry =>
-    entry.startsWith('/') ? `/sitemap${entry}.xml` : `/sitemap/${entry}.xml`
+    `/sitemap${entry.replace(/^\//, '')}.xml`
   )
 
   return extendedEntries || []

--- a/node/services/routes.ts
+++ b/node/services/routes.ts
@@ -44,7 +44,7 @@ async function fetchExtendedRoutes(ctx: Context) {
   )
 
   const extendedEntries = extendedIndex?.index.map(entry =>
-    entry.startsWith('/') ? entry : `/${entry}`
+    entry.startsWith('/') ? `${entry}.xml` : `/${entry}.xml`
   )
 
   return extendedEntries || []

--- a/node/services/routes.ts
+++ b/node/services/routes.ts
@@ -60,8 +60,6 @@ export async function getUserRoutes(ctx: Context) {
     fetchExtendedRoutes(ctx),
   ])
 
-  console.log('extendedRoutes:', extendedRoutes)
-
   const validInternalRoutes = internalRoutes
     .filter(isValidRoute)
     .map(route => route.from)


### PR DESCRIPTION
### What is the purpose of this pull request and the problem it is solving?

The recently introduced `custom-routes` is an endpoint that exposes user-routes and apps-routes to clients, and is used to help generate the sitemap.

This PR aims to integrate the behavior of the `saveIndex` mutation with the `custom-routes` endpoint, allowing routes created by this mutation also be exposed in the `custom-user-routes.xml` file

### How should this be tested? (manually or automated)

* [Workspace with](https://www.climario.com.br/sitemap.xml?v=2)  the modification (this URL uses v=2 query string to bypass cache)
  * Access the URL and format the JSON output
  * The response should include a `/blog-posts` at the end of the `routes` array

* [Workspace without](https://www.climario.com.br/sitemap.xml) modification
  * Access the URL and format the JSON output
  * The response should **not ** include a `/blog-posts` at the end of the `routes` array