### PR TITLE
chore: STR-969 catalog platform-flow-id (Shopper#1, Merch#8)

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -13,7 +13,7 @@ metadata:
     vtex.com/o11y-os-index: ""
     grafana/dashboard-selector: ""
     github.com/project-slug: vtex-apps/store-sitemap
-    vtex.com/platform-flow-id: ""
+    vtex.com/platform-flow-id: Shopper#1,Merch#8
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: XBR61V1L
 spec:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update DK Catalog platform-flow-id
+
 ## [2.18.6] - 2026-03-18
 
 ## [2.18.5] - 2026-03-18


### PR DESCRIPTION
## Jira

https://vtex-dev.atlassian.net/browse/STR-969

## Summary

Updates Backstage catalog metadata by setting `vtex.com/platform-flow-id` in `.vtex/catalog-info.yaml` to match the **Platform Flows (Dark Kitchen)** classification for this component (initiative STR-969).

## Change

| Annotation | Value |
|------------|-------|
| `vtex.com/platform-flow-id` | `Shopper#1,Merch#8` |

**Convention:** multiple DK IDs are **comma-separated with no spaces**.

## Classification context (source artifact)

The following summary is taken from the internal classification table (Portuguese) used for STR-969:

> **Serviço:** app IO que gera/atualiza `sitemap.xml` e rotas para SEO. **Decisão:** README/docs: sitemap e arquitetura de rotas customizadas; skill: lê `rewriter`, traduz via `messages`, consulta `graphql-server`, VBase → descoberta (**Shopper#1**) + conteúdo de loja endereçável (**Merch#8**).

## Changelog

- `CHANGELOG.md` — **[Unreleased]** → **Changed**: Update DK Catalog platform-flow-id


---

Reviewers: @vmourac-vtex @iago1501
