### PR TITLE
[STR-883] Respect enableAppsRoutes flag in custom routes endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Custom routes endpoint now respects `enableAppsRoutes` setting, filtering apps-routes when disabled
+
 ## [2.18.3] - 2025-10-14
 
 ## [2.18.1] - 2025-07-25

--- a/node/index.ts
+++ b/node/index.ts
@@ -187,7 +187,7 @@ export default new Service<Clients, State, ParamsContext>({
     sitemap: sitemapPipeline,
     sitemapEntry: sitemapEntryPipeline,
     customRoutes: method({
-      GET: [cache, binding, customRoutes],
+      GET: [settings, cache, binding, customRoutes],
     }),
   },
 })

--- a/node/middlewares/customRoutes.test.ts
+++ b/node/middlewares/customRoutes.test.ts
@@ -1,0 +1,155 @@
+import {
+  IOContext,
+  IOResponse,
+  Logger,
+  VBase,
+  VBaseSaveResponse,
+} from '@vtex/api'
+import * as TypeMoq from 'typemoq'
+
+import { Clients } from '../clients'
+import { CUSTOM_ROUTES_BUCKET, CUSTOM_ROUTES_FILENAME } from '../utils'
+import { customRoutes } from './customRoutes'
+
+const vbaseTypeMock = TypeMoq.Mock.ofInstance(VBase)
+const contextMock = TypeMoq.Mock.ofType<Context>()
+const ioContext = TypeMoq.Mock.ofType<IOContext>()
+const state = TypeMoq.Mock.ofType<State>()
+const loggerMock = TypeMoq.Mock.ofType<Logger>()
+
+describe('Test customRoutes middleware', () => {
+  let context: Context
+  let cachedData: CustomRoutesData | null
+
+  const vbase = class VBaseMock extends vbaseTypeMock.object {
+    constructor() {
+      super(ioContext.object)
+    }
+
+    public getJSON = async <T>(
+      bucket: string,
+      file: string,
+      _?: boolean | undefined
+    ): Promise<T> => {
+      if (bucket === CUSTOM_ROUTES_BUCKET && file === CUSTOM_ROUTES_FILENAME) {
+        return (cachedData as unknown) as T
+      }
+      return (null as unknown) as T
+    }
+
+    public saveJSON = async <T>(
+      _bucket: string,
+      _file: string,
+      _data: T
+    ): Promise<VBaseSaveResponse> => {
+      return {} as VBaseSaveResponse
+    }
+
+    public deleteFile = async (
+      _bucket: string,
+      _file: string
+    ): Promise<IOResponse<void>> => {
+      return {} as IOResponse<void>
+    }
+  }
+
+  const next = jest.fn()
+
+  beforeEach(() => {
+    // Reset mocks
+    next.mockClear()
+    loggerMock.reset()
+
+    // tslint:disable-next-line: max-classes-per-file
+    const ClientsImpl = class ClientsMock extends Clients {
+      public get vbase() {
+        return this.getOrSet('vbase', vbase)
+      }
+    }
+
+    cachedData = null
+
+    context = {
+      ...contextMock.object,
+      clients: new ClientsImpl({}, ioContext.object),
+      state: {
+        ...state.object,
+        settings: {
+          disableRoutesTerm: '',
+          enableAppsRoutes: true,
+          enableNavigationRoutes: true,
+          enableProductRoutes: true,
+          ignoreBindings: false,
+        },
+      },
+      vtex: {
+        ...ioContext.object,
+        logger: loggerMock.object,
+      },
+    }
+  })
+
+  it('should return 403 when enableAppsRoutes is disabled', async () => {
+    context.state.settings.enableAppsRoutes = false
+
+    await customRoutes(context, next)
+
+    expect(context.status).toBe(403)
+    expect(context.body).toEqual({
+      message: 'Custom routes are disabled',
+    })
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should return cached data when enableAppsRoutes is enabled and data exists', async () => {
+    const mockData = {
+      data: [
+        { name: 'app1', routes: ['/custom-1', '/custom-2'] },
+        { name: 'app2', routes: ['/custom-3'] },
+      ],
+      timestamp: Date.now() - 1000 * 60 * 60, // 1 hour ago
+    }
+    cachedData = mockData
+
+    await customRoutes(context, next)
+
+    expect(context.status).toBe(200)
+    expect(context.body).toEqual(mockData.data)
+    expect(context.state.useLongCacheControl).toBe(true)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should return 404 when enableAppsRoutes is enabled but no cached data exists', async () => {
+    cachedData = null
+
+    await customRoutes(context, next)
+
+    expect(context.status).toBe(404)
+    expect(context.body).toHaveProperty('message')
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should serve stale data and trigger background regeneration when data is old', async () => {
+    const ONE_DAY_MS = 24 * 60 * 60 * 1000
+    const mockData = {
+      data: [{ name: 'app1', routes: ['/custom-1'] }],
+      timestamp: Date.now() - ONE_DAY_MS - 1000, // Slightly over 1 day old
+    }
+    cachedData = mockData
+
+    await customRoutes(context, next)
+
+    expect(context.status).toBe(200)
+    expect(context.body).toEqual(mockData.data)
+    expect(context.state.useLongCacheControl).toBe(true)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should log when custom routes are disabled', async () => {
+    context.state.settings.enableAppsRoutes = false
+
+    await customRoutes(context, next)
+
+    expect(loggerMock.object.info).toBeDefined()
+  })
+})

--- a/node/middlewares/customRoutes.test.ts
+++ b/node/middlewares/customRoutes.test.ts
@@ -153,12 +153,4 @@ describe('Test customRoutes middleware', () => {
     expect(context.state.useLongCacheControl).toBe(true)
     expect(next).toHaveBeenCalled()
   })
-
-  it('should log when custom routes are disabled', async () => {
-    context.state.settings.enableAppsRoutes = false
-
-    await customRoutes(context, next)
-
-    expect(loggerMock.object.info).toBeDefined()
-  })
 })

--- a/node/middlewares/customRoutes.test.ts
+++ b/node/middlewares/customRoutes.test.ts
@@ -89,23 +89,32 @@ describe('Test customRoutes middleware', () => {
     }
   })
 
-  it('should return 403 when enableAppsRoutes is disabled', async () => {
+  it('should filter out apps-routes when enableAppsRoutes is disabled', async () => {
+    const mockData = {
+      data: [
+        { name: 'apps-routes', routes: ['/app-1', '/app-2'] },
+        { name: 'user-routes', routes: ['/user-1', '/user-2'] },
+      ],
+      timestamp: Date.now() - 1000 * 60 * 60, // 1 hour ago
+    }
+    cachedData = mockData
     context.state.settings.enableAppsRoutes = false
 
     await customRoutes(context, next)
 
-    expect(context.status).toBe(403)
-    expect(context.body).toEqual({
-      message: 'Custom routes are disabled',
-    })
+    expect(context.status).toBe(200)
+    expect(context.body).toEqual([
+      { name: 'user-routes', routes: ['/user-1', '/user-2'] },
+    ])
+    expect(context.state.useLongCacheControl).toBe(true)
     expect(next).toHaveBeenCalled()
   })
 
-  it('should return cached data when enableAppsRoutes is enabled and data exists', async () => {
+  it('should return all routes when enableAppsRoutes is enabled', async () => {
     const mockData = {
       data: [
-        { name: 'app1', routes: ['/custom-1', '/custom-2'] },
-        { name: 'app2', routes: ['/custom-3'] },
+        { name: 'apps-routes', routes: ['/app-1', '/app-2'] },
+        { name: 'user-routes', routes: ['/user-1', '/user-2'] },
       ],
       timestamp: Date.now() - 1000 * 60 * 60, // 1 hour ago
     }

--- a/node/middlewares/customRoutes.ts
+++ b/node/middlewares/customRoutes.ts
@@ -186,7 +186,22 @@ export async function customRoutes(ctx: Context, next: () => Promise<void>) {
   const {
     vtex: { logger },
     clients: { vbase },
+    state: { settings },
   } = ctx
+
+  // Check if custom routes are enabled
+  if (!settings.enableAppsRoutes) {
+    logger.info({
+      message: 'Custom routes are disabled',
+      type: 'custom-routes-disabled',
+    })
+    ctx.status = 403
+    ctx.body = {
+      message: 'Custom routes are disabled',
+    }
+    await next()
+    return
+  }
 
   try {
     // Get pre-compiled custom routes from VBase

--- a/node/middlewares/customRoutes.ts
+++ b/node/middlewares/customRoutes.ts
@@ -189,20 +189,6 @@ export async function customRoutes(ctx: Context, next: () => Promise<void>) {
     state: { settings },
   } = ctx
 
-  // Check if custom routes are enabled
-  if (!settings.enableAppsRoutes) {
-    logger.info({
-      message: 'Custom routes are disabled',
-      type: 'custom-routes-disabled',
-    })
-    ctx.status = 403
-    ctx.body = {
-      message: 'Custom routes are disabled',
-    }
-    await next()
-    return
-  }
-
   try {
     // Get pre-compiled custom routes from VBase
     const cachedData = await vbase.getJSON<CustomRoutesData>(
@@ -271,9 +257,14 @@ export async function customRoutes(ctx: Context, next: () => Promise<void>) {
       triggerCustomRoutesGeneration(ctx)
     }
 
+    // Filter data based on enableAppsRoutes setting
+    const filteredData = settings.enableAppsRoutes
+      ? cachedData.data
+      : cachedData.data.filter(item => item.name !== 'apps-routes')
+
     // Return cached data
     ctx.status = 200
-    ctx.body = cachedData.data
+    ctx.body = filteredData
     ctx.state.useLongCacheControl = true
 
     const diffTime = process.hrtime(startTime)


### PR DESCRIPTION
#### What problem is this solving?

The custom routes endpoint (`/_v/public/sitemap/custom-routes`) was ignoring the `enableAppsRoutes` setting and always returning both apps-routes and user-routes, even when apps routes were explicitly disabled in the app settings. This created inconsistency with the sitemap generation behavior, which already respects this flag.

#### How to test it?

Tested on `zaffari` account, `vuvas` workspace.

1. Link the app in a workspace
2. **With `enableAppsRoutes` enabled (default):**
   ```bash
   curl -v "https://{workspace}--{account}.myvtex.com/_v/public/sitemap/custom-routes"
   ```
   Expected: 200 + JSON with both `apps-routes` and `user-routes`
   ```json
   [
     { "name": "apps-routes", "routes": [...] },
     { "name": "user-routes", "routes": [...] }
   ]
   ```

3. **Disable the flag in Admin:**
   - Go to `https://{workspace}--{account}.myvtex.com/admin/apps/vtex.store-sitemap@2.x/setup`
   - Uncheck "Enable Apps Routes"
   - Save settings

4. **Test again:**
   ```bash
   curl -v "https://{workspace}--{account}.myvtex.com/_v/public/sitemap/custom-routes"
   ```
   Expected: 200 + JSON with only `user-routes`
   ```json
   [
     { "name": "user-routes", "routes": [...] }
   ]
   ```

---

**Changes made:**
- Added `settings` middleware to the custom routes endpoint pipeline
- Filter `apps-routes` from response when `enableAppsRoutes` is disabled
- `user-routes` are always returned regardless of the flag
- Added comprehensive unit tests covering all scenarios