### PR TITLE
Fix Extended Route Sitemap Entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix missing `/` for extended routes in custom-routes
+
 ## [2.18.0] - 2025-07-25
 
 ### Changed

--- a/node/services/routes.ts
+++ b/node/services/routes.ts
@@ -43,8 +43,8 @@ async function fetchExtendedRoutes(ctx: Context) {
     true
   )
 
-  const extendedEntries = extendedIndex?.index.map(entry =>
-    `/sitemap${entry.replace(/^\//, '')}.xml`
+  const extendedEntries = extendedIndex?.index.map(
+    entry => `/sitemap/${entry.replace(/^\//, '')}.xml`
   )
 
   return extendedEntries || []


### PR DESCRIPTION
Missing `/` in sitemap custom-routes

[Workspace with error
](https://climario.myvtex.com/_v/public/sitemap/custom-routes)
[Workspace with fix
](https://sitemap3--climario.myvtex.com/_v/public/sitemap/custom-routes)
Currently the endpoint is responding:

```json
[
    {
        "name": "apps-routes",
        "routes": []
    },
    {
        "name": "user-routes",
        "routes": [
            "/sitemapblog-posts.xml"
        ]
    }
]
```

But should be:
```json
[
    {
        "name": "apps-routes",
        "routes": []
    },
    {
        "name": "user-routes",
        "routes": [
            "/sitemap/blog-posts.xml"
        ]
    }
]
```