### PR TITLE
feat: cms-routes-in-sitemap-for-faststore

### DIFF
--- a/docs/CMS_ROUTES.md
+++ b/docs/CMS_ROUTES.md
@@ -1,0 +1,301 @@
+# CMS routes in sitemap (FastStore)
+
+> **Availability**: `vtex.store-sitemap@2.19.x` and later, with `enableCmsRoutes: true`.
+> **Jira**: [SFS-3123](https://vtex-dev.atlassian.net/browse/SFS-3123)
+
+FastStore stores can now include pages created in VTEX headless CMS (hCMS) — PDPs, PLPs, landing pages, and any custom-slug page — directly in the generated sitemap, without manual workarounds like `next-sitemap` or hand-edited `sitemap.xml` files.
+
+This document covers:
+
+- [How it works](#how-it-works)
+- [Enabling CMS routes](#enabling-cms-routes)
+- [Verifying the sitemap](#verifying-the-sitemap)
+- [Excluding a page from the sitemap](#excluding-a-page-from-the-sitemap)
+- [Multi-locale stores](#multi-locale-stores)
+- [Fetching CMS routes as JSON](#fetching-cms-routes-as-json)
+- [robots.txt integration](#robotstxt-integration)
+- [Known limitations](#known-limitations)
+
+---
+
+## How it works
+
+When `enableCmsRoutes` is `true`, the Sitemap app:
+
+1. **Sources CMS pages from Rewriter.** Pages published via hCMS are stored as Rewriter `Internal` entries. The app reads those entries and filters for CMS-origin routes, excluding framework-generated catalog pages (products, departments, categories, subcategories, brands) that are already covered by the existing product/navigation pipelines.
+
+2. **Applies mandatory exclusions.** The following pages are never included, regardless of other settings:
+   - Login pages
+   - Error pages
+   - Pages with `disableSitemapEntry: true` in Rewriter (the CMS "exclude from sitemap" toggle)
+   - Pages matching the existing `disableRoutesTerm` setting
+
+3. **Writes per-binding sub-sitemaps.** Each binding gets its own set of `cms-routes-N.xml` files under the `<sitemapindex>`, chunked at Google's protocol ceilings: **50,000 URLs** or **50 MB** per file — whichever is hit first.
+
+4. **Emits protocol-compliant URL entries.** Every CMS URL includes `<loc>`, `<lastmod>`, `<changefreq>` (`weekly`), and `<priority>` (`0.5`). For multi-locale stores, each URL also declares `<xhtml:link>` alternate tags for every locale plus `hreflang="x-default"`.
+
+5. **Injects a `Sitemap:` directive in `robots.txt`** if one is not already present.
+
+6. **Exposes CMS routes via the JSON endpoint** (`/_v/public/sitemap/custom-routes`) so FastStore can consume them at build time or runtime.
+
+The feature is **fully gated** by the `enableCmsRoutes` setting (default `false`). When the flag is off, the app behaves exactly as before — no extra VBase reads, no extra XML entries, no extra response keys.
+
+---
+
+## Enabling CMS routes
+
+### Via Admin UI
+
+1. In your browser, go to **Account settings > Apps > My apps** and search for the **Sitemap** app.
+2. Enable the **Enable CMS routes source (FastStore)** toggle.
+3. Save.
+
+### Via CLI
+
+```bash
+vtex use {workspaceName} --production
+```
+
+Then patch the app settings via the VTEX Admin API:
+
+```bash
+curl -X PATCH \
+  "https://{workspace}--{account}.myvtex.com/_v/private/apps/vtex.store-sitemap@2.x/settings" \
+  -H "VtexIdclientAutCookie: {token}" \
+  -H "Content-Type: application/json" \
+  -d '{"enableCmsRoutes": true}'
+```
+
+> ⚠️ Replace the values in curly brackets with the values that apply to your scenario.
+
+---
+
+## Verifying the sitemap
+
+After enabling the feature, the first request to any sitemap endpoint triggers background generation. The following steps verify that CMS routes are correctly included.
+
+### Step 1 — Trigger generation
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/_v/public/sitemap/custom-routes"
+```
+
+**Expected response on first call (generation triggered):**
+
+```json
+{ "message": "Custom routes not available. Generation has been triggered." }
+```
+
+**Status code:** `404`
+
+Generation runs in the background. The time depends on the number of pages. For most stores this completes in under a minute.
+
+### Step 2 — Confirm the CMS section is present
+
+Poll the same endpoint after a minute:
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/_v/public/sitemap/custom-routes"
+```
+
+**Expected response:**
+
+```json
+[
+  { "name": "apps-routes",  "routes": ["/store-locator/ny", "/store-locator/ca"] },
+  { "name": "user-routes",  "routes": ["/about-us", "/contact", "/faq"] },
+  { "name": "cms-routes",   "routes": ["/our-story", "/black-friday", "/landing/holiday"] }
+]
+```
+
+The `cms-routes` section contains all CMS pages that passed the filters.
+
+### Step 3 — Check the sitemap index
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/sitemap.xml"
+```
+
+The `<sitemapindex>` should now reference one or more `cms-routes-N.xml` files:
+
+```xml
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  ...
+  <sitemap>
+    <loc>https://{account}.myvtex.com/sitemap/cms-routes-0.xml</loc>
+    <lastmod>2026-05-27T...</lastmod>
+  </sitemap>
+</sitemapindex>
+```
+
+### Step 4 — Inspect a CMS sub-sitemap
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/sitemap/cms-routes-0.xml"
+```
+
+Each URL entry includes the full protocol tag set:
+
+```xml
+<url>
+  <loc>https://{account}.myvtex.com/our-story</loc>
+  <lastmod>2026-05-27T13:00:00.000Z</lastmod>
+  <changefreq>weekly</changefreq>
+  <priority>0.5</priority>
+</url>
+```
+
+For multi-locale stores, the `<url>` also contains `<xhtml:link>` alternates — see [Multi-locale stores](#multi-locale-stores).
+
+### Step 5 — Verify robots.txt
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/robots.txt" | grep -i Sitemap
+```
+
+**Expected output:**
+
+```
+Sitemap: https://{account}.myvtex.com/sitemap.xml
+```
+
+If your `robots.txt` already contained a `Sitemap:` directive, no duplicate is added.
+
+---
+
+## Excluding a page from the sitemap
+
+### Option 1 — Per-page toggle (recommended)
+
+The CMS "Include in sitemap" toggle maps to the `disableSitemapEntry` field in Rewriter. When the toggle is **off**, the page is excluded from both the XML sitemap and the `cms-routes` JSON section.
+
+> ℹ️ The Admin UI for this toggle is currently being built by the hCMS team and will be released separately. In the meantime, use Option 2 below.
+
+### Option 2 — Rewriter mutation
+
+Set `disableSitemapEntry: true` directly via the Rewriter GraphQL API. Access the GraphQL Admin IDE at **Store Settings > Storefront > GraphiQL IDE**, select the `vtex.rewriter@1.x` app, and run:
+
+```graphql
+mutation {
+  internal {
+    save(route: {
+      id: "your-page-id"
+      from: "/your-page-slug"
+      type: "userRoute"
+      binding: "your-binding-id"
+      disableSitemapEntry: true
+    }) {
+      id
+      from
+      disableSitemapEntry
+    }
+  }
+}
+```
+
+To re-include the page, set `disableSitemapEntry: false` or omit the field.
+
+### Option 3 — `disableRoutesTerm` setting
+
+The existing `disableRoutesTerm` setting (a substring filter applied to all user-defined routes) also applies to CMS routes. Any page whose path contains the configured string is excluded.
+
+Configure it via **Account settings > Apps > My apps > Sitemap > Disable routes from userRoutes with the following string**.
+
+---
+
+## Multi-locale stores
+
+For stores with multiple bindings (multi-language / multi-currency), each CMS URL entry in the sitemap declares all locale alternates, including the URL itself and a `hreflang="x-default"` pointing at the default binding's version.
+
+**Example — page `/about` in a store with `en-US` (default), `pt-BR`, and `de-DE`:**
+
+```xml
+<url>
+  <loc>https://store.example.com/about</loc>
+  <xhtml:link rel="alternate" hreflang="en-US"   href="https://store.example.com/about"/>
+  <xhtml:link rel="alternate" hreflang="pt-BR"   href="https://store.example.com/br/sobre"/>
+  <xhtml:link rel="alternate" hreflang="de-DE"   href="https://store.example.com/de/ueber-uns"/>
+  <xhtml:link rel="alternate" hreflang="x-default" href="https://store.example.com/about"/>
+  <lastmod>2026-05-27T...</lastmod>
+  <changefreq>weekly</changefreq>
+  <priority>0.5</priority>
+</url>
+```
+
+This follows [Google's recommendation for localized versions](https://developers.google.com/search/docs/specialty/international/localized-versions#example_2).
+
+Single-binding stores do not emit `<xhtml:link>` tags — the behavior is unchanged from previous versions.
+
+---
+
+## Fetching CMS routes as JSON
+
+The `/_v/public/sitemap/custom-routes` endpoint is useful for FastStore projects that build or serve their own sitemap (e.g., with `next-sitemap`) and need to pull CMS routes without parsing XML.
+
+| Method | Endpoint |
+|--------|----------|
+| `GET`  | `/_v/public/sitemap/custom-routes` |
+
+The `cms-routes` section is **only present** when `enableCmsRoutes` is `true`. When the flag is off, the response contains only `apps-routes` and `user-routes` (backwards-compatible behavior).
+
+**Example response with `enableCmsRoutes: true`:**
+
+```json
+[
+  { "name": "apps-routes",  "routes": ["/store-locator/ny"] },
+  { "name": "user-routes",  "routes": ["/about-us", "/contact"] },
+  { "name": "cms-routes",   "routes": ["/our-story", "/black-friday"] }
+]
+```
+
+**Caching:** The response is cached for up to 1 day. Stale data triggers a background refresh and is still served while the new generation runs (stale-while-revalidate). See [`docs/CUSTOM_ROUTES_ARCHITECTURE.md`](./CUSTOM_ROUTES_ARCHITECTURE.md) for architecture details.
+
+### Migrating from `next-sitemap` + custom rewrites
+
+If your FastStore project currently uses `next-sitemap` with additional rewrites to include CMS pages, the migration path is:
+
+1. Enable `enableCmsRoutes` in `vtex.store-sitemap`.
+2. Verify CMS routes appear in `/_v/public/sitemap/custom-routes` and `/sitemap/cms-routes-0.xml`.
+3. Point your storefront's sitemap generation to consume `/_v/public/sitemap/custom-routes` instead of the manually curated list.
+4. Remove the custom rewrites and `next-sitemap` CMS overrides from your store repository.
+5. Confirm `robots.txt` references `/sitemap.xml` (the app injects this automatically).
+
+---
+
+## robots.txt integration
+
+The `robots` middleware automatically appends a `Sitemap:` directive pointing to `/sitemap.xml` whenever the served `robots.txt` does not already contain one.
+
+The check is **case-insensitive** and tolerates leading whitespace, so a manually added line like `  sitemap: https://...` is correctly detected and not duplicated.
+
+**Behavior summary:**
+
+| Scenario | Result |
+|---|---|
+| `robots.txt` has no `Sitemap:` line | Directive is appended |
+| `robots.txt` already has `Sitemap: https://store.example.com/sitemap.xml` | No change |
+| `robots.txt` has `sitemap:` (lowercase) | No change (case-insensitive) |
+| `enableCmsRoutes` is `false` | Directive is still appended (the `robots.txt` logic is independent of this setting) |
+
+---
+
+## Known limitations
+
+The following features are **not yet available** and are planned as follow-up work:
+
+| Limitation | Status |
+|---|---|
+| **`noindex` auto-exclusion** — pages marked as `noindex` in hCMS are not yet automatically filtered. Exclude them manually via `disableSitemapEntry` for now. | Waiting on hCMS metadata endpoint (cross-team dependency, Decision 3 of the spec). |
+| **Canonical-mismatch auto-exclusion** — pages whose canonical points to a different URL are not yet automatically filtered. | Same dependency as above. |
+| **Admin UI toggle in hCMS** — the per-page "Include in sitemap" toggle is not yet surfaced in the CMS Admin UI. Use the Rewriter mutation (Option 2 above) as a workaround. | Being built by the hCMS team. |
+| **URL-level deduplication between `cms-routes` and `user-routes`** — if `enableNavigationRoutes` and `enableCmsRoutes` are both on, a CMS page whose Rewriter type is `userRoute` may appear in both sub-sitemaps. Search engines tolerate this; a deduplication step is planned. | Planned follow-up. |
+
+---
+
+## Reference
+
+- [Spec: cms-routes-in-sitemap-for-faststore](../specs/cms-routes-in-sitemap-for-faststore.md)
+- [Architecture: custom routes](./CUSTOM_ROUTES_ARCHITECTURE.md)
+- [Google Sitemap protocol](https://www.sitemaps.org/protocol.html)
+- [Google: localized versions with hreflang](https://developers.google.com/search/docs/specialty/international/localized-versions)
+- [Known Issue: Native sitemap is not fully integrated with FastStore](https://help.vtex.com/known-issues/native-sitemap-is-not-fully-integrated-with-faststore--5IrsqCEtQKPFstqywlV7Nn)

--- a/docs/README.md
+++ b/docs/README.md
@@ -184,6 +184,12 @@ If you want to remove a custom route, execute the following mutation, which take
    }
    ```
 
+### CMS routes (FastStore)
+
+If your store runs on FastStore, you can include pages created in VTEX headless CMS — PDPs, PLPs, landing pages, and custom-slug pages — directly in the generated sitemap by enabling the `enableCmsRoutes` setting.
+
+For a complete setup guide, see [CMS routes in sitemap (FastStore)](./CMS_ROUTES.md).
+
 ### Fetching custom routes in JSON format
 
 The `vtex.store-sitemap` app exposes an API endpoint that allows you to retrieve route data in JSON format. This endpoint is useful for external sitemap generation or custom indexing workflows.

--- a/manifest.json
+++ b/manifest.json
@@ -139,6 +139,12 @@
         "type": "boolean",
         "default": true
       },
+      "enableCmsRoutes": {
+        "title": "Enable CMS routes source (FastStore)",
+        "description": "When enabled, pages published in VTEX hCMS — including PDPs, PLPs, landing pages and any other custom-slug page — are included in the generated sitemap. Each URL declares its locale alternates (hreflang + x-default) when the store is multi-binding. Defaults to false during rollout.",
+        "type": "boolean",
+        "default": false
+      },
       "disableRoutesTerm": {
         "title": "Disable routes from userRoutes with the following string",
         "description": "Routes that include the string below will be excluded from the sitemap. Useful for selecting which pages will be in that folder.",

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -40,12 +40,27 @@ declare global {
     pageType: string
   }
 
+  type ChangeFreq =
+    | 'always'
+    | 'hourly'
+    | 'daily'
+    | 'weekly'
+    | 'monthly'
+    | 'yearly'
+    | 'never'
+
   interface Route {
     id: string
     path: string,
     alternates?: AlternateRoute[]
     imagePath?: string
     imageTitle?: string
+    // Optional sitemap protocol tags (sitemaps.org/protocol). When present they
+    // are emitted by URLEntry; absent → tag is omitted, preserving backwards
+    // compatibility with sources that do not annotate routes.
+    changefreq?: ChangeFreq
+    priority?: number
+    lastmod?: string
   }
 
   interface AlternateRoute {

--- a/node/index.ts
+++ b/node/index.ts
@@ -16,6 +16,7 @@ import { binding } from './middlewares/binding'
 import { cache } from './middlewares/cache'
 import { errors } from './middlewares/errors'
 import { generateAppsRoutes } from './middlewares/generateMiddlewares/generateAppsRoutes'
+import { generateCmsRoutes } from './middlewares/generateMiddlewares/generateCmsRoutes'
 import { generateProductRoutes } from './middlewares/generateMiddlewares/generateProductRoutes'
 import { generateRewriterRoutes } from './middlewares/generateMiddlewares/generateRewriterRoutes'
 import {
@@ -122,6 +123,18 @@ export default new Service<Clients, State, ParamsContext>({
       isCrossBorder,
       generationPrepare,
       generateAppsRoutes,
+    ],
+    /**
+     * @deprecated This event is being deprecated. Sitemap generation in this major version will not be triggered by events.
+     * Use the REST API endpoints instead.
+     */
+    generateCmsRoutes: [
+      throttle,
+      errors,
+      settings,
+      isCrossBorder,
+      generationPrepare,
+      generateCmsRoutes,
     ],
     /**
      * @deprecated This event is being deprecated. Sitemap generation in this major version will not be triggered by events.

--- a/node/middlewares/customRoutes.test.ts
+++ b/node/middlewares/customRoutes.test.ts
@@ -77,6 +77,7 @@ describe('Test customRoutes middleware', () => {
         settings: {
           disableRoutesTerm: '',
           enableAppsRoutes: true,
+          enableCmsRoutes: false,
           enableNavigationRoutes: true,
           enableProductRoutes: true,
           ignoreBindings: false,
@@ -151,6 +152,47 @@ describe('Test customRoutes middleware', () => {
     expect(context.status).toBe(200)
     expect(context.body).toEqual(mockData.data)
     expect(context.state.useLongCacheControl).toBe(true)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should expose cms-routes when enableCmsRoutes is true', async () => {
+    const mockData = {
+      data: [
+        { name: 'apps-routes', routes: ['/app-1'] },
+        { name: 'user-routes', routes: ['/user-1'] },
+        { name: 'cms-routes', routes: ['/our-story', '/black-friday'] },
+      ],
+      timestamp: Date.now() - 1000 * 60 * 60,
+    }
+    cachedData = mockData
+    context.state.settings.enableCmsRoutes = true
+
+    await customRoutes(context, next)
+
+    expect(context.status).toBe(200)
+    expect(context.body).toEqual(mockData.data)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should omit cms-routes when enableCmsRoutes is false (rollout-gated)', async () => {
+    const mockData = {
+      data: [
+        { name: 'apps-routes', routes: ['/app-1'] },
+        { name: 'user-routes', routes: ['/user-1'] },
+        { name: 'cms-routes', routes: ['/our-story'] },
+      ],
+      timestamp: Date.now() - 1000 * 60 * 60,
+    }
+    cachedData = mockData
+    context.state.settings.enableCmsRoutes = false
+
+    await customRoutes(context, next)
+
+    expect(context.status).toBe(200)
+    expect(context.body).toEqual([
+      { name: 'apps-routes', routes: ['/app-1'] },
+      { name: 'user-routes', routes: ['/user-1'] },
+    ])
     expect(next).toHaveBeenCalled()
   })
 })

--- a/node/middlewares/customRoutes.ts
+++ b/node/middlewares/customRoutes.ts
@@ -257,10 +257,18 @@ export async function customRoutes(ctx: Context, next: () => Promise<void>) {
       triggerCustomRoutesGeneration(ctx)
     }
 
-    // Filter data based on enableAppsRoutes setting
-    const filteredData = settings.enableAppsRoutes
-      ? cachedData.data
-      : cachedData.data.filter(item => item.name !== 'apps-routes')
+    // Filter data based on which sources are enabled. When a flag is off the
+    // corresponding section is omitted entirely so consumers see the feature
+    // as if it did not exist (invariant 9 — settings gating).
+    const filteredData = cachedData.data.filter(item => {
+      if (item.name === 'apps-routes' && !settings.enableAppsRoutes) {
+        return false
+      }
+      if (item.name === 'cms-routes' && !settings.enableCmsRoutes) {
+        return false
+      }
+      return true
+    })
 
     // Return cached data
     ctx.status = 200

--- a/node/middlewares/generateMiddlewares/generateCmsRoutes.test.ts
+++ b/node/middlewares/generateMiddlewares/generateCmsRoutes.test.ts
@@ -208,6 +208,70 @@ describe('generateCmsRoutes', () => {
     expect(collectPaths(bindingTwoEntries)).toEqual(['/nossa-historia'])
   })
 
+  it('populates alternates across bindings for the same logical page id (US-3)', async () => {
+    const internals = [
+      { binding: '1', from: '/our-story', id: 'cms-1', type: 'userRoute' },
+      { binding: '2', from: '/nossa-historia', id: 'cms-1', type: 'userRoute' },
+    ] as Internal[]
+
+    const context = buildContext({ internals })
+    await generateCmsRoutes(context, next)
+
+    const expectedAlternates = [
+      { bindingId: '1', path: '/our-story' },
+      { bindingId: '2', path: '/nossa-historia' },
+    ]
+
+    const { vbase } = context.clients
+    const bindingOneIndex = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    const bindingOneEntry = await vbase.getJSON<SitemapEntry>(
+      bucketFor('1'),
+      bindingOneIndex.index[0],
+      true
+    )
+    expect(bindingOneEntry.routes[0].alternates).toEqual(expectedAlternates)
+
+    const bindingTwoIndex = await vbase.getJSON<SitemapIndex>(
+      bucketFor('2'),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    const bindingTwoEntry = await vbase.getJSON<SitemapEntry>(
+      bucketFor('2'),
+      bindingTwoIndex.index[0],
+      true
+    )
+    expect(bindingTwoEntry.routes[0].alternates).toEqual(expectedAlternates)
+  })
+
+  it('sets alternates to a single self entry when the page exists in only one binding', async () => {
+    const internals = [
+      { binding: '1', from: '/our-story', id: 'cms-1', type: 'userRoute' },
+    ] as Internal[]
+
+    const context = buildContext({ internals })
+    await generateCmsRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    const entry = await vbase.getJSON<SitemapEntry>(
+      bucketFor('1'),
+      index.index[0],
+      true
+    )
+    expect(entry.routes[0].alternates).toEqual([
+      { bindingId: '1', path: '/our-story' },
+    ])
+  })
+
   it('excludes framework-generated types (product, department, category, subcategory, brand) from cms-routes', async () => {
     const internals = [
       { binding: '1', from: '/p/123', id: 'p1', type: 'product' },

--- a/node/middlewares/generateMiddlewares/generateCmsRoutes.test.ts
+++ b/node/middlewares/generateMiddlewares/generateCmsRoutes.test.ts
@@ -1,0 +1,363 @@
+import {
+  IOContext,
+  Logger,
+  RequestConfig,
+  Tenant,
+  TenantClient,
+  VBase,
+  VBaseSaveResponse,
+} from '@vtex/api'
+import * as TypeMoq from 'typemoq'
+import { EntityLocator, Internal } from 'vtex.rewriter'
+
+import { Clients } from '../../clients'
+import {
+  CMS_ROUTES_PREFIX,
+  CMS_ROUTES_MAX_URLS_PER_FILE,
+  getBucket,
+  hashString,
+} from '../../utils'
+import { Rewriter } from './../../clients/rewriter'
+import { generateCmsRoutes } from './generateCmsRoutes'
+import {
+  CMS_ROUTES_INDEX,
+  SitemapEntry,
+  SitemapIndex,
+} from './utils'
+
+const tenantTypeMock = TypeMoq.Mock.ofInstance(TenantClient)
+const rewriterTypeMock = TypeMoq.Mock.ofInstance(Rewriter)
+const vbaseTypeMock = TypeMoq.Mock.ofInstance(VBase)
+const contextMock = TypeMoq.Mock.ofType<EventContext>()
+const ioContext = TypeMoq.Mock.ofType<IOContext>()
+const state = TypeMoq.Mock.ofType<State>()
+const loggerMock = TypeMoq.Mock.ofType<Logger>()
+
+let next: any
+
+interface BuildContextOptions {
+  internals: Internal[]
+  disableRoutesTerm?: string
+}
+
+const buildContext = ({ internals, disableRoutesTerm = '' }: BuildContextOptions): EventContext => {
+  // tslint:disable-next-line:max-classes-per-file
+  const vbase = class VBaseMock extends vbaseTypeMock.object {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public jsonData: Record<string, any> = {}
+
+    constructor() {
+      super(ioContext.object)
+    }
+
+    public getJSON = async <T>(
+      bucket: string,
+      file: string,
+      nullOrUndefined?: boolean | undefined
+    ): Promise<T> => {
+      if (!this.jsonData[bucket]?.[file] && nullOrUndefined) {
+        return (null as unknown) as T
+      }
+      return Promise.resolve(this.jsonData[bucket][file] as T)
+    }
+
+    public saveJSON = async <T>(
+      bucket: string,
+      file: string,
+      data: T
+    ): Promise<VBaseSaveResponse> => {
+      if (!this.jsonData[bucket]) {
+        this.jsonData[bucket] = {}
+      }
+      this.jsonData[bucket][file] = data
+      return Promise.resolve(({
+        updated: true,
+      } as unknown) as VBaseSaveResponse)
+    }
+  }
+
+  // tslint:disable-next-line:max-classes-per-file
+  const tenant = class TenantMock extends tenantTypeMock.object {
+    constructor() {
+      super(ioContext.object)
+    }
+
+    public info = async (_?: RequestConfig) => {
+      return {
+        bindings: [
+          {
+            id: '1',
+            targetProduct: 'vtex-storefront',
+          },
+          {
+            id: '2',
+            targetProduct: 'vtex-storefront',
+          },
+        ],
+      } as Tenant
+    }
+  }
+
+  // tslint:disable-next-line:max-classes-per-file
+  const rewriter = class RewriterMock extends rewriterTypeMock.object {
+    constructor() {
+      super(ioContext.object)
+    }
+
+    public routesById = async (_: EntityLocator) => []
+
+    public listInternalsWithRetry = async (_: number, cursor: Maybe<string>) => {
+      if (cursor === null || cursor === undefined) {
+        return { next: null, routes: internals }
+      }
+      return { next: null, routes: [] as Internal[] }
+    }
+  }
+
+  // tslint:disable-next-line:max-classes-per-file
+  const ClientsImpl = class ClientsMock extends Clients {
+    get vbase() {
+      return this.getOrSet('vbase', vbase)
+    }
+
+    get rewriter() {
+      return this.getOrSet('rewriter', rewriter)
+    }
+
+    get tenant() {
+      return this.getOrSet('tenant', tenant)
+    }
+  }
+
+  return {
+    ...contextMock.object,
+    body: {
+      generationId: 'gen-1',
+    },
+    clients: new ClientsImpl({}, ioContext.object),
+    state: {
+      ...state.object,
+      settings: {
+        disableRoutesTerm,
+        enableAppsRoutes: true,
+        enableCmsRoutes: true,
+        enableNavigationRoutes: true,
+        enableProductRoutes: true,
+        ignoreBindings: false,
+      },
+    },
+    vtex: {
+      ...ioContext.object,
+      logger: loggerMock.object,
+    },
+  } as EventContext
+}
+
+const bucketFor = (bindingId: string) => getBucket(CMS_ROUTES_PREFIX, hashString(bindingId))
+
+const collectPaths = (entries: SitemapEntry[]): string[] =>
+  entries.reduce<string[]>(
+    (acc, entry) => acc.concat(entry.routes.map(r => r.path)),
+    []
+  )
+
+describe('generateCmsRoutes', () => {
+  beforeEach(() => {
+    next = jest.fn()
+  })
+
+  it('groups CMS-origin Rewriter Internals by binding and writes them under the cms-routes bucket', async () => {
+    const internals = [
+      { binding: '1', from: '/our-story', id: 'cms-1', type: 'userRoute' },
+      { binding: '1', from: '/black-friday', id: 'cms-2', type: 'user-canonical' },
+      { binding: '2', from: '/nossa-historia', id: 'cms-1', type: 'userRoute' },
+    ] as Internal[]
+
+    const context = buildContext({ internals })
+    await generateCmsRoutes(context, next)
+
+    expect(next).toBeCalled()
+
+    const { vbase } = context.clients
+    const bindingOneIndex = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    expect(bindingOneIndex).not.toBeNull()
+    expect(bindingOneIndex.index.length).toBeGreaterThan(0)
+
+    const bindingOneEntries = await Promise.all(
+      bindingOneIndex.index.map(file =>
+        vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true)
+      )
+    )
+    const bindingOnePaths = collectPaths(bindingOneEntries).sort()
+    expect(bindingOnePaths).toEqual(['/black-friday', '/our-story'])
+
+    const bindingTwoIndex = await vbase.getJSON<SitemapIndex>(
+      bucketFor('2'),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    const bindingTwoEntries = await Promise.all(
+      bindingTwoIndex.index.map(file =>
+        vbase.getJSON<SitemapEntry>(bucketFor('2'), file, true)
+      )
+    )
+    expect(collectPaths(bindingTwoEntries)).toEqual(['/nossa-historia'])
+  })
+
+  it('excludes framework-generated types (product, department, category, subcategory, brand) from cms-routes', async () => {
+    const internals = [
+      { binding: '1', from: '/p/123', id: 'p1', type: 'product' },
+      { binding: '1', from: '/fruits', id: 'd1', type: 'department' },
+      { binding: '1', from: '/fruits/citrics', id: 'c1', type: 'category' },
+      { binding: '1', from: '/fruits/citrics/orange', id: 's1', type: 'subcategory' },
+      { binding: '1', from: '/brand-x', id: 'b1', type: 'brand' },
+      { binding: '1', from: '/our-story', id: 'cms-1', type: 'userRoute' },
+    ] as Internal[]
+
+    const context = buildContext({ internals })
+    await generateCmsRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    const entries = await Promise.all(
+      index.index.map(file => vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true))
+    )
+    expect(collectPaths(entries)).toEqual(['/our-story'])
+  })
+
+  it('excludes routes with disableSitemapEntry=true (the CMS toggle)', async () => {
+    const internals = [
+      { binding: '1', from: '/keep', id: 'k', type: 'userRoute' },
+      {
+        binding: '1',
+        disableSitemapEntry: true,
+        from: '/hidden',
+        id: 'h',
+        type: 'userRoute',
+      },
+    ] as Internal[]
+
+    const context = buildContext({ internals })
+    await generateCmsRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    const entries = await Promise.all(
+      index.index.map(file => vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true))
+    )
+    expect(collectPaths(entries)).toEqual(['/keep'])
+  })
+
+  it('excludes notFound* types and routes flagged as login or error', async () => {
+    const internals = [
+      { binding: '1', from: '/not-here', id: 'nf1', type: 'notFound' },
+      { binding: '1', from: '/also-missing', id: 'nf2', type: 'notFoundProduct' },
+      { binding: '1', from: '/login', id: 'l1', type: 'login' },
+      { binding: '1', from: '/error', id: 'e1', type: 'error' },
+      { binding: '1', from: '/our-story', id: 'ok', type: 'userRoute' },
+    ] as Internal[]
+
+    const context = buildContext({ internals })
+    await generateCmsRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    const entries = await Promise.all(
+      index.index.map(file => vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true))
+    )
+    expect(collectPaths(entries)).toEqual(['/our-story'])
+  })
+
+  it('honors disableRoutesTerm by filtering out matching substrings', async () => {
+    const internals = [
+      { binding: '1', from: '/keep', id: '1', type: 'userRoute' },
+      { binding: '1', from: '/internal/staging-only', id: '2', type: 'userRoute' },
+    ] as Internal[]
+
+    const context = buildContext({ internals, disableRoutesTerm: '/internal/' })
+    await generateCmsRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    const entries = await Promise.all(
+      index.index.map(file => vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true))
+    )
+    expect(collectPaths(entries)).toEqual(['/keep'])
+  })
+
+  it('chunks routes into multiple files when CMS_ROUTES_MAX_URLS_PER_FILE is exceeded', async () => {
+    // Use a small overflow to keep the test fast
+    const overflowCount = CMS_ROUTES_MAX_URLS_PER_FILE + 5
+    const internals: Internal[] = Array.from({ length: overflowCount }).map(
+      (_, i) => ({
+        binding: '1',
+        from: `/page-${i}`,
+        id: `cms-${i}`,
+        type: 'userRoute',
+      })
+    ) as Internal[]
+
+    const context = buildContext({ internals })
+    await generateCmsRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    expect(index.index.length).toBe(2)
+
+    const first = await vbase.getJSON<SitemapEntry>(
+      bucketFor('1'),
+      index.index[0],
+      true
+    )
+    const second = await vbase.getJSON<SitemapEntry>(
+      bucketFor('1'),
+      index.index[1],
+      true
+    )
+    expect(first.routes.length).toBe(CMS_ROUTES_MAX_URLS_PER_FILE)
+    expect(second.routes.length).toBe(5)
+  })
+
+  it('skips generation when enableCmsRoutes is off and does not touch VBase', async () => {
+    const internals = [
+      { binding: '1', from: '/our-story', id: 'cms-1', type: 'userRoute' },
+    ] as Internal[]
+
+    const context = buildContext({ internals })
+    context.state.settings.enableCmsRoutes = false
+    await generateCmsRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    expect(index).toBeNull()
+    expect(next).toBeCalled()
+  })
+})

--- a/node/middlewares/generateMiddlewares/generateCmsRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateCmsRoutes.ts
@@ -1,0 +1,255 @@
+import { Internal, ListInternalsResponse } from 'vtex.rewriter'
+
+import {
+  CMS_ROUTES_MAX_BYTES_PER_FILE,
+  CMS_ROUTES_MAX_URLS_PER_FILE,
+  CMS_ROUTES_PREFIX,
+  getBucket,
+  hashString,
+} from '../../utils'
+import {
+  CMS_ROUTES_INDEX,
+  createFileName,
+  currentDate,
+  SitemapEntry,
+  SitemapIndex,
+} from './utils'
+
+const LIST_LIMIT = 300
+const MAX_PAGES = 100
+
+// Types managed by other generators / not CMS-origin.
+const FRAMEWORK_OWNED_TYPES = new Set([
+  'product',
+  'department',
+  'category',
+  'subcategory',
+  'brand',
+])
+
+// Page classifications that are mandatorily excluded from the sitemap
+// per FR-3 (regardless of merchant toggle).
+const MANDATORY_EXCLUDED_TYPE_FRAGMENTS = ['login', 'error']
+
+const isCmsOriginType = (rawType: string | undefined): boolean => {
+  const type = (rawType || '').toLowerCase()
+  if (!type) {
+    return false
+  }
+  if (type.startsWith('notfound')) {
+    return false
+  }
+  if (FRAMEWORK_OWNED_TYPES.has(type)) {
+    return false
+  }
+  if (MANDATORY_EXCLUDED_TYPE_FRAGMENTS.some(fragment => type.includes(fragment))) {
+    return false
+  }
+  return true
+}
+
+const isValidCmsRoute = (internal: Internal, disableRoutesTerm: string): boolean => {
+  if (internal.disableSitemapEntry) {
+    return false
+  }
+  if (!isCmsOriginType(internal.type)) {
+    return false
+  }
+  if (disableRoutesTerm && internal.from.includes(disableRoutesTerm)) {
+    return false
+  }
+  return true
+}
+
+const toRoute = (internal: Internal): Route => ({
+  alternates: [],
+  id: internal.id,
+  imagePath: internal.imagePath || undefined,
+  imageTitle: internal.imageTitle || undefined,
+  path: internal.from,
+})
+
+// Rough JSON byte size estimate — adequate as a proxy for serialized output
+// because XML produced from each Route is within a constant factor of its JSON.
+const estimateRouteBytes = (route: Route): number => JSON.stringify(route).length
+
+interface ChunkAccumulator {
+  chunks: Route[][]
+  current: Route[]
+  currentBytes: number
+}
+
+const newAccumulator = (): ChunkAccumulator => ({
+  chunks: [],
+  current: [],
+  currentBytes: 0,
+})
+
+const pushRoute = (acc: ChunkAccumulator, route: Route) => {
+  const routeBytes = estimateRouteBytes(route)
+  const wouldExceedUrls = acc.current.length >= CMS_ROUTES_MAX_URLS_PER_FILE
+  const wouldExceedBytes =
+    acc.current.length > 0 &&
+    acc.currentBytes + routeBytes > CMS_ROUTES_MAX_BYTES_PER_FILE
+  if (wouldExceedUrls || wouldExceedBytes) {
+    acc.chunks.push(acc.current)
+    acc.current = []
+    acc.currentBytes = 0
+  }
+  acc.current.push(route)
+  acc.currentBytes += routeBytes
+}
+
+const flushAccumulator = (acc: ChunkAccumulator): Route[][] => {
+  if (acc.current.length > 0) {
+    acc.chunks.push(acc.current)
+    acc.current = []
+    acc.currentBytes = 0
+  }
+  return acc.chunks
+}
+
+const partitionByBinding = (
+  internals: Internal[],
+  disableRoutesTerm: string
+): Map<string, Route[]> => {
+  const byBinding = new Map<string, Route[]>()
+  for (const internal of internals) {
+    if (!isValidCmsRoute(internal, disableRoutesTerm)) {
+      continue
+    }
+    const bucket = byBinding.get(internal.binding) || []
+    bucket.push(toRoute(internal))
+    byBinding.set(internal.binding, bucket)
+  }
+  return byBinding
+}
+
+const fetchAllInternals = async (ctx: Context | EventContext): Promise<Internal[]> => {
+  const {
+    clients: { rewriter },
+    vtex: { logger },
+  } = ctx
+  const internals: Internal[] = []
+  let cursor: Maybe<string> = null
+  let page = 0
+  do {
+    page += 1
+    // eslint-disable-next-line no-await-in-loop
+    const response: ListInternalsResponse = await rewriter.listInternalsWithRetry(
+      LIST_LIMIT,
+      cursor
+    )
+    internals.push(...(response.routes ?? []))
+    cursor = response.next
+    if (page >= MAX_PAGES && cursor) {
+      logger.warn({
+        message: 'CMS routes generation: reached MAX_PAGES, stopping pagination',
+        type: 'cms-routes-max-pages',
+        page,
+        totalRoutes: internals.length,
+      })
+      break
+    }
+  } while (cursor)
+  return internals
+}
+
+const saveBindingChunks = async (
+  ctx: Context | EventContext,
+  bindingId: string,
+  routes: Route[]
+) => {
+  const {
+    clients: { vbase },
+  } = ctx
+  const bucket = getBucket(CMS_ROUTES_PREFIX, hashString(bindingId))
+  const acc = newAccumulator()
+  for (const route of routes) {
+    pushRoute(acc, route)
+  }
+  const chunks = flushAccumulator(acc)
+  const lastUpdated = currentDate()
+  const fileNames: string[] = []
+  // Sequential writes keep order predictable across runs (determinism per invariant 6).
+  for (let i = 0; i < chunks.length; i += 1) {
+    const fileName = createFileName('cms-routes', i)
+    // eslint-disable-next-line no-await-in-loop
+    await vbase.saveJSON<SitemapEntry>(bucket, fileName, {
+      lastUpdated,
+      routes: chunks[i],
+    })
+    fileNames.push(fileName)
+  }
+  await vbase.saveJSON<SitemapIndex>(bucket, CMS_ROUTES_INDEX, {
+    index: fileNames,
+    lastUpdated,
+  })
+  return fileNames.length
+}
+
+export async function generateCmsRoutes(
+  ctx: Context | EventContext,
+  next?: () => Promise<void>
+) {
+  const {
+    state: { settings },
+    vtex: { logger },
+  } = ctx
+
+  if (!settings?.enableCmsRoutes) {
+    logger.info({
+      message: 'CMS routes generation skipped: enableCmsRoutes is off',
+      type: 'cms-routes-generation-skipped',
+    })
+    if (next) {
+      await next()
+    }
+    return
+  }
+
+  const disableRoutesTerm = settings.disableRoutesTerm || ''
+  const startTime = Date.now()
+  logger.info({
+    message: 'CMS routes generation started',
+    type: 'cms-routes-generation-started',
+  })
+
+  try {
+    const internals = await fetchAllInternals(ctx)
+    const byBinding = partitionByBinding(internals, disableRoutesTerm)
+
+    const bindingIds = Array.from(byBinding.keys())
+    const fileCounts = await Promise.all(
+      bindingIds.map(bindingId =>
+        saveBindingChunks(ctx, bindingId, byBinding.get(bindingId)!)
+      )
+    )
+
+    const totalRoutes = Array.from(byBinding.values()).reduce(
+      (sum, routes) => sum + routes.length,
+      0
+    )
+    const totalFiles = fileCounts.reduce((sum, n) => sum + n, 0)
+
+    logger.info({
+      message: 'CMS routes generation complete',
+      type: 'cms-routes-generation-complete',
+      durationMs: Date.now() - startTime,
+      bindings: bindingIds.length,
+      totalFiles,
+      totalRoutes,
+    })
+  } catch (error) {
+    logger.error({
+      error,
+      message: 'CMS routes generation failed',
+      type: 'cms-routes-generation-error',
+    })
+    throw error
+  } finally {
+    if (next) {
+      await next()
+    }
+  }
+}

--- a/node/middlewares/generateMiddlewares/generateCmsRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateCmsRoutes.ts
@@ -31,7 +31,7 @@ const FRAMEWORK_OWNED_TYPES = new Set([
 // per FR-3 (regardless of merchant toggle).
 const MANDATORY_EXCLUDED_TYPE_FRAGMENTS = ['login', 'error']
 
-const isCmsOriginType = (rawType: string | undefined): boolean => {
+export const isCmsOriginType = (rawType: string | undefined): boolean => {
   const type = (rawType || '').toLowerCase()
   if (!type) {
     return false
@@ -48,7 +48,10 @@ const isCmsOriginType = (rawType: string | undefined): boolean => {
   return true
 }
 
-const isValidCmsRoute = (internal: Internal, disableRoutesTerm: string): boolean => {
+export const isValidCmsRoute = (
+  internal: Internal,
+  disableRoutesTerm: string
+): boolean => {
   if (internal.disableSitemapEntry) {
     return false
   }

--- a/node/middlewares/generateMiddlewares/generateCmsRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateCmsRoutes.ts
@@ -64,12 +64,19 @@ export const isValidCmsRoute = (
   return true
 }
 
+// Defaults for sitemap protocol tags applied to every CMS route (FR-5).
+// They can be overridden once hCMS exposes per-page values (Decision 3).
+export const CMS_ROUTES_DEFAULT_CHANGEFREQ: ChangeFreq = 'weekly'
+export const CMS_ROUTES_DEFAULT_PRIORITY = 0.5
+
 const toRoute = (internal: Internal): Route => ({
   alternates: [],
+  changefreq: CMS_ROUTES_DEFAULT_CHANGEFREQ,
   id: internal.id,
   imagePath: internal.imagePath || undefined,
   imageTitle: internal.imageTitle || undefined,
   path: internal.from,
+  priority: CMS_ROUTES_DEFAULT_PRIORITY,
 })
 
 // Rough JSON byte size estimate — adequate as a proxy for serialized output

--- a/node/middlewares/generateMiddlewares/generateCmsRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateCmsRoutes.ts
@@ -69,8 +69,8 @@ export const isValidCmsRoute = (
 export const CMS_ROUTES_DEFAULT_CHANGEFREQ: ChangeFreq = 'weekly'
 export const CMS_ROUTES_DEFAULT_PRIORITY = 0.5
 
-const toRoute = (internal: Internal): Route => ({
-  alternates: [],
+const toRoute = (internal: Internal, alternates: AlternateRoute[]): Route => ({
+  alternates,
   changefreq: CMS_ROUTES_DEFAULT_CHANGEFREQ,
   id: internal.id,
   imagePath: internal.imagePath || undefined,
@@ -123,14 +123,27 @@ const partitionByBinding = (
   internals: Internal[],
   disableRoutesTerm: string
 ): Map<string, Route[]> => {
-  const byBinding = new Map<string, Route[]>()
+  const byId = new Map<string, Internal[]>()
   for (const internal of internals) {
     if (!isValidCmsRoute(internal, disableRoutesTerm)) {
       continue
     }
-    const bucket = byBinding.get(internal.binding) || []
-    bucket.push(toRoute(internal))
-    byBinding.set(internal.binding, bucket)
+    const group = byId.get(internal.id) ?? []
+    group.push(internal)
+    byId.set(internal.id, group)
+  }
+
+  const byBinding = new Map<string, Route[]>()
+  for (const group of byId.values()) {
+    const alternates: AlternateRoute[] = group.map(i => ({
+      bindingId: i.binding,
+      path: i.from,
+    }))
+    for (const internal of group) {
+      const bucket = byBinding.get(internal.binding) ?? []
+      bucket.push(toRoute(internal, alternates))
+      byBinding.set(internal.binding, bucket)
+    }
   }
   return byBinding
 }

--- a/node/middlewares/generateMiddlewares/generateCustomRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateCustomRoutes.ts
@@ -1,6 +1,6 @@
 import { getDefaultStoreBinding } from '../../resources/bindings'
 import { clearCustomRoutesGenerationLock } from '../customRoutes'
-import { getAppsRoutes, getUserRoutes } from '../../services/routes'
+import { getAppsRoutes, getCmsRoutes, getUserRoutes } from '../../services/routes'
 import { CUSTOM_ROUTES_BUCKET, CUSTOM_ROUTES_FILENAME } from '../../utils'
 
 export async function generateCustomRoutes(ctx: Context) {
@@ -35,14 +35,16 @@ export async function generateCustomRoutes(ctx: Context) {
       vtex: ctx.vtex,
     } as Context
 
-    const [appsRoutes, userRoutes] = await Promise.all([
+    const [appsRoutes, userRoutes, cmsRoutes] = await Promise.all([
       getAppsRoutes(routeCtx),
       getUserRoutes(routeCtx),
+      getCmsRoutes(routeCtx),
     ])
 
     logger.info({
       message: 'Routes fetched',
       appsRoutesCount: appsRoutes.length,
+      cmsRoutesCount: cmsRoutes.length,
       userRoutesCount: userRoutes.length,
     })
 
@@ -51,6 +53,7 @@ export async function generateCustomRoutes(ctx: Context) {
       data: [
         { name: 'apps-routes', routes: appsRoutes },
         { name: 'user-routes', routes: userRoutes },
+        { name: 'cms-routes', routes: cmsRoutes },
       ],
     }
 

--- a/node/middlewares/generateMiddlewares/generateSitemap.test.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.test.ts
@@ -73,6 +73,7 @@ describe('Test generate sitemap', () => {
         settings: {
           disableRoutesTerm: '',
           enableAppsRoutes: true,
+          enableCmsRoutes: true,
           enableNavigationRoutes: true,
           enableProductRoutes: true,
           ignoreBindings: false,
@@ -108,6 +109,7 @@ describe('Test generate sitemap', () => {
     context.state.settings = {
       disableRoutesTerm: '',
       enableAppsRoutes: true,
+      enableCmsRoutes: true,
       enableNavigationRoutes: true,
       enableProductRoutes: false,
       ignoreBindings: false,
@@ -130,6 +132,7 @@ describe('Test generate sitemap', () => {
     context.state.settings = {
       disableRoutesTerm: '',
       enableAppsRoutes: false,
+      enableCmsRoutes: true,
       enableNavigationRoutes: false,
       enableProductRoutes: true,
       ignoreBindings: false,

--- a/node/middlewares/generateMiddlewares/generateSitemap.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.ts
@@ -3,6 +3,7 @@ import { MultipleSitemapGenerationError } from './../../errors'
 
 import {
   GENERATE_APPS_ROUTES_EVENT,
+  GENERATE_CMS_ROUTES_EVENT,
   GENERATE_PRODUCT_ROUTES_EVENT,
   GENERATE_REWRITER_ROUTES_EVENT,
 } from './utils'
@@ -49,5 +50,9 @@ export async function generateSitemap(ctx: EventContext) {
 
   if (settings.enableAppsRoutes) {
     events.sendEvent('', GENERATE_APPS_ROUTES_EVENT, { generationId })
+  }
+
+  if (settings.enableCmsRoutes) {
+    events.sendEvent('', GENERATE_CMS_ROUTES_EVENT, { generationId })
   }
 }

--- a/node/middlewares/generateMiddlewares/utils.ts
+++ b/node/middlewares/generateMiddlewares/utils.ts
@@ -10,6 +10,7 @@ export const RAW_DATA_PREFIX = `${LINKED ? 'L' : ''}C`
 export const REWRITER_ROUTES_INDEX = 'rewriterRoutesIndex.json'
 export const PRODUCT_ROUTES_INDEX = 'productRoutesIndex.json'
 export const APPS_ROUTES_INDEX = 'appsRoutesIndex.json'
+export const CMS_ROUTES_INDEX = 'cmsRoutesIndex.json'
 
 export const GENERATE_SITEMAP_EVENT = 'sitemap.generate'
 export const GENERATE_REWRITER_ROUTES_EVENT = 'sitemap.generate:rewriter-routes'

--- a/node/middlewares/generateMiddlewares/utils.ts
+++ b/node/middlewares/generateMiddlewares/utils.ts
@@ -16,6 +16,7 @@ export const GENERATE_SITEMAP_EVENT = 'sitemap.generate'
 export const GENERATE_REWRITER_ROUTES_EVENT = 'sitemap.generate:rewriter-routes'
 export const GENERATE_PRODUCT_ROUTES_EVENT = 'sitemap.generate:product-routes'
 export const GENERATE_APPS_ROUTES_EVENT = 'sitemap.generate:apps-routes'
+export const GENERATE_CMS_ROUTES_EVENT = 'sitemap.generate:cms-routes'
 export const GROUP_ENTRIES_EVENT = 'sitemap.generate:group-entries'
 
 export const DEFAULT_CONFIG: Config = {

--- a/node/middlewares/robots.test.ts
+++ b/node/middlewares/robots.test.ts
@@ -1,0 +1,52 @@
+import { ensureSitemapDirective } from './robots'
+
+describe('ensureSitemapDirective', () => {
+  const sitemapUrl = 'https://example.com/sitemap.xml'
+
+  it('appends the directive to a body that has no Sitemap line', () => {
+    const body = 'User-agent: *\nDisallow: /admin'
+    const result = ensureSitemapDirective(body, sitemapUrl)
+    expect(result).toContain('User-agent: *')
+    expect(result).toContain('Disallow: /admin')
+    expect(result).toContain(`Sitemap: ${sitemapUrl}`)
+  })
+
+  it('returns the body unchanged when a Sitemap directive already exists', () => {
+    const body = `User-agent: *\nDisallow:\nSitemap: ${sitemapUrl}`
+    const result = ensureSitemapDirective(body, sitemapUrl)
+    expect(result).toEqual(body)
+  })
+
+  it('detects an existing Sitemap directive case-insensitively (invariant 8)', () => {
+    const body = 'User-agent: *\nsITEmap: https://example.com/other.xml'
+    const result = ensureSitemapDirective(body, sitemapUrl)
+    expect(result).toEqual(body)
+    expect((result.match(/sitemap\s*:/gi) || []).length).toBe(1)
+  })
+
+  it('detects an existing Sitemap directive even when indented with whitespace', () => {
+    const body = `User-agent: *\n   Sitemap: ${sitemapUrl}`
+    const result = ensureSitemapDirective(body, sitemapUrl)
+    expect(result).toEqual(body)
+  })
+
+  it('writes a single-line file when given an empty body', () => {
+    const result = ensureSitemapDirective(undefined, sitemapUrl)
+    expect(result).toContain(`Sitemap: ${sitemapUrl}`)
+  })
+
+  it('is idempotent across repeated calls', () => {
+    const initial = 'User-agent: *\nDisallow:'
+    const once = ensureSitemapDirective(initial, sitemapUrl)
+    const twice = ensureSitemapDirective(once, sitemapUrl)
+    expect(twice).toEqual(once)
+    expect((twice.match(/sitemap\s*:/gi) || []).length).toBe(1)
+  })
+
+  it('does not duplicate the directive when the existing Sitemap URL differs', () => {
+    const body = 'User-agent: *\nSitemap: https://old.example.com/sitemap.xml'
+    const result = ensureSitemapDirective(body, sitemapUrl)
+    expect(result).toEqual(body)
+    expect(result).not.toContain(sitemapUrl)
+  })
+})

--- a/node/middlewares/robots.ts
+++ b/node/middlewares/robots.ts
@@ -10,6 +10,36 @@ interface RobotsFile {
 
 const SITEMAP_BUILD_FILE = 'dist/vtex.store-sitemap/build.json'
 
+// Multiline, case-insensitive — matches "Sitemap:" anywhere in the file at the
+// start of a (possibly indented) line. Mirrors how robots.txt parsers detect
+// the directive.
+const SITEMAP_DIRECTIVE_REGEX = /^\s*Sitemap\s*:/im
+
+/**
+ * Idempotently inject a `Sitemap:` directive into a robots.txt body.
+ *
+ * - Returns the body unchanged when a `Sitemap:` line is already present
+ *   (case-insensitive, leading-whitespace-tolerant — Decision 6 of the spec).
+ * - When the body is empty/undefined, returns a single-line file containing
+ *   the directive.
+ * - Otherwise appends the directive after a blank line, preserving content.
+ *
+ * Pure helper — exported for unit testing (US-4 acceptance criteria).
+ */
+export const ensureSitemapDirective = (
+  robotsBody: string | undefined,
+  sitemapUrl: string
+): string => {
+  if (!robotsBody) {
+    return `Sitemap: ${sitemapUrl}\n`
+  }
+  if (SITEMAP_DIRECTIVE_REGEX.test(robotsBody)) {
+    return robotsBody
+  }
+  const trimmed = robotsBody.replace(/\s+$/, '')
+  return `${trimmed}\n\nSitemap: ${sitemapUrl}\n`
+}
+
 const getRobotForBinding = async (
   bindingId: string,
   account: string,
@@ -49,6 +79,14 @@ export async function robots(ctx: Context) {
   }
   if (!data || !binding?.id) {
     data = await robotsDataSource.fromLegacy(account)
+  }
+
+  // Decision 6 of the spec: guarantee a `Sitemap:` directive is present so
+  // crawlers can always discover the sitemap. Idempotent — never duplicates an
+  // existing directive added manually by the merchant.
+  const forwardedHost = ctx.get('x-forwarded-host')
+  if (forwardedHost) {
+    data = ensureSitemapDirective(data, `https://${forwardedHost}/sitemap.xml`)
   }
 
   ctx.set('Content-Type', 'text/plain')

--- a/node/middlewares/settings.test.ts
+++ b/node/middlewares/settings.test.ts
@@ -2,7 +2,7 @@ import { Apps, IOContext, Logger, RequestTracingConfig } from '@vtex/api'
 import * as TypeMoq from 'typemoq'
 
 import { Clients } from '../clients'
-import { APPS_ROUTES_INDEX, PRODUCT_ROUTES_INDEX, REWRITER_ROUTES_INDEX } from './generateMiddlewares/utils'
+import { APPS_ROUTES_INDEX, CMS_ROUTES_INDEX, PRODUCT_ROUTES_INDEX, REWRITER_ROUTES_INDEX } from './generateMiddlewares/utils'
 import { settings } from './settings'
 
 const appsTypeMock = TypeMoq.Mock.ofInstance(Apps)
@@ -81,5 +81,34 @@ describe('Test settings middleware', () => {
     }
     await settings(context, next)
     expect(context.state.enabledIndexFiles).toStrictEqual([])
+  })
+
+  it('Should include CMS_ROUTES_INDEX when enableCmsRoutes is true', async () => {
+    const appClient = context.clients.apps as any
+    appClient.settings = {
+      enableAppsRoutes: false,
+      enableCmsRoutes: true,
+      enableNavigationRoutes: false,
+      enableProductRoutes: false,
+    }
+    await settings(context, next)
+    expect(context.state.enabledIndexFiles).toStrictEqual([CMS_ROUTES_INDEX])
+  })
+
+  it('Should omit CMS_ROUTES_INDEX when enableCmsRoutes is false (default rollout state)', async () => {
+    const appClient = context.clients.apps as any
+    appClient.settings = {
+      enableAppsRoutes: true,
+      enableCmsRoutes: false,
+      enableNavigationRoutes: true,
+      enableProductRoutes: true,
+    }
+    await settings(context, next)
+    expect(context.state.enabledIndexFiles).not.toContain(CMS_ROUTES_INDEX)
+    expect(context.state.enabledIndexFiles).toStrictEqual([
+      APPS_ROUTES_INDEX,
+      REWRITER_ROUTES_INDEX,
+      PRODUCT_ROUTES_INDEX,
+    ])
   })
 })

--- a/node/middlewares/settings.test.ts
+++ b/node/middlewares/settings.test.ts
@@ -83,7 +83,7 @@ describe('Test settings middleware', () => {
     expect(context.state.enabledIndexFiles).toStrictEqual([])
   })
 
-  it('Should include CMS_ROUTES_INDEX when enableCmsRoutes is true', async () => {
+  it('Should NOT include CMS_ROUTES_INDEX in enabledIndexFiles when enableCmsRoutes is true (CMS uses its own bucket)', async () => {
     const appClient = context.clients.apps as any
     appClient.settings = {
       enableAppsRoutes: false,
@@ -92,7 +92,8 @@ describe('Test settings middleware', () => {
       enableProductRoutes: false,
     }
     await settings(context, next)
-    expect(context.state.enabledIndexFiles).toStrictEqual([CMS_ROUTES_INDEX])
+    expect(context.state.enabledIndexFiles).not.toContain(CMS_ROUTES_INDEX)
+    expect(context.state.enabledIndexFiles).toStrictEqual([])
   })
 
   it('Should omit CMS_ROUTES_INDEX when enableCmsRoutes is false (default rollout state)', async () => {

--- a/node/middlewares/settings.ts
+++ b/node/middlewares/settings.ts
@@ -1,6 +1,7 @@
 import { appIdToAppAtMajor } from '@vtex/api'
 import {
   APPS_ROUTES_INDEX,
+  CMS_ROUTES_INDEX,
   PRODUCT_ROUTES_INDEX,
   REWRITER_ROUTES_INDEX,
 } from './generateMiddlewares/utils'
@@ -9,6 +10,7 @@ export interface Settings {
   enableAppsRoutes: boolean
   enableProductRoutes: boolean
   enableNavigationRoutes: boolean
+  enableCmsRoutes: boolean
   ignoreBindings: boolean
   disableRoutesTerm: string
 }
@@ -16,17 +18,19 @@ export interface Settings {
 const VTEX_APP_ID = process.env.VTEX_APP_ID!
 const VTEX_APP_AT_MAJOR = appIdToAppAtMajor(VTEX_APP_ID)
 
-const DEFAULT_SETTINGS = {
+const DEFAULT_SETTINGS: Settings = {
   disableRoutesTerm: '',
   enableAppsRoutes: true,
+  enableCmsRoutes: false,
   enableNavigationRoutes: true,
   enableProductRoutes: true,
   ignoreBindings: false,
 }
 
-const INDEX_MAP = {
+const INDEX_MAP: Record<keyof Settings, string> = {
   disableRoutesTerm: '',
   enableAppsRoutes: APPS_ROUTES_INDEX,
+  enableCmsRoutes: CMS_ROUTES_INDEX,
   enableNavigationRoutes: REWRITER_ROUTES_INDEX,
   enableProductRoutes: PRODUCT_ROUTES_INDEX,
   ignoreBindings: '',

--- a/node/middlewares/settings.ts
+++ b/node/middlewares/settings.ts
@@ -1,7 +1,6 @@
 import { appIdToAppAtMajor } from '@vtex/api'
 import {
   APPS_ROUTES_INDEX,
-  CMS_ROUTES_INDEX,
   PRODUCT_ROUTES_INDEX,
   REWRITER_ROUTES_INDEX,
 } from './generateMiddlewares/utils'
@@ -27,10 +26,13 @@ const DEFAULT_SETTINGS: Settings = {
   ignoreBindings: false,
 }
 
+// CMS routes use a dedicated per-binding bucket (spec Decision 1) and are
+// composed into /sitemap.xml via cmsRoutesPromise in sitemap.ts — not via
+// enabledIndexFiles / the shared production bucket.
 const INDEX_MAP: Record<keyof Settings, string> = {
   disableRoutesTerm: '',
   enableAppsRoutes: APPS_ROUTES_INDEX,
-  enableCmsRoutes: CMS_ROUTES_INDEX,
+  enableCmsRoutes: '',
   enableNavigationRoutes: REWRITER_ROUTES_INDEX,
   enableProductRoutes: PRODUCT_ROUTES_INDEX,
   ignoreBindings: '',

--- a/node/middlewares/sitemap.test.ts
+++ b/node/middlewares/sitemap.test.ts
@@ -3,12 +3,13 @@ import * as TypeMoq from 'typemoq'
 
 import {
   APPS_ROUTES_INDEX,
+  CMS_ROUTES_INDEX,
   PRODUCT_ROUTES_INDEX,
   REWRITER_ROUTES_INDEX,
 } from './generateMiddlewares/utils'
 
 import { Clients } from '../clients'
-import { EXTENDED_INDEX_FILE } from '../utils'
+import { CMS_ROUTES_PREFIX, EXTENDED_INDEX_FILE, getBucket, hashString } from '../utils'
 import { sitemap } from './sitemap'
 
 const vbaseTypeMock = TypeMoq.Mock.ofInstance(VBase)
@@ -22,6 +23,9 @@ const removeSpaces = (str: string) => str.replace(/(\r\n|\n|\r|\s)/gm, '')
 describe('Test sitemap middleware', () => {
   let context: Context
   let hasExtendedFiles: boolean
+  let hasCmsRoutesFiles: boolean
+
+  const cmsBucket = getBucket(CMS_ROUTES_PREFIX, hashString('1'))
 
   const vbase = class VBaseMock extends vbaseTypeMock.object {
     constructor() {
@@ -29,10 +33,18 @@ describe('Test sitemap middleware', () => {
     }
 
     public getJSON = async <T>(
-      _: string,
+      bucket: string,
       file: string,
       __?: boolean | undefined
     ): Promise<T> => {
+      if (file === CMS_ROUTES_INDEX && bucket === cmsBucket) {
+        return ((hasCmsRoutesFiles
+          ? {
+              index: ['cms-routes-0'],
+              lastUpdated: '2019-12-04',
+            }
+          : null) as unknown) as T
+      }
       switch (file) {
         case APPS_ROUTES_INDEX:
           return ({
@@ -91,6 +103,7 @@ describe('Test sitemap middleware', () => {
     }
 
     hasExtendedFiles = false
+    hasCmsRoutesFiles = false
     context = {
       ...contextMock.object,
       clients: new ClientsImpl({}, ioContext.object),
@@ -107,11 +120,13 @@ describe('Test sitemap middleware', () => {
         ],
         forwardedHost: 'www.host.com',
         forwardedPath: '/sitemap/file1.xml',
+        isCrossBorder: true,
         matchingBindings: [matchingBindings[0]],
         rootPath: '',
         settings: {
           disableRoutesTerm: '',
           enableAppsRoutes: true,
+          enableCmsRoutes: false,
           enableNavigationRoutes: true,
           enableProductRoutes: true,
           ignoreBindings: false,
@@ -339,5 +354,21 @@ describe('Test sitemap middleware', () => {
       </sitemapindex>`
       )
     )
+  })
+
+  it('Should append cms-routes sub-sitemaps to <sitemapindex> when enableCmsRoutes is on (US-1)', async () => {
+    hasCmsRoutesFiles = true
+    context.state.settings.enableCmsRoutes = true
+    await sitemap(context, next)
+    expect(context.body).toContain(
+      '<loc>https://www.host.com/sitemap/cms-routes-0.xml</loc>'
+    )
+  })
+
+  it('Should NOT read or append cms-routes when enableCmsRoutes is off (invariant 9)', async () => {
+    hasCmsRoutesFiles = true
+    context.state.settings.enableCmsRoutes = false
+    await sitemap(context, next)
+    expect(context.body).not.toContain('cms-routes-0')
   })
 })

--- a/node/middlewares/sitemap.ts
+++ b/node/middlewares/sitemap.ts
@@ -2,6 +2,7 @@ import * as cheerio from 'cheerio'
 
 import { MultipleSitemapGenerationError } from '../errors'
 import {
+  CMS_ROUTES_PREFIX,
   EXTENDED_INDEX_FILE,
   xmlTruncateNodes,
   getBucket,
@@ -9,7 +10,11 @@ import {
   SitemapNotFound,
   startSitemapGeneration,
 } from '../utils'
-import { currentDate, SitemapIndex } from './generateMiddlewares/utils'
+import {
+  CMS_ROUTES_INDEX,
+  currentDate,
+  SitemapIndex,
+} from './generateMiddlewares/utils'
 
 const sitemapIndexEntry = (
   forwardedHost: string,
@@ -50,6 +55,7 @@ const sitemapIndex = async (ctx: Context) => {
       bucket,
       rootPath,
       bindingAddress,
+      settings,
     },
     clients: { vbase },
   } = ctx
@@ -61,6 +67,18 @@ const sitemapIndex = async (ctx: Context) => {
     }
   )
 
+  // CMS routes are stored in a dedicated bucket (Decision 1 of the spec) and
+  // only read when the rollout flag is on (invariant 9 — settings gating). The
+  // read is fire-and-forget on absence: missing CMS index simply means there
+  // are no extra sub-sitemaps to append.
+  const cmsRoutesPromise = settings?.enableCmsRoutes
+    ? vbase.getJSON<SitemapIndex>(
+        getBucket(CMS_ROUTES_PREFIX, hashString(binding.id)),
+        CMS_ROUTES_INDEX,
+        true
+      )
+    : Promise.resolve(null as SitemapIndex | null)
+
   const rawIndexFiles = await Promise.all([
     ...enabledIndexFiles.map(indexFile =>
       vbase.getJSON<SitemapIndex>(bucket, indexFile, true)
@@ -70,9 +88,10 @@ const sitemapIndex = async (ctx: Context) => {
       EXTENDED_INDEX_FILE,
       true
     ),
+    cmsRoutesPromise,
   ])
 
-  const indexFiles = rawIndexFiles.filter(Boolean)
+  const indexFiles = rawIndexFiles.filter(Boolean) as SitemapIndex[]
 
   if (indexFiles.length === 0) {
     throw new SitemapNotFound('Sitemap not found')

--- a/node/middlewares/sitemapEntry.test.ts
+++ b/node/middlewares/sitemapEntry.test.ts
@@ -149,7 +149,7 @@ describe('Test sitemap entry', () => {
     ))
   })
 
-  it('Should create a correct sitemap entry with localization', async () => {
+  it('Should create a correct sitemap entry with localization (self + x-default per spec Decision 5)', async () => {
     const alternates: AlternateRoute[] = [
       {
         bindingId: '1',
@@ -172,14 +172,16 @@ describe('Test sitemap entry', () => {
     expect(removeSpaces(entry)).toStrictEqual(removeSpaces(
     `<url>
       <loc>https://host.com/pear</loc>
+      <xhtml:link rel="alternate" hreflang="en-US" href="https://host.com/pear"/>
       <xhtml:link rel="alternate" hreflang="pt-BR" href="https://www.host.com/br/pera"/>
       <xhtml:link rel="alternate" hreflang="de-DE" href="https://www.host.com/de/brine"/>
+      <xhtml:link rel="alternate" hreflang="x-default" href="https://host.com/pear"/>
       <lastmod>2019-12-04</lastmod>
      </url>`
     ))
   })
 
-  it('Should create a correct sitemap entry with localization with binding address querystring', async () => {
+  it('Should create a correct sitemap entry with localization with binding address querystring (self + x-default)', async () => {
     const alternates: AlternateRoute[] = [
       {
         bindingId: '1',
@@ -209,11 +211,122 @@ describe('Test sitemap entry', () => {
     expect(removeSpaces(entry)).toStrictEqual(removeSpaces(
     `<url>
       <loc>https://host.com/pear?__bindingAddress=www.host.com/es</loc>
+      <xhtml:link rel="alternate" hreflang="en-US" href="https://host.com/pear?__bindingAddress=www.host.com/es"/>
       <xhtml:link rel="alternate" hreflang="pt-BR" href="https://host.com/pera?__bindingAddress=www.host.com/br"/>
       <xhtml:link rel="alternate" hreflang="de-DE" href="https://host.com/brine?__bindingAddress=www.host.com/de"/>
+      <xhtml:link rel="alternate" hreflang="x-default" href="https://host.com/pear?__bindingAddress=www.host.com/es"/>
       <lastmod>2019-12-04</lastmod>
      </url>`
     ))
+  })
+
+  it('Should emit no alternates for a single-binding store (US-3 negative case)', async () => {
+    const alternates: AlternateRoute[] = [
+      {
+        bindingId: '1',
+        path: '/pear',
+      },
+    ]
+    const route: Route = {
+      ...defaultRoute,
+      alternates,
+    }
+    const singleBindingContext = {
+      ...context,
+      state: {
+        ...context.state,
+        matchingBindings: [
+          {
+            canonicalBaseAddress: 'www.host.com',
+            defaultLocale: 'en-US',
+            id: '1',
+          },
+        ] as any[],
+      },
+    }
+    const entry = URLEntry(singleBindingContext, route, defaultLastUpdated)
+    expect(entry).not.toContain('xhtml:link')
+    expect(entry).not.toContain('x-default')
+  })
+
+  it('Should emit x-default pointing at the default binding even when current binding is not the default (US-3)', async () => {
+    const alternates: AlternateRoute[] = [
+      {
+        bindingId: '1',
+        path: '/pear',
+      },
+      {
+        bindingId: '2',
+        path: '/pera',
+      },
+      {
+        bindingId: '3',
+        path: '/brine',
+      },
+    ]
+    const route: Route = {
+      ...defaultRoute,
+      alternates,
+    }
+    const ptBrCurrent = {
+      ...context,
+      state: {
+        ...context.state,
+        binding: { id: '2' } as any,
+      },
+    }
+    const entry = URLEntry(ptBrCurrent, route, defaultLastUpdated)
+    // self alternate uses forwardedHost
+    expect(entry).toContain(
+      '<xhtml:link rel="alternate" hreflang="pt-BR" href="https://host.com/pera"/>'
+    )
+    // x-default points at the FIRST matching binding (default), via its canonicalBaseAddress
+    expect(entry).toContain(
+      '<xhtml:link rel="alternate" hreflang="x-default" href="https://www.host.com/pear"/>'
+    )
+  })
+
+  it('Should emit changefreq and priority tags when the route declares them (FR-5)', async () => {
+    const route: Route = {
+      ...defaultRoute,
+      changefreq: 'daily',
+      priority: 0.8,
+    }
+    const singleBindingContext = {
+      ...context,
+      state: {
+        ...context.state,
+        matchingBindings: [
+          {
+            canonicalBaseAddress: 'www.host.com',
+            defaultLocale: 'en-US',
+            id: '1',
+          },
+        ] as any[],
+      },
+    }
+    const entry = URLEntry(singleBindingContext, route, defaultLastUpdated)
+    expect(entry).toContain('<changefreq>daily</changefreq>')
+    expect(entry).toContain('<priority>0.8</priority>')
+  })
+
+  it('Should NOT emit changefreq/priority when the route omits them (backwards compat invariant 7)', async () => {
+    const singleBindingContext = {
+      ...context,
+      state: {
+        ...context.state,
+        matchingBindings: [
+          {
+            canonicalBaseAddress: 'www.host.com',
+            defaultLocale: 'en-US',
+            id: '1',
+          },
+        ] as any[],
+      },
+    }
+    const entry = URLEntry(singleBindingContext, defaultRoute, defaultLastUpdated)
+    expect(entry).not.toContain('<changefreq>')
+    expect(entry).not.toContain('<priority>')
   })
 
   it('Should create a correct sitemap entry with root path', async () => {

--- a/node/middlewares/sitemapEntry.ts
+++ b/node/middlewares/sitemapEntry.ts
@@ -8,43 +8,134 @@ import { SitemapEntry } from './generateMiddlewares/utils'
 const getBinding = (bindingId: string, bindings: Binding[]) =>
   bindings.find(binding => binding.id === bindingId)
 
+// Default binding identification: prefer the first store-targeted binding, fall
+// back to the first binding in the matching list. This is the same convention
+// used by `resources/bindings.ts` (the "first store binding" fallback path).
+const getDefaultMatchingBinding = (
+  matchingBindings: Binding[]
+): Binding | undefined =>
+  matchingBindings.find(b => b.targetProduct === 'vtex-storefront') ??
+  matchingBindings[0]
+
+interface LocaleHrefArgs {
+  alternate: AlternateRoute
+  alternateBinding: Binding
+  bindingAddress?: string
+  currentBindingId: string
+  forwardedHost: string
+  rootPath: string
+}
+
+const buildLocaleHref = ({
+  alternate,
+  alternateBinding,
+  bindingAddress,
+  currentBindingId,
+  forwardedHost,
+  rootPath,
+}: LocaleHrefArgs): string => {
+  if (alternate.bindingId === currentBindingId) {
+    const querystring = bindingAddress
+      ? `?__bindingAddress=${bindingAddress}`
+      : ''
+    return `https://${forwardedHost}${rootPath}${alternate.path}${querystring}`
+  }
+  if (bindingAddress) {
+    return `https://${forwardedHost}${alternate.path}?__bindingAddress=${alternateBinding.canonicalBaseAddress}`
+  }
+  return `https://${alternateBinding.canonicalBaseAddress}${alternate.path}`
+}
+
+const buildLocalization = (
+  ctx: Context,
+  route: Route
+): string => {
+  const {
+    state: {
+      binding,
+      bindingAddress,
+      forwardedHost,
+      rootPath,
+      matchingBindings,
+    },
+  } = ctx
+
+  // Single-binding store → emit no alternates (behavior preserved).
+  if (!matchingBindings || matchingBindings.length <= 1) {
+    return ''
+  }
+  if (!route.alternates || route.alternates.length === 0) {
+    return ''
+  }
+
+  const lines: string[] = []
+  for (const alternate of route.alternates) {
+    const alternateBinding = getBinding(alternate.bindingId, matchingBindings)
+    if (!alternateBinding) {
+      continue
+    }
+    const href = buildLocaleHref({
+      alternate,
+      alternateBinding,
+      bindingAddress,
+      currentBindingId: binding.id,
+      forwardedHost,
+      rootPath,
+    })
+    const locale = alternateBinding.defaultLocale
+    lines.push(
+      `<xhtml:link rel="alternate" hreflang="${locale}" href="${href}"/>`
+    )
+  }
+
+  const defaultBinding = getDefaultMatchingBinding(matchingBindings)
+  if (defaultBinding) {
+    const defaultAlternate =
+      route.alternates.find(a => a.bindingId === defaultBinding.id) ??
+      ({ bindingId: defaultBinding.id, path: route.path } as AlternateRoute)
+    const defaultHref = buildLocaleHref({
+      alternate: defaultAlternate,
+      alternateBinding: defaultBinding,
+      bindingAddress,
+      currentBindingId: binding.id,
+      forwardedHost,
+      rootPath,
+    })
+    lines.push(
+      `<xhtml:link rel="alternate" hreflang="x-default" href="${defaultHref}"/>`
+    )
+  }
+
+  return lines.join('\n')
+}
+
 export const URLEntry = (
   ctx: Context,
   route: Route,
   lastUpdated: string
 ): string => {
-  const { state: {
-    binding,
-    bindingAddress,
-    forwardedHost,
-    rootPath,
-    matchingBindings,
-  },
+  const {
+    state: { bindingAddress, forwardedHost, rootPath },
   } = ctx
   const querystring = bindingAddress
     ? `?__bindingAddress=${bindingAddress}`
     : ''
   const loc = `https://${forwardedHost}${rootPath}${route.path}${querystring}`
-  const localization = route.alternates && route.alternates.length > 1
-    ? route.alternates.map(
-      ({ bindingId, path }) => {
-        const alternateBinding = getBinding(bindingId, matchingBindings)
-        if (bindingId === binding.id || !alternateBinding) {
-            return ''
-          }
-          const { canonicalBaseAddress, defaultLocale: locale } = alternateBinding
-          const href = querystring
-            ? `https://${forwardedHost}${path}?__bindingAddress=${canonicalBaseAddress}`
-            : `https://${canonicalBaseAddress}${path}`
-          return `<xhtml:link rel="alternate" hreflang="${locale}" href="${href}"/>`
-        }
-       )
-      .join('\n')
+  const localization = buildLocalization(ctx, route)
+  const lastmodValue = route.lastmod || lastUpdated
+  const changefreqTag = route.changefreq
+    ? `<changefreq>${route.changefreq}</changefreq>`
     : ''
+  const priorityTag =
+    typeof route.priority === 'number'
+      ? `<priority>${route.priority.toFixed(1)}</priority>`
+      : ''
   let entry = `
       <loc>${loc}</loc>
       ${localization}
-      <lastmod>${lastUpdated}</lastmod>
+      <lastmod>${lastmodValue}</lastmod>
+      ${changefreqTag}
+      ${priorityTag}
     `
   if (route.imagePath && route.imageTitle) {
     // add image metainfo

--- a/node/middlewares/sitemapEntry.ts
+++ b/node/middlewares/sitemapEntry.ts
@@ -2,7 +2,12 @@ import { Binding } from '@vtex/api'
 import * as cheerio from 'cheerio'
 import RouteParser from 'route-parser'
 
-import { SITEMAP_URL } from '../utils'
+import {
+  CMS_ROUTES_PREFIX,
+  getBucket,
+  hashString,
+  SITEMAP_URL,
+} from '../utils'
 import { SitemapEntry } from './generateMiddlewares/utils'
 
 const getBinding = (bindingId: string, bindings: Binding[]) =>
@@ -165,7 +170,7 @@ export async function sitemapEntry(ctx: Context, next: () => Promise<void>) {
 async function legacySitemapEntry(ctx: Context) {
   const {
     clients: { vbase },
-    state: { forwardedPath, bucket },
+    state: { forwardedPath, bucket, binding, settings },
     vtex: { logger },
   } = ctx
 
@@ -196,11 +201,23 @@ async function legacySitemapEntry(ctx: Context) {
   )
 
   const fileName = path.split('.')[0]
-  const maybeRoutesInfo = await vbase.getJSON<SitemapEntry>(
+  let maybeRoutesInfo = await vbase.getJSON<SitemapEntry>(
     bucket,
     fileName,
     true
   )
+
+  // Fall back to the cms-routes bucket — CMS sub-sitemaps live in their own
+  // dedicated bucket (Decision 1), so requests for `/sitemap/cms-routes-N.xml`
+  // do not find a match in the production bucket above.
+  if (!maybeRoutesInfo && settings?.enableCmsRoutes && binding?.id) {
+    const cmsBucket = getBucket(CMS_ROUTES_PREFIX, hashString(binding.id))
+    maybeRoutesInfo = await vbase.getJSON<SitemapEntry>(
+      cmsBucket,
+      fileName,
+      true
+    )
+  }
 
   if (!maybeRoutesInfo) {
     ctx.status = 404

--- a/node/service.json
+++ b/node/service.json
@@ -45,6 +45,10 @@
       "sender": "vtex.store-sitemap",
       "keys": ["sitemap.generate:apps-routes"]
     },
+    "generateCmsRoutes": {
+      "sender": "vtex.store-sitemap",
+      "keys": ["sitemap.generate:cms-routes"]
+    },
     "groupEntries": {
       "sender": "vtex.store-sitemap",
       "keys": ["sitemap.generate:group-entries"]

--- a/node/services/routes.ts
+++ b/node/services/routes.ts
@@ -1,6 +1,7 @@
 import { Internal, ListInternalsResponse } from 'vtex.rewriter'
 import { flatten } from 'ramda'
 
+import { isValidCmsRoute } from '../middlewares/generateMiddlewares/generateCmsRoutes'
 import { SitemapIndex } from '../middlewares/generateMiddlewares/utils'
 import { EXTENDED_INDEX_FILE, getBucket, hashString } from '../utils'
 
@@ -112,4 +113,30 @@ export async function getAppsRoutes(ctx: Context) {
   )
 
   return flatten<string>(routes)
+}
+
+/**
+ * Return the flat list of CMS-origin route paths that pass the CMS sitemap
+ * filter. Mirrors `getUserRoutes` shape (paths across all bindings) so it can
+ * be embedded directly in the `customRoutes` JSON cache.
+ *
+ * Filter logic is shared with `generateCmsRoutes` (the XML pipeline) via
+ * `isValidCmsRoute`, keeping both views consistent (invariant 6 — determinism).
+ */
+export async function getCmsRoutes(ctx: Context): Promise<string[]> {
+  const {
+    state: { settings },
+  } = ctx
+
+  // When the rollout flag is off this feature behaves as if it did not exist
+  // (invariant 9 — settings gating); skip the Rewriter calls entirely.
+  if (!settings?.enableCmsRoutes) {
+    return []
+  }
+
+  const disableRoutesTerm = settings.disableRoutesTerm || ''
+  const internalRoutes = await fetchInternalRoutes(ctx, LIST_LIMIT)
+  return internalRoutes
+    .filter(internal => isValidCmsRoute(internal, disableRoutesTerm))
+    .map(internal => internal.from)
 }

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -15,6 +15,12 @@ export const CUSTOM_ROUTES_BUCKET = 'custom-routes'
 export const CUSTOM_ROUTES_FILENAME = 'custom-routes.json'
 export const CUSTOM_ROUTES_GENERATION_LOCK_FILENAME = 'generation-lock.json'
 
+// CMS routes — per Google's sitemap protocol limits (50k URLs / 50 MB per file).
+// These ceilings drive the chunking in generateCmsRoutes.
+export const CMS_ROUTES_MAX_URLS_PER_FILE = 50000
+export const CMS_ROUTES_MAX_BYTES_PER_FILE = 50 * 1024 * 1024
+export const CMS_ROUTES_PREFIX = 'cms-routes'
+
 export const TENANT_CACHE_TTL_S = 60 * 10
 
 export const STORE_PRODUCT = 'vtex-storefront'

--- a/specs/cms-routes-in-sitemap-for-faststore.md
+++ b/specs/cms-routes-in-sitemap-for-faststore.md
@@ -1,0 +1,392 @@
+# Include CMS routes in Sitemap generation for FastStore
+
+> **Status**: Draft
+> **Created**: 2026-05-27
+> **Jira**: [SFS-3123](https://vtex-dev.atlassian.net/browse/SFS-3123)
+> **PRD**: [Sitemap generation in FastStore](https://docs.google.com/document/d/18QrjAJmGpfLJCW-br5a2Tw-rAvC57biKAl5Z2_4djiM/edit)
+> **Related**: [Known Issue — Native sitemap is not fully integrated with FastStore](https://help.vtex.com/known-issues/native-sitemap-is-not-fully-integrated-with-faststore--5IrsqCEtQKPFstqywlV7Nn)
+
+## Assumptions
+
+These assumptions guide this spec; revisit during review if they change.
+
+- **Implementation repo**: `vtex.store-sitemap` (this repo). The IO app is extended to source CMS routes from VTEX Rewriter and expose them through the existing `/_v/public/sitemap/*` and `/sitemap*.xml` pipelines that FastStore already consumes. Changes inside the FastStore project (Next.js side) are out of scope of this spec.
+- **CMS source**: VTEX **headless CMS (hCMS)**, whose pages are persisted as Rewriter `Internal` entries (the same store of record already used by `generateRewriterRoutes` and `customRoutes`). External CMSs (Contentful, etc.) are out of scope.
+- **Multi-binding/locale strategy** (subfolder vs. subdomain) is owned by the [Multi-bindings Sitemap Support](https://docs.google.com/document/d/12NfWIF9boKgOSh3u4BqwSSJkwB7cm9PG7iBUAJ0QzGQ/edit?tab=t.yfo5oamq0rgl) spec. This document defines only the **shape** of multi-locale output (hreflang/x-default tags per URL entry), not how bindings are resolved.
+
+---
+
+## 1. Business Context
+
+### Problem Statement
+
+Stores running **FastStore** (Next.js storefront) do not have a native, integrated way to generate and keep their `sitemap.xml` up to date. The current solution — the IO Sitemap app (this repo) — was designed for Store Framework with Site Editor and does **not** include pages created via VTEX CMS / hCMS. As a result, merchants resort to manual workarounds with high maintenance cost:
+
+- Combining the IO Sitemap with the `next-sitemap` plugin and custom rewrites in the store repository
+- Manually downloading product/category data, running scripts, and editing `sitemap.xml` by hand whenever CMS pages change
+
+Any content change (a new category, product, or CMS page) requires a developer to regenerate and republish the sitemap, creating ongoing overhead and risk of stale sitemaps — which hurts the store's SEO. This is a publicly mapped Known Issue impacting customers like **Hearst, ODP, JW Pepper and Americanas**.
+
+In parallel, a multi-language / multi-currency evolution is underway in FastStore that demands that each URL declare its locale alternates in the sitemap.
+
+### Goals
+
+- FastStore stores expose a single, automatically maintained sitemap that **includes all CMS/hCMS pages** alongside framework-generated pages (PDPs, PLPs, landing pages, and any custom-slug page).
+- The merchant can **opt a page out of the sitemap from the CMS** without code changes.
+- The generated sitemap follows the Google sitemap protocol — including `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>`, the **50,000 URL / 50 MB chunking limit**, and a `robots.txt` entry pointing to it.
+- For multi-locale stores, each URL declares all locale alternates via `xhtml:link` `hreflang` tags, including `x-default`.
+- Eliminate the manual workarounds described in the Problem Statement for the customers listed above and equivalent FastStore tenants.
+
+### User Stories
+
+#### US-1: Merchant — CMS pages appear in the sitemap
+
+- **Story**: As a merchant on FastStore, I want every page I publish in the CMS (PDP, PLP, landing page or custom-slug page) to automatically appear in my store sitemap, so that Google can discover and index it without me editing files.
+- **Acceptance Criteria**:
+  - **Given** a published CMS page with a custom slug `/our-story`, **when** the sitemap is regenerated, **then** `https://{store}/our-story` appears as a `<url>` entry in the served sitemap.
+  - **Given** a published CMS-defined PLP at `/black-friday`, **when** the sitemap is regenerated, **then** the URL is present **and** is not duplicated by an automatically generated category URL.
+  - **Given** a CMS page is unpublished or deleted, **when** the next regeneration completes, **then** the URL is removed from the served sitemap.
+
+#### US-2: Merchant — Opt a page out of the sitemap
+
+- **Story**: As a merchant, I want a per-page toggle in the CMS to exclude a specific page from the sitemap, so that I can keep internal/test pages out of search engine indexes without losing the page itself.
+- **Acceptance Criteria**:
+  - **Given** a CMS page where the "Include in sitemap" toggle is **on** (the default), **when** the sitemap is regenerated, **then** the URL is included.
+  - **Given** a CMS page where the toggle is **off**, **when** the sitemap is regenerated, **then** the URL is excluded.
+  - **Given** a CMS page configured with `noindex`, **canonical pointing to a different URL**, or marked as a **login / error page**, **when** the sitemap is regenerated, **then** the URL is excluded regardless of the toggle.
+
+#### US-3: SEO operator — Multi-locale alternates
+
+- **Story**: As an SEO operator for a multi-language store, I want each URL in the sitemap to declare its alternate locale versions, so that Google serves the correct localized URL to each user.
+- **Acceptance Criteria**:
+  - **Given** a page `/about` exists in locales `en-US`, `pt-BR`, `es-ES`, **when** the sitemap is served, **then** the `<url>` entry for the `en-US` version contains three `<xhtml:link rel="alternate" hreflang="..." href="..."/>` tags — **one for each locale, including itself** — plus one `hreflang="x-default"` pointing to the store's default locale version.
+  - **Given** a single-locale store, **when** the sitemap is served, **then** no `<xhtml:link>` tags are emitted.
+  - **Given** a page exists only in `en-US`, **when** the sitemap is served, **then** that URL declares no alternates beyond `x-default` (which equals itself).
+
+#### US-4: SEO operator — Spec-compliant sitemap
+
+- **Story**: As an SEO operator, I want the generated sitemap to respect Google's protocol, so that no manual chunking or `robots.txt` edits are needed.
+- **Acceptance Criteria**:
+  - **Given** the store has more than 50,000 indexable URLs **or** a sub-sitemap would exceed 50 MB, **when** the sitemap is generated, **then** it is automatically chunked into multiple sub-sitemaps referenced by a top-level `<sitemapindex>`.
+  - **Given** any `<url>` entry, **when** the sitemap is served, **then** it contains `<loc>`, `<lastmod>`, `<changefreq>` and `<priority>` tags with valid values.
+  - **Given** the store has a sitemap, **when** `GET /robots.txt` is served, **then** it contains a `Sitemap: https://{store}/sitemap.xml` directive.
+
+#### US-5: Developer / Integrator — Programmatic access to CMS-included routes
+
+- **Story**: As a FastStore developer building or migrating a store, I want to fetch the list of CMS-backed routes via a public JSON endpoint, so that I can use them in build-time or runtime sitemap composition if needed.
+- **Acceptance Criteria**:
+  - **Given** the store has CMS pages, **when** I `GET /_v/public/sitemap/custom-routes`, **then** the response includes a section listing CMS-backed routes (in addition to existing `apps-routes` and `user-routes`).
+  - **Given** the response is cached, **when** I make multiple requests within the cache window, **then** I receive the same data without triggering regeneration.
+
+### Key Scenarios
+
+| Scenario | Pre-conditions | Steps | Expected Result |
+|---|---|---|---|
+| Happy path — CMS page included | FastStore store with hCMS active; merchant publishes `/our-mission` with default toggle | Sitemap regeneration runs (scheduled or triggered) | `/our-mission` appears with `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>` in the served sitemap |
+| Happy path — Multi-locale page | Store with `en-US` (default), `pt-BR`, `es-ES`; page `/about` exists in all three | Sitemap is served | `<url>` entry contains 3 `<xhtml:link>` alternates + 1 `x-default` |
+| Error — Canonical to external URL | CMS page `/promo-old` has canonical → `/promo-new` | Sitemap regeneration runs | `/promo-old` is excluded; `/promo-new` is included (if eligible) |
+| Error — Rewriter unavailable | Rewriter GraphQL is failing during generation | Sitemap regeneration is triggered | Generation retries (per existing `listInternalsWithRetry`), logs `cms-routes-generation-error`, and falls back to the **previous successful sitemap**; served XML does not regress to empty |
+| Edge — Chunking boundary (>50k URLs) | Store has 120,000 indexable URLs | Sitemap regeneration runs | Top-level `<sitemapindex>` references three sub-sitemap files (`50k + 50k + 20k`), all linked from `/sitemap.xml`; `robots.txt` references the index |
+| Edge — Toggle off + multi-locale | `/secret` toggle is off in locale `en-US` only | Sitemap is served | `/secret` is fully excluded across all locales (a page hidden in any locale is treated as not-in-sitemap for all alternates) |
+| Edge — CMS page conflicts with auto route | A CMS page `/p/12345` overrides an auto-generated product URL with same path | Sitemap regeneration runs | A single entry is emitted (deduplicated); CMS metadata (`lastmod`, toggle) takes precedence over the auto-generated one |
+
+### Functional Requirements
+
+**FR-1 — CMS route ingestion**
+The generator MUST source CMS-published routes (Rewriter Internals whose origin is `hcms` / `cms`) and include them in the sitemap together with framework-generated PDPs, PLPs and landing pages.
+
+**FR-2 — Per-page CMS toggle**
+The CMS MUST surface a boolean configuration field "Include in sitemap" (default `true`) that, when `false`, causes the route to be omitted from the sitemap. The generator MUST honor this flag (mapped onto Rewriter `disableSitemapEntry` or an equivalent attribute — see [Decision 3](#decision-3-cms-toggle--persistence-model)).
+
+**FR-3 — Mandatory exclusions**
+The generator MUST exclude:
+- Pages classified as login pages
+- Pages declaring `noindex` (robots meta or page setting)
+- Pages whose canonical URL points to a **different** URL
+- Pages classified as error pages (e.g., `notFound*`)
+
+**FR-4 — Multi-locale alternates**
+For each indexable URL in a multi-locale store, the generator MUST emit one `<xhtml:link rel="alternate" hreflang="{locale}" href="{href}"/>` per locale version (including the URL itself) **and** one `<xhtml:link rel="alternate" hreflang="x-default" href="{defaultHref}"/>` pointing to the store's default locale version.
+
+**FR-5 — Sitemap protocol tags**
+Each `<url>` entry MUST contain `<loc>`, `<lastmod>`, `<changefreq>` and `<priority>` with valid values per [sitemaps.org/protocol](https://www.sitemaps.org/protocol.html).
+
+**FR-6 — Chunking**
+The generator MUST split content into multiple sub-sitemap files whenever a single file would exceed **50,000 URLs** or **50 MB uncompressed**, exposing them through a top-level `<sitemapindex>` at `/sitemap.xml`.
+
+**FR-7 — `robots.txt` integration**
+The `/robots.txt` served by this app MUST contain a `Sitemap:` directive pointing to the canonical `https://{host}/sitemap.xml` for the current binding.
+
+**FR-8 — Public JSON endpoint**
+The existing `/_v/public/sitemap/custom-routes` endpoint MUST expose CMS-backed routes alongside the current `apps-routes` and `user-routes` sections.
+
+### Non-Functional Requirements
+
+- **Performance**: Full regeneration for a store with 100k URLs and 3 locales completes within the existing background-generation budget (target: ≤ 30 min, matching today's documented ≈ 30 min for 60k products). No additional synchronous load on the sitemap serve path.
+- **Cacheability**: Served XML continues to honor existing cache-control rules (long cache control for the `customRoutes` route, public for `robots`). The CMS toggle changes propagate at most within the existing generation cadence (≤ 1 day stale window, mirroring the `customRoutes` cache).
+- **Reliability**: Generation failures MUST NOT cause the served sitemap to regress to empty; the previous successful version remains available until a new one is produced (current VBase-cached behavior).
+- **Observability**: Every regeneration emits structured logs and metrics: counts per source (CMS, product, navigation, apps), exclusion counters per reason (`noindex`, `canonical-mismatch`, `login`, `error`, `toggle-off`), and chunking outcome.
+- **Backwards compatibility**: Existing consumers of `/sitemap.xml`, `/sitemap/*.xml`, `/robots.txt`, and `/_v/public/sitemap/custom-routes` MUST continue to work without contract-breaking changes. The CMS-routes addition is additive.
+- **Security**: No new outbound network policies beyond what hCMS access (via Rewriter / existing GraphQL apps) already requires.
+
+### Out of Scope
+
+- Multi-locale support for **non-CMS, framework-generated routes** (PDP/PLP/department auto-routes) — owned by the Store Framework Multi-bindings work referenced in the PRD.
+- Image and video sub-sitemaps.
+- Gzip compression of sitemap files.
+- Changes to the FastStore Next.js project (`next-sitemap` removal, rewrites cleanup, etc.) — only the IO-side API changes.
+- A new admin UI inside the IO app for sitemap content (configuration continues to live in the CMS and in the existing settings schema).
+- Migration tooling for stores currently using the `next-sitemap` workaround.
+
+---
+
+## 2. Arch Decisions
+
+### Proposed Solution
+
+Extend the existing `vtex.store-sitemap` IO app to treat **CMS-published routes as a first-class route source**, alongside the current product, navigation and apps sources. Concretely:
+
+1. **Source layer** — Add a `generateCmsRoutes` middleware (sibling to `generateRewriterRoutes`/`generateAppsRoutes`/`generateProductRoutes`) that fetches CMS-origin Rewriter Internals and stores them in a dedicated VBase bucket using the existing `SitemapEntry`/`SitemapIndex` shape. CMS pages already flow through Rewriter today (the same mechanism that backs `generateRewriterRoutes`), so the change is primarily about **classifying, filtering and enriching** those entries rather than fetching from a new system. If hCMS exposes additional metadata (canonical, noindex, login/error flags, `includeInSitemap` toggle) that Rewriter does not currently carry, those fields are materialized at generation time via a thin hCMS client (see [Decision 3](#decision-3-cms-toggle--persistence-model)).
+2. **Entry shape** — Reuse the `URLEntry` builder in `sitemapEntry.ts` and extend it to emit `<changefreq>`, `<priority>` and a full `xhtml:link` alternate set including `x-default`. Today only a partial alternate set is emitted (and only when the binding differs from the current one).
+3. **Index layer** — Use the existing `<sitemapindex>` composition (`sitemap.ts`) to glue the new `cms-routes` index into the served `/sitemap.xml`. The 50k / 50 MB chunking rule replaces the current per-entity `5k` limit for CMS entries.
+4. **Public endpoint** — Augment the `customRoutes` middleware response with a `cms-routes` section. The shape is **additive** (new entry in the existing array), preserving backwards compatibility.
+5. **`robots.txt`** — Add a single `Sitemap:` directive at the end of the served `robots.txt` (or merge into existing per-binding overrides). Avoid duplicates when the merchant already added one.
+
+The current cache (1 day fresh / 23 h lock) and stale-while-revalidate semantics documented in [`docs/CUSTOM_ROUTES_ARCHITECTURE.md`](../docs/CUSTOM_ROUTES_ARCHITECTURE.md) are reused as-is.
+
+### Architecture Overview
+
+```mermaid
+flowchart LR
+    subgraph CMS[VTEX hCMS]
+      direction TB
+      CmsPage[CMS Page<br/>slug, locale, includeInSitemap,<br/>noindex, canonical, type]
+    end
+
+    subgraph Rewriter[VTEX Rewriter]
+      InternalRoute[Internal route<br/>from, type, binding,<br/>disableSitemapEntry,<br/>endDate, imagePath]
+    end
+
+    CmsPage -->|published| InternalRoute
+
+    subgraph App[vtex.store-sitemap IO app]
+      direction TB
+      GenCms[generateCmsRoutes<br/>middleware]
+      GenProd[generateProductRoutes]
+      GenNav[generateRewriterRoutes]
+      GenApps[generateAppsRoutes]
+      GroupEntries[groupEntries<br/>chunks 50k/50MB]
+      VBase[(VBase<br/>cms-routes bucket<br/>+ existing buckets)]
+      SitemapMW[sitemap middleware<br/>builds sitemap.xml]
+      EntryMW[sitemapEntry middleware<br/>builds /sitemap/*.xml]
+      RobotsMW[robots middleware]
+      CustomRoutesMW[customRoutes middleware<br/>/_v/public/sitemap/custom-routes]
+    end
+
+    InternalRoute --> GenCms
+    GenCms --> GroupEntries
+    GenProd --> GroupEntries
+    GenNav --> GroupEntries
+    GenApps --> GroupEntries
+    GroupEntries --> VBase
+
+    VBase --> SitemapMW
+    VBase --> EntryMW
+    VBase --> CustomRoutesMW
+
+    subgraph FastStore[FastStore storefront]
+      Browser[Search engines / Browsers]
+    end
+
+    Browser -->|GET /sitemap.xml| SitemapMW
+    Browser -->|GET /sitemap/*.xml| EntryMW
+    Browser -->|GET /robots.txt| RobotsMW
+    FastStore -->|GET /_v/public/sitemap/custom-routes| CustomRoutesMW
+```
+
+### Alternatives Considered
+
+| Alternative | Pros | Cons | Verdict |
+|---|---|---|---|
+| **Generate sitemap entirely client-side in FastStore (via `next-sitemap`)** | No IO changes; lives next to the storefront codebase | Reproduces today's manual workaround; requires storefront developers per change; can't easily incorporate Rewriter/Apps routes; no central caching | Rejected — recreates the original problem |
+| **Standalone microservice for FastStore sitemap** | Clean separation; can be optimized for FastStore | Re-implements infrastructure already present here (VBase caching, locking, Rewriter integration, multi-binding, robots); fragments the contract | Rejected — duplication and ops cost |
+| **Extend `vtex.store-sitemap` (this proposal)** | Reuses caching, locking, multi-binding logic, `customRoutes` endpoint, robots; already serves IO traffic for FastStore stores | Couples FastStore evolution to an IO app currently shared with Store Framework | **Accepted** — lowest risk, highest reuse |
+| **Source CMS directly via hCMS API (bypass Rewriter)** | Single source of truth for CMS metadata (`noindex`, canonical, toggle) | Bypasses Rewriter's existing publish/translate/multi-binding plumbing; duplicates URL resolution logic | Partially accepted — Rewriter is the primary source; hCMS is queried only for metadata fields Rewriter does not carry (see [Decision 3](#decision-3-cms-toggle--persistence-model)) |
+
+### Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|---|---|---|---|
+| Sitemap explosion (CMS adds tens of thousands of pages) | Medium | Medium | Reuse `groupEntries`-style chunking with 50k/50 MB limits; emit metrics on counts; document a cap warning |
+| Rewriter pagination timeouts during generation | High | Low–Medium | Already mitigated by `listInternalsWithRetry`; extend retry to the CMS-metadata fetch path and keep fallback to previous successful VBase entry |
+| Duplicate URLs between CMS and auto-generated sources | Medium | Medium | Deduplicate by canonical URL during `groupEntries`; CMS metadata wins ties (see [Decision 4](#decision-4-deduplication-and-precedence)) |
+| Backwards-incompatible change to `customRoutes` response | High | Low | Add `cms-routes` as a **new** entry in the existing array; do not modify shape of existing entries |
+| Multi-locale alternate explosion (Cartesian growth with locales × URLs) | Medium | Low–Medium | Cap alternate-set generation to declared store locales (not arbitrary CMS locales); skip alternates for single-locale stores |
+| `disableRoutesTerm` interaction (existing substring exclude) | Low | Low | Apply the existing `disableRoutesTerm` to CMS routes too, for consistency with `generateRewriterRoutes` |
+| `robots.txt` duplicate Sitemap entries | Low | Medium | Detect existing `Sitemap:` directives in custom robots (per-binding) before appending |
+
+### Key Decisions
+
+#### Decision 1: New route source plugged into the existing pipeline (vs. a parallel sitemap pipeline)
+
+- **Status**: Accepted
+- **Context**: We need to add CMS pages to the sitemap. We could either add a new source to the existing pipeline (`generateProductRoutes`, `generateRewriterRoutes`, `generateAppsRoutes`) or build a separate "FastStore sitemap" pipeline.
+- **Decision**: Add a new source — `generateCmsRoutes` — to the existing pipeline. It writes a dedicated VBase bucket using the established `SitemapEntry` / `SitemapIndex` shape, and is composed into `/sitemap.xml` via the same `<sitemapindex>` logic.
+- **Consequences**: Maximum reuse of caching, locking, multi-binding handling, observability and security policies. The trade-off is that FastStore-specific behavior must coexist with Store Framework behavior in the same code; we manage this via clear file boundaries and feature flags in the settings schema.
+
+#### Decision 2: Reuse the `<sitemapindex>` chunking model for the 50k / 50 MB limit
+
+- **Status**: Accepted
+- **Context**: Today, sitemap entries are split per entity type with a per-file limit of 5,000 routes (see README). Google allows up to 50,000 URLs or 50 MB per file. We need to honor that explicitly.
+- **Decision**: Continue producing one file per entity bucket, but raise the per-file budget to Google's protocol limit (50,000 URLs **or** 50 MB serialized, whichever is hit first). The `groupEntries` step splits oversized buckets into numbered files (`cms-routes-1.xml`, `cms-routes-2.xml`, …) and references all of them from the top-level index.
+- **Consequences**: Fewer HTTP round-trips for crawlers; bigger XML payloads per file. Existing 5k-per-file behavior for product/navigation/apps may need to be revisited for consistency, but that's outside this spec.
+
+#### Decision 3: CMS toggle — persistence model
+
+- **Status**: Accepted
+- **Context**: The merchant-visible "Include in sitemap" toggle (default `true`) must be readable by the generator. Today, Rewriter `Internal` already carries `disableSitemapEntry`, populated for legacy Store Framework routes. Surfacing the toggle in the CMS UI and the additional metadata fields (`noindex`, canonical, login/error classification) requires a coordinated change in the hCMS team's surface.
+- **Decision**: Reuse `disableSitemapEntry` as the **wire** for the toggle. The CMS UI writes to Rewriter (the existing CMS-publish path) and sets `disableSitemapEntry = !includeInSitemap`. Additional metadata that Rewriter does not yet carry — `noindex`, `canonical` (when pointing to a different URL), explicit `login`/`error` classification — is fetched from hCMS at generation time and joined by Rewriter `id`. The hCMS UI change and the metadata endpoint contract are tracked as **dependencies on the hCMS team** but do not gate the start of P1; the generator ships defensively (treats missing metadata as "not excluded" and `includeInSitemap = true`) until those fields land.
+- **Consequences**: Avoids a new column/index in Rewriter for FastStore-specific data; keeps the generator's primary loop dependent on Rewriter only. The metadata join introduces a per-page hCMS read during generation — mitigated by batching and the daily generation cadence. Carries a cross-team dependency that must be tracked alongside this spec (separate Jira link to be added once the hCMS counterpart ticket is filed).
+
+#### Decision 4: Deduplication and precedence
+
+- **Status**: Accepted
+- **Context**: A CMS-defined PLP and an auto-generated category page may resolve to the same URL.
+- **Decision**: After all sources produce their entries, `groupEntries` deduplicates by **final URL** (taking the binding/locale into account). When a duplicate is found, the CMS-origin entry wins (its `lastmod`, toggle and metadata are used) because it represents an explicit editorial choice.
+- **Consequences**: Predictable behavior; no double-listing in Google. CMS authors can override auto-routes by republishing through the CMS.
+
+#### Decision 5: Multi-locale shape (hreflang + x-default)
+
+- **Status**: Accepted
+- **Context**: The existing `URLEntry` emits `<xhtml:link>` only for alternates that belong to a **different** binding than the current one, and never emits `x-default`. The ticket requires the full set including self and `x-default`.
+- **Decision**: Update `URLEntry` so that, when more than one matching binding has the same `targetProduct` (i.e., a multi-locale store), it emits **one `<xhtml:link>` per locale including self** and one `hreflang="x-default"` pointing to the default binding's canonical URL.
+- **Consequences**: Slightly larger XML per entry, but aligned with [Google's recommendation](https://developers.google.com/search/docs/specialty/international/localized-versions#example_2). Single-locale stores emit zero alternates (behavior preserved).
+
+#### Decision 6: `robots.txt` Sitemap directive
+
+- **Status**: Accepted
+- **Context**: The current `robots` middleware serves robots content from an app's `build.json` (per binding) and falls back to a legacy source. It does not guarantee a `Sitemap:` directive.
+- **Decision**: The `robots` middleware appends `Sitemap: https://{host}/sitemap.xml` to the served body if one is not already present. The check is case-insensitive and stripped of trailing whitespace.
+- **Consequences**: Merchants who already declared their sitemap manually are unaffected; everyone else gets it for free. No new VBase write.
+
+### Implementation Plan
+
+Phased rollout, each phase independently shippable behind the existing settings schema or new boolean flag (e.g. `enableCmsRoutes`, default `false` until validated):
+
+| Phase | Scope | Outcome |
+|---|---|---|
+| **P1 — Foundation** | New `generateCmsRoutes` middleware + VBase bucket; classification (`type === 'cms'` or equivalent); reuse the existing `customRoutes` lock/cache. Add `enableCmsRoutes` setting to `manifest.json`. | CMS routes can be generated and inspected via VBase; no impact on served XML yet. |
+| **P2 — Public exposure** | Glue `cms-routes` into the served `<sitemapindex>` and expose them in `/_v/public/sitemap/custom-routes`. | FastStore can consume the new section; sitemap reflects CMS pages for opt-in stores. |
+| **P3 — Protocol completeness** | Extend `URLEntry` with `<changefreq>`, `<priority>`, full `xhtml:link` set including `x-default`. Raise per-file limit to 50k/50 MB and apply chunking. | Sitemap is spec-compliant per Google protocol. |
+| **P4 — `robots.txt` directive + exclusions** | Append `Sitemap:` to robots if missing; honor hCMS metadata for `noindex`, canonical-mismatch, login/error classification. | Mandatory exclusions enforced; SEO operators get robots-integrated discovery. |
+| **P5 — Rollout** | Enable `enableCmsRoutes` by default; coordinate with FastStore docs and customer success for Hearst, ODP, JW Pepper and Americanas migration paths. | Replace `next-sitemap` workarounds in customer projects. |
+
+A minor-version bump (e.g., `2.19.0`) on P2 and a major-version bump only if a backwards-incompatible change is unavoidable (none are currently anticipated).
+
+---
+
+## 3. Technical Contract
+
+### Data Models
+
+**CMS route (internal, generator-side)**
+
+```ts
+interface CmsRouteEntry {
+  id: string                       // Rewriter Internal id (stable per CMS page)
+  path: string                     // e.g. "/about", "/black-friday"
+  bindingId: string                // matches Binding.id
+  locale: string                   // e.g. "en-US"; derived from binding.defaultLocale
+  lastmod: string                  // ISO timestamp, UTC
+  changefreq?: ChangeFreq          // see below
+  priority?: number                // 0.0 – 1.0, two decimals
+  includeInSitemap: boolean        // ! Internal.disableSitemapEntry
+  noindex: boolean                 // from hCMS metadata
+  canonical?: string               // from hCMS; when present and != path, route is excluded
+  classification: 'pdp' | 'plp' | 'landing' | 'cms-custom' | 'login' | 'error' | 'other'
+  imagePath?: string
+  imageTitle?: string
+}
+
+type ChangeFreq =
+  | 'always' | 'hourly' | 'daily' | 'weekly'
+  | 'monthly' | 'yearly' | 'never'
+```
+
+**Sitemap entry (persisted in VBase, reuses existing `SitemapEntry`)**
+
+```ts
+interface SitemapEntry {
+  lastUpdated: string
+  routes: Route[]   // existing global Route type; extended below
+}
+
+interface Route {
+  id: string
+  path: string
+  alternates?: AlternateRoute[]
+  imagePath?: string
+  imageTitle?: string
+  // NEW (additive)
+  changefreq?: ChangeFreq
+  priority?: number
+  lastmod?: string  // overrides SitemapEntry.lastUpdated when set
+}
+```
+
+**Public `customRoutes` response (additive)**
+
+```ts
+type CustomRoutesResponse = Array<
+  | { name: 'apps-routes'; routes: string[] }
+  | { name: 'user-routes'; routes: string[] }
+  | { name: 'cms-routes'; routes: string[] }   // NEW
+>
+```
+
+### Interfaces
+
+**HTTP — served by this app**
+
+| Method | Path | Behavior change |
+|---|---|---|
+| `GET` | `/sitemap.xml` | Now includes `cms-routes-*.xml` entries in the top-level `<sitemapindex>`. Each sub-sitemap respects the 50k/50 MB limit. |
+| `GET` | `/sitemap/cms-routes-{n}.xml` | **New** sub-sitemap files. Each `<url>` carries `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>` and (multi-locale only) the full `xhtml:link` set including `hreflang="x-default"`. |
+| `GET` | `/sitemap/*.xml` | Existing sub-sitemaps gain `<changefreq>` and `<priority>` tags and the extended `xhtml:link` set when the store is multi-locale. |
+| `GET` | `/robots.txt` | Adds `Sitemap: https://{host}/sitemap.xml` at the end if not already present. |
+| `GET` | `/_v/public/sitemap/custom-routes` | Response array additionally contains `{ name: 'cms-routes', routes: string[] }` for stores where the source is enabled. |
+
+**Module boundaries — internal**
+
+| Module | Responsibility |
+|---|---|
+| `node/middlewares/generateMiddlewares/generateCmsRoutes.ts` (new) | Pull CMS-origin Rewriter Internals, join with hCMS metadata, write per-binding `SitemapEntry` files into a `cms-routes_*` bucket via `getBucket('cms-routes', hashString(binding.id))`. |
+| `node/services/routes.ts` | Add `getCmsRoutes(ctx)` analogous to `getUserRoutes` / `getAppsRoutes` for use by `generateCustomRoutes` and `customRoutes`. |
+| `node/middlewares/sitemap.ts` | Read the `cms-routes` index file from VBase and append to the `<sitemapindex>`. |
+| `node/middlewares/sitemapEntry.ts` | Extend `URLEntry` with `<changefreq>`, `<priority>`, full alternate set + `x-default`. |
+| `node/middlewares/robots.ts` | Ensure the served body contains a `Sitemap:` directive; idempotent append. |
+| `node/middlewares/customRoutes.ts` | Add `cms-routes` to the cached payload. |
+| `node/clients/hcms.ts` (new, if needed per [Decision 3](#decision-3-cms-toggle--persistence-model)) | Read CMS metadata (`noindex`, canonical, `includeInSitemap`, classification) for a batch of page ids. |
+| `manifest.json` settings schema | New boolean `enableCmsRoutes` (default `false` during rollout; flip to `true` in P5). |
+
+### Integration Points
+
+- **VTEX Rewriter** (`vtex.rewriter`) — primary source of routes. Already consumed via `listInternalsWithRetry`. CMS pages are filtered by `type` (CMS-classified) and by `binding`.
+- **VTEX hCMS** — secondary source for per-page metadata not currently surfaced by Rewriter Internal. Accessed via the relevant CMS GraphQL/REST endpoints (exact host depends on hCMS API, to be confirmed during P1). New `outbound-access` policy may be required in `manifest.json` if not already covered.
+- **Tenant API** (`@vtex/api` `TenantClient`) — already used for binding/locale discovery. No changes.
+- **VBase** — already used. New bucket prefix `cms-routes` per binding; existing buckets unchanged.
+- **`@vtex/api` Logger / Metrics** — emit `cms-routes-generation-*` event types analogous to existing `custom-routes-*`.
+- **FastStore storefront** — consumes `/sitemap.xml` and `/_v/public/sitemap/custom-routes`; no contract break.
+
+### Invariants & Constraints
+
+1. **No empty sitemap regression**: if a regeneration fails, `/sitemap.xml` continues to serve the most recent successful version from VBase.
+2. **Per-file budget**: each sub-sitemap is at most **50,000 URLs** AND at most **50 MB** uncompressed. Exceeding either triggers a new file.
+3. **`includeInSitemap` precedence**: a route with `includeInSitemap = false` (from hCMS) or `disableSitemapEntry = true` (from Rewriter) MUST NOT appear in any served sitemap or in `customRoutes`.
+4. **Exclusion superseding**: if any mandatory exclusion applies (`noindex`, canonical-mismatch, login, error classification), the route is excluded **regardless** of the merchant toggle (i.e., merchant cannot force-include a `noindex` page).
+5. **Locale completeness**: in a multi-locale store, every emitted `<url>` declares alternates for **every store locale where the page exists**, plus `x-default`. Missing locales are silently omitted (not faked).
+6. **Determinism**: two consecutive successful generations on the same Rewriter+hCMS state MUST produce semantically equivalent XML (entry order is not part of the contract, but the set of `<loc>` values is).
+7. **Backwards compatibility**: existing `customRoutes` consumers must continue to work; new entry types are additive. Existing `<url>` entries gain `<changefreq>`/`<priority>` (optional in the protocol) without removing or renaming any tag.
+8. **`robots.txt` idempotency**: the appended `Sitemap:` directive must not duplicate an existing one (case-insensitive match on the URL).
+9. **Settings gating**: when `enableCmsRoutes` is `false`, this feature behaves as if it did not exist (no extra VBase reads, no extra response keys, no extra XML entries) so that the rollout is reversible.
+

--- a/specs/cms-routes-in-sitemap-for-faststore.md
+++ b/specs/cms-routes-in-sitemap-for-faststore.md
@@ -1,6 +1,6 @@
 # Include CMS routes in Sitemap generation for FastStore
 
-> **Status**: Approved
+> **Status**: Done
 > **Created**: 2026-05-27
 > **Jira**: [SFS-3123](https://vtex-dev.atlassian.net/browse/SFS-3123)
 > **PRD**: [Sitemap generation in FastStore](https://docs.google.com/document/d/18QrjAJmGpfLJCW-br5a2Tw-rAvC57biKAl5Z2_4djiM/edit)

--- a/specs/cms-routes-in-sitemap-for-faststore.md
+++ b/specs/cms-routes-in-sitemap-for-faststore.md
@@ -1,6 +1,6 @@
 # Include CMS routes in Sitemap generation for FastStore
 
-> **Status**: Draft
+> **Status**: Approved
 > **Created**: 2026-05-27
 > **Jira**: [SFS-3123](https://vtex-dev.atlassian.net/browse/SFS-3123)
 > **PRD**: [Sitemap generation in FastStore](https://docs.google.com/document/d/18QrjAJmGpfLJCW-br5a2Tw-rAvC57biKAl5Z2_4djiM/edit)


### PR DESCRIPTION
## Summary

Implements [SFS-3123 — Include CMS routes in Sitemap generation for FastStore](https://vtex-dev.atlassian.net/browse/SFS-3123) per the approved spec at `specs/cms-routes-in-sitemap-for-faststore.md` (PR #187).

The whole feature is gated behind a new boolean setting **`enableCmsRoutes`** (default `false`) so the rollout is reversible (invariant 9). When the flag is off, the app behaves byte-for-byte as it did before this change.

### Per user story

- **US-1 / US-2** — new `node/middlewares/generateMiddlewares/generateCmsRoutes.ts` middleware materializes the CMS-routes sitemap source. It pulls Rewriter Internals, classifies routes as CMS-origin by excluding framework-owned types (`product`, `department`, `category`, `subcategory`, `brand`) and `notFound*` pages, mandatorily excludes types containing `login`/`error` substrings (FR-3), honors `disableSitemapEntry` (the merchant toggle — Decision 3), honors the existing `disableRoutesTerm` substring filter, partitions by binding, and chunks into a per-binding `cms-routes_<hash>` bucket using the Google protocol ceilings (`CMS_ROUTES_MAX_URLS_PER_FILE = 50000`, `CMS_ROUTES_MAX_BYTES_PER_FILE = 50 MiB`).
- **US-3 / FR-5** — `URLEntry` in `sitemapEntry.ts` rebuilt: multi-locale stores now declare every locale alternate (including self) plus a `hreflang="x-default"` pointing at the first store binding (Decision 5). Single-binding stores still emit zero alternates (preserves invariant 7). Optional `Route.changefreq` and `Route.priority` are emitted only when set, so existing sources (products / navigation / apps) remain byte-compatible. `generateCmsRoutes` writes CMS routes with safe defaults (`weekly` / `0.5`) so every CMS entry carries the protocol tags as required.
- **US-4** — chunking is built into `generateCmsRoutes` (50k URLs / 50 MB per file) and the served XML wires the cms-routes index into the top-level `<sitemapindex>` via `sitemap.ts`. `robots.ts` gains an `ensureSitemapDirective` helper that idempotently appends `Sitemap: https://{host}/sitemap.xml` whenever the served body does not already contain one (case-insensitive, leading-whitespace-tolerant — invariant 8).
- **US-5** — `services/routes.ts` gets `getCmsRoutes` mirroring the shape of `getUserRoutes`/`getAppsRoutes` (flat path list) and reusing the `isValidCmsRoute` filter exported from `generateCmsRoutes` so the JSON API and the XML pipeline apply the same classification (invariant 6 — determinism). `generateCustomRoutes` now writes a third entry `{ name: 'cms-routes', routes: [...] }` to the VBase cache served by `GET /_v/public/sitemap/custom-routes`. The `customRoutes` middleware filters that section out when `enableCmsRoutes` is off.

### Settings & manifest

`enableCmsRoutes` is added to the `Settings` interface, wired into the existing `INDEX_MAP` so it is reflected in `state.enabledIndexFiles`, and exposed in `manifest.json` with rollout-aware copy. Default is `false`.

## Tests

All new code is covered by jest. Per-suite breakdown:

| Suite | Tests added/touched | Result |
|---|---|---|
| `node/middlewares/generateMiddlewares/generateCmsRoutes.test.ts` (new) | 7 | all pass |
| `node/middlewares/robots.test.ts` (new) | 7 | all pass |
| `node/middlewares/customRoutes.test.ts` | +2 | all pass |
| `node/middlewares/settings.test.ts` | +2 | all pass |
| `node/middlewares/sitemap.test.ts` | +2 + side-effect fix (`isCrossBorder: true`) | 9/9 pass — **unblocked 7 pre-existing failures** |
| `node/middlewares/sitemapEntry.test.ts` | +4 new + 2 updated | 9/12 pass — 3 pre-existing failures in unrelated `catalogSitemapEntry` path remain |

**Suite-level delta vs `master`:**

| | Baseline | This PR | Delta |
|---|---|---|---|
| Suites: PASS / FAIL | 8 / 6 | 11 / 5 | **+3 PASS, −1 FAIL** |
| Tests: PASS / FAIL | 49 / 20 | 80 / 13 | **+31 PASS, −7 FAIL** |

The 13 remaining failing tests (in `utils.test.ts`, `generateRewriterRoutes.test.ts`, `generateSitemap.test.ts`, `prepare.test.ts`, `sitemapEntry.test.ts`) are all pre-existing on `master` and unrelated to this change — verified by checking out `master` and re-running the suite.

Lint (`yarn lint` in `node/`) shows the same 10 errors on this branch as on `master` (in `node_modules` typings for `@opentelemetry` and `axios` that `typescript@3.9.7` cannot parse). Not in scope of this PR.

## Assumptions

- The implementation targets this repo (`vtex.store-sitemap` IO app); changes inside FastStore Next.js projects are out of scope. Recorded explicitly in the spec.
- CMS classification today uses Rewriter `type` heuristics (CMS-origin = anything that is not `product` / `department` / `category` / `subcategory` / `brand` / `notFound*`). Per-page hCMS metadata (`noindex`, canonical, explicit classification) is **not yet available** — see "Deviations".
- Default binding for `hreflang="x-default"` = first binding in `matchingBindings` with `targetProduct === 'vtex-storefront'`, falling back to `matchingBindings[0]`. Same convention used by `resources/bindings.ts`.

## Deviations

- **Decision 3 — hCMS metadata join is not implemented**. Per the spec's own defensive default (Decision 3 / Assumption block), the generator ships treating missing hCMS metadata as "not excluded" / `includeInSitemap = true`. The Rewriter-backed toggle (`disableSitemapEntry`) is wired and tested. The hCMS UI work for the per-page toggle and the metadata endpoint contract are tracked as a cross-team dependency on the hCMS team. This means **mandatory exclusions for `noindex` and canonical-mismatch (FR-3 bullets 2 and 3) are not enforced in this PR** — they will land once hCMS exposes the fields. Login/error exclusions are still applied via Rewriter `type` substring matching.
- **Decision 4 — Deduplication between cms-routes and user-routes is not implemented**. Today these sources are siblings populated from the same Rewriter Internals catalog with overlapping classifications (CMS pages can also be `userRoute` type). The spec calls for URL-level deduplication with CMS-wins precedence; that lives in `groupEntries` and is left as a follow-up. In practice, when `enableCmsRoutes` is on alongside `enableNavigationRoutes`, the served `<sitemapindex>` may reference both `rewriterRoutesIndex` and `cmsRoutesIndex` files containing overlapping URLs. Search engines tolerate duplicate `<loc>` across sub-sitemaps; the dedup is an optimization, not a correctness fix.

## Follow-ups

- Implement the hCMS metadata join (Decision 3) once the hCMS team exposes per-page `noindex`, canonical, and classification. File the counterpart hCMS ticket and link it from the spec.
- Implement URL-level deduplication between cms-routes and user-routes (Decision 4).
- Pre-existing test failures in `utils.test.ts`, `generateRewriterRoutes.test.ts`, `generateSitemap.test.ts`, `prepare.test.ts`, and `sitemapEntry.test.ts` (`catalogSitemapEntry` path) — out of scope here, but worth a small follow-up PR to unblock them the same way `sitemap.test.ts` was unblocked.
- Public docs (`docs/README.md`) should mention the new `enableCmsRoutes` setting once the rollout is greenlit (current default is `false`).
- Flip `enableCmsRoutes` default to `true` in a future minor bump (P5 in the spec's implementation plan) once the hCMS join and dedup follow-ups land.

## Spec

`specs/cms-routes-in-sitemap-for-faststore.md` — status updated from `Approved` → `Done` in the final commit. The spec is referenced by [PR #187](https://github.com/vtex-apps/store-sitemap/pull/187).

Made with [Cursor](https://cursor.com)