### PR TITLE
feat: Content Platform CMS routes in sitemap (Increment 2 of cms-routes-in-sitemap-for-faststore)

### DIFF
--- a/docs/CMS_ROUTES.md
+++ b/docs/CMS_ROUTES.md
@@ -1,0 +1,517 @@
+# CMS routes in sitemap (FastStore)
+
+> **Availability (hCMS legacy)**: `vtex.store-sitemap@2.19.x` and later, with `enableCmsRoutes: true`.
+> **Availability (Content Platform — new CMS)**: `vtex.store-sitemap@2.20.x` and later, with `enableContentPlatformRoutes: true`. See [Content Platform support](#content-platform-support).
+> **Jira**: [SFS-3123](https://vtex-dev.atlassian.net/browse/SFS-3123)
+
+FastStore stores can include CMS pages — PDPs, PLPs, landing pages, and any custom-slug page — directly in the generated sitemap, without manual workarounds like `next-sitemap` or hand-edited `sitemap.xml` files. The app supports both VTEX CMS surfaces:
+
+- **Headless CMS (hCMS, legacy)** — FastStore pages served via the CMS Builder REST API (`/_v/cms/api/{projectId}/{contentType}`). They are **not** registered as Rewriter Internals. Available today.
+- **VTEX CMS (Content Platform, new)** — pages exposed via the CMS's production-only **Data Plane REST API** (`{account}.vtexcommercestable.com.br/api/content-platform/data/*`), with native ETag caching and multi-language. [Progressively rolled out since March 2026](https://help.vtex.com/announcements/2026-03-30-headless-cms-stores-will-be-upgraded-to-the-new-vtex-cms).
+
+The two sources are **mutually exclusive per store** — at most one is active per generation. When both flags are `true`, Content Platform wins (see [Content Platform support](#content-platform-support)).
+
+This document covers:
+
+- [How it works](#how-it-works)
+- [Enabling CMS routes](#enabling-cms-routes)
+- [Verifying the sitemap](#verifying-the-sitemap)
+- [Excluding a page from the sitemap](#excluding-a-page-from-the-sitemap)
+- [Multi-locale stores](#multi-locale-stores)
+- [Fetching CMS routes as JSON](#fetching-cms-routes-as-json)
+- [robots.txt integration](#robotstxt-integration)
+- [Content Platform support](#content-platform-support)
+- [Migrating from hCMS to Content Platform](#migrating-from-hcms-to-content-platform)
+- [Known limitations](#known-limitations)
+
+---
+
+## How it works
+
+This section describes the **hCMS legacy** flow. The Content Platform flow is parallel and described in [Content Platform support](#content-platform-support).
+
+When `enableCmsRoutes` is `true`, the Sitemap app:
+
+1. **Sources CMS pages from the CMS Builder API.** FastStore Headless CMS pages live in the CMS builder data layer (`{account}.myvtex.com/_v/cms/api/{projectId}/{contentType}`). The app lists **published** pages for the configured project (`hcmsProjectId`, default `"faststore"`) and content types (`hcmsContentTypes`, default `["landingPage", "home"]`), then emits routes from each page's `settings.seo.slug`.
+
+2. **Applies eligibility filters.** A page is included only when it is published, has a non-empty `seo.slug` that is not the homepage (`/`), is not opted out via `seo.canonical` (see [Excluding a page](#excluding-a-page-from-the-sitemap)), and does not match the merchant's `disableRoutesTerm` setting.
+
+3. **Writes per-binding sub-sitemaps.** Routes are stored under the default store binding and exposed as `hcms-routes-N.xml` files under the `<sitemapindex>`, chunked at Google's protocol ceilings: **50,000 URLs** or **50 MB** per file — whichever is hit first.
+
+4. **Emits protocol-compliant URL entries.** Every CMS URL includes `<loc>`, `<changefreq>` (`weekly`), and `<priority>` (`0.5`). The CMS Builder listing does not expose per-page `updatedAt`, so hCMS entries omit `<lastmod>`. For multi-binding stores, hCMS routes carry a single self alternate on the default binding (the builder API is project-scoped and does not provide per-locale slugs).
+
+5. **Injects a `Sitemap:` directive in `robots.txt`** if one is not already present.
+
+6. **Exposes CMS routes via the JSON endpoint** (`/_v/public/sitemap/custom-routes`) under the `cms-routes` section so FastStore can consume them at build time or runtime.
+
+The feature is **fully gated** by the `enableCmsRoutes` setting (default `false`). When the flag is off (and `enableContentPlatformRoutes` is also off), the app behaves exactly as before — no extra VBase reads, no extra XML entries, no extra response keys.
+
+---
+
+## Enabling CMS routes
+
+### Via Admin UI
+
+1. In your browser, go to **Account settings > Apps > My apps** and search for the **Sitemap** app.
+2. Enable the **Enable CMS routes source (FastStore)** toggle.
+3. Save.
+
+### Via CLI
+
+```bash
+vtex use {workspaceName} --production
+```
+
+Then patch the app settings via the VTEX Admin API:
+
+```bash
+curl -X PATCH \
+  "https://{workspace}--{account}.myvtex.com/_v/private/apps/vtex.store-sitemap@2.x/settings" \
+  -H "VtexIdclientAutCookie: {token}" \
+  -H "Content-Type: application/json" \
+  -d '{"enableCmsRoutes": true}'
+```
+
+> ⚠️ Replace the values in curly brackets with the values that apply to your scenario.
+
+---
+
+## Verifying the sitemap
+
+After enabling the feature, the first request to any sitemap endpoint triggers background generation. The following steps verify that CMS routes are correctly included.
+
+### Step 1 — Trigger generation
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/_v/public/sitemap/custom-routes"
+```
+
+**Expected response on first call (generation triggered):**
+
+```json
+{ "message": "Custom routes not available. Generation has been triggered." }
+```
+
+**Status code:** `404`
+
+Generation runs in the background. The time depends on the number of pages. For most stores this completes in under a minute.
+
+### Step 2 — Confirm the CMS section is present
+
+Poll the same endpoint after a minute:
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/_v/public/sitemap/custom-routes"
+```
+
+**Expected response:**
+
+```json
+[
+  { "name": "apps-routes",  "routes": ["/store-locator/ny", "/store-locator/ca"] },
+  { "name": "user-routes",  "routes": ["/about-us", "/contact", "/faq"] },
+  { "name": "cms-routes",   "routes": ["/our-story", "/black-friday", "/landing/holiday"] }
+]
+```
+
+The `cms-routes` section contains all CMS pages that passed the filters.
+
+### Step 3 — Check the sitemap index
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/sitemap.xml"
+```
+
+The `<sitemapindex>` should now reference one or more `hcms-routes-N.xml` files:
+
+```xml
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  ...
+  <sitemap>
+    <loc>https://{account}.myvtex.com/sitemap/hcms-routes-0.xml</loc>
+    <lastmod>2026-05-27T...</lastmod>
+  </sitemap>
+</sitemapindex>
+```
+
+### Step 4 — Inspect a CMS sub-sitemap
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/sitemap/hcms-routes-0.xml"
+```
+
+Each URL entry includes the full protocol tag set:
+
+```xml
+<url>
+  <loc>https://{account}.myvtex.com/our-story</loc>
+  <lastmod>2026-05-27T13:00:00.000Z</lastmod>
+  <changefreq>weekly</changefreq>
+  <priority>0.5</priority>
+</url>
+```
+
+For multi-locale stores, the `<url>` also contains `<xhtml:link>` alternates — see [Multi-locale stores](#multi-locale-stores).
+
+### Step 5 — Verify robots.txt
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/robots.txt" | grep -i Sitemap
+```
+
+**Expected output:**
+
+```
+Sitemap: https://{account}.myvtex.com/sitemap.xml
+```
+
+If your `robots.txt` already contained a `Sitemap:` directive, no duplicate is added.
+
+---
+
+## Excluding a page from the sitemap
+
+### Option 1 — Canonical opt-out (recommended for FastStore hCMS)
+
+Set `settings.seo.canonical` on the CMS page to a URL **different** from the page's own `seo.slug`. An empty or self-referencing canonical does not exclude the page. This is the same rule used by the Content Platform source (see [Content Platform support](#content-platform-support)).
+
+### Option 2 — `disableRoutesTerm` setting
+
+The existing `disableRoutesTerm` setting (a substring filter applied to all user-defined routes) also applies to CMS routes. Any page whose path contains the configured string is excluded.
+
+Configure it via **Account settings > Apps > My apps > Sitemap > Disable routes from userRoutes with the following string**.
+
+> **Note for Store Framework stores:** pages registered as Rewriter `Internal` entries can still be excluded via `disableSitemapEntry` in Rewriter. That path does **not** apply to FastStore hCMS pages, which are sourced from the CMS Builder API rather than Rewriter.
+
+---
+
+## Multi-locale stores
+
+For stores with multiple bindings (multi-language / multi-currency), each CMS URL entry in the sitemap declares all locale alternates, including the URL itself and a `hreflang="x-default"` pointing at the default binding's version.
+
+**Example — page `/about` in a store with `en-US` (default), `pt-BR`, and `de-DE`:**
+
+```xml
+<url>
+  <loc>https://store.example.com/about</loc>
+  <xhtml:link rel="alternate" hreflang="en-US"   href="https://store.example.com/about"/>
+  <xhtml:link rel="alternate" hreflang="pt-BR"   href="https://store.example.com/br/sobre"/>
+  <xhtml:link rel="alternate" hreflang="de-DE"   href="https://store.example.com/de/ueber-uns"/>
+  <xhtml:link rel="alternate" hreflang="x-default" href="https://store.example.com/about"/>
+  <lastmod>2026-05-27T...</lastmod>
+  <changefreq>weekly</changefreq>
+  <priority>0.5</priority>
+</url>
+```
+
+This follows [Google's recommendation for localized versions](https://developers.google.com/search/docs/specialty/international/localized-versions#example_2).
+
+Single-binding stores do not emit `<xhtml:link>` tags — the behavior is unchanged from previous versions.
+
+---
+
+## Fetching CMS routes as JSON
+
+The `/_v/public/sitemap/custom-routes` endpoint is useful for FastStore projects that build or serve their own sitemap (e.g., with `next-sitemap`) and need to pull CMS routes without parsing XML.
+
+| Method | Endpoint |
+|--------|----------|
+| `GET`  | `/_v/public/sitemap/custom-routes` |
+
+The `cms-routes` section is **only present** when `enableCmsRoutes` is `true`. When the flag is off, the response contains only `apps-routes` and `user-routes` (backwards-compatible behavior).
+
+**Example response with `enableCmsRoutes: true`:**
+
+```json
+[
+  { "name": "apps-routes",  "routes": ["/store-locator/ny"] },
+  { "name": "user-routes",  "routes": ["/about-us", "/contact"] },
+  { "name": "cms-routes",   "routes": ["/our-story", "/black-friday"] }
+]
+```
+
+**Caching:** The response is cached for up to 1 day. Stale data triggers a background refresh and is still served while the new generation runs (stale-while-revalidate). See [`docs/CUSTOM_ROUTES_ARCHITECTURE.md`](./CUSTOM_ROUTES_ARCHITECTURE.md) for architecture details.
+
+### Migrating from `next-sitemap` + custom rewrites
+
+If your FastStore project currently uses `next-sitemap` with additional rewrites to include CMS pages, the migration path is:
+
+1. Enable `enableCmsRoutes` in `vtex.store-sitemap`.
+2. Verify CMS routes appear in `/_v/public/sitemap/custom-routes` and `/sitemap/hcms-routes-0.xml`.
+3. Point your storefront's sitemap generation to consume `/_v/public/sitemap/custom-routes` instead of the manually curated list.
+4. Remove the custom rewrites and `next-sitemap` CMS overrides from your store repository.
+5. Confirm `robots.txt` references `/sitemap.xml` (the app injects this automatically).
+
+---
+
+## robots.txt integration
+
+The `robots` middleware automatically appends a `Sitemap:` directive pointing to `/sitemap.xml` whenever the served `robots.txt` does not already contain one.
+
+The check is **case-insensitive** and tolerates leading whitespace, so a manually added line like `  sitemap: https://...` is correctly detected and not duplicated.
+
+**Behavior summary:**
+
+| Scenario | Result |
+|---|---|
+| `robots.txt` has no `Sitemap:` line | Directive is appended |
+| `robots.txt` already has `Sitemap: https://store.example.com/sitemap.xml` | No change |
+| `robots.txt` has `sitemap:` (lowercase) | No change (case-insensitive) |
+| `enableCmsRoutes` is `false` | Directive is still appended (the `robots.txt` logic is independent of this setting) |
+
+---
+
+## Content Platform support
+
+The new **VTEX CMS (Content Platform)** is the [successor to the Headless CMS (legacy)](https://help.vtex.com/announcements/2026-03-30-headless-cms-stores-will-be-upgraded-to-the-new-vtex-cms), used by FastStore v3 stores. It has a **different architecture** than hCMS — content lives in a CQRS data plane with ETag caching and native multi-language — and pages are **not** persisted as Rewriter Internals.
+
+The Sitemap app supports Content Platform via a **parallel ingestion path**: a separate middleware (`generateContentPlatformRoutes`) reads from the VTEX CMS **Data Plane REST API** (`https://{account}.vtexcommercestable.com.br/api/content-platform/data/*`) and writes its own VBase bucket. Everything downstream — chunking, `<sitemapindex>` composition, multi-locale `xhtml:link` emission, `robots.txt` directive — is shared with the hCMS path.
+
+### How it works
+
+When `enableContentPlatformRoutes` is `true`, the Sitemap app:
+
+1. **Iterates the routable content type allowlist.** Types are read from the `contentPlatformContentTypes` app setting (default `["landingPage", "home"]`). Add custom routable types — e.g. `"microsite"`, `"campaign"`, `"editorial"` — to that array to get them ingested without an app release. PDP / PLP / search Content Types should not be added: their URLs come from the catalog pipelines.
+
+2. **Paginates published entries via the Data Plane.** For each allowlisted type the app calls `listEntries` with the `scroll` cursor until exhausted. The Data Plane is **production-only by API design** — there is no `branch` parameter and no preview path through this app; drafts live on the Control Plane and are unreachable from here.
+
+3. **Fans out one `getEntry` call per (entry × binding-locale).** Each binding's `defaultLocale` is sent as the `?locale=` query parameter. A `200 OK` produces a route candidate using `entry.seo.slug` as the public path; a `404 Not Found` means the editor did not publish that locale and the binding is **silently skipped** — runtime locale fallback is not synthesized into the sitemap.
+
+4. **Applies SEO `canonical` opt-out.** A Content Platform entry is excluded when `seo.canonical` is a non-empty string AND points to a URL different from the entry's own `seo.slug`. `seo.canonical = ""` is the Data Plane default and means "no override". There is **no `noindex` opt-out today** — the field is not part of the current Content Platform `seo` schema (see [the spec's Decision 10](../specs/cms-routes-in-sitemap-for-faststore.md#decision-10-content-platform-opt-out-via-seo-canonical)).
+
+5. **Uses a VBase-backed ETag cache.** Each successful `getEntry` response is stored in the `content-platform-data-cache` bucket keyed by `(contentType, entryId, locale)`. On the next run the cached ETag is sent as `If-None-Match`; a `304 Not Modified` reuses the cached entry verbatim. Steady-state regenerations collapse to ΔN re-serializations — only entries the editor actually touched re-fetch their SEO payload.
+
+6. **Writes per-binding sub-sitemaps.** Each binding gets its own set of `content-platform-routes-N.xml` files under the `<sitemapindex>`, chunked at Google's protocol ceilings (50k URLs / 50 MB per file).
+
+7. **Emits protocol-compliant URL entries.** Same shape as `cms-routes-N.xml`: `<loc>` (`seo.slug`), `<lastmod>` (listing-level `entry.updatedAt`), `<changefreq>` (`weekly`), `<priority>` (`0.5`) and (multi-locale only) full `<xhtml:link>` alternate set including `hreflang="x-default"`, built from the locales that actually returned 200.
+
+8. **Exposes Content Platform routes via the JSON endpoint** as a new section named `content-platform-routes` (parallel to `cms-routes` for hCMS).
+
+The feature is **fully gated** by the `enableContentPlatformRoutes` setting (default `false`).
+
+### Source mutual exclusivity
+
+A store is expected to use exactly one VTEX CMS surface at a time during the upgrade window. Accordingly, **at most one of `enableCmsRoutes` / `enableContentPlatformRoutes` takes effect per generation**:
+
+| `enableCmsRoutes` | `enableContentPlatformRoutes` | Active source | Sub-sitemap files | JSON section |
+|---|---|---|---|---|
+| `false` | `false` | None | none added | `apps-routes`, `user-routes` only |
+| `true`  | `false` | hCMS legacy | `hcms-routes-N.xml` | `cms-routes` |
+| `false` | `true`  | Content Platform | `content-platform-routes-N.xml` | `content-platform-routes` |
+| `true`  | `true`  | **Content Platform wins** — hCMS skipped | `content-platform-routes-N.xml` | `content-platform-routes` |
+
+When both flags are set, a one-shot structured log `cms-routes-ignored-by-mutual-exclusivity` is emitted per generation cycle so the situation is observable.
+
+### Enabling Content Platform routes
+
+#### Via Admin UI
+
+1. In your browser, go to **Account settings > Apps > My apps** and search for the **Sitemap** app.
+2. Enable the **Enable Content Platform routes source (FastStore v3)** toggle.
+3. If migrating from hCMS, also disable **Enable CMS routes source (FastStore)** to avoid the mutual-exclusivity log (the result is the same either way, but disabling the legacy flag is cleaner).
+4. Save.
+
+#### Via CLI
+
+```bash
+vtex use {workspaceName} --production
+```
+
+Then patch the app settings via the VTEX Admin API:
+
+```bash
+curl -X PATCH \
+  "https://{workspace}--{account}.myvtex.com/_v/private/apps/vtex.store-sitemap@2.x/settings" \
+  -H "VtexIdclientAutCookie: {token}" \
+  -H "Content-Type: application/json" \
+  -d '{"enableContentPlatformRoutes": true, "enableCmsRoutes": false}'
+```
+
+> Replace the values in curly brackets with the values that apply to your scenario.
+
+#### Customizing the routable type allowlist
+
+By default, only `landingPage` and `home` entries are ingested. If your store registered additional routable content types in Content Platform, add their keys to the `contentPlatformContentTypes` setting:
+
+```bash
+curl -X PATCH \
+  "https://{workspace}--{account}.myvtex.com/_v/private/apps/vtex.store-sitemap@2.x/settings" \
+  -H "VtexIdclientAutCookie: {token}" \
+  -H "Content-Type: application/json" \
+  -d '{"contentPlatformContentTypes": ["landingPage", "home", "microsite", "campaign"]}'
+```
+
+The `contentPlatformStoreId` setting (default `"faststore"`) controls the `{storeId}` path segment sent to the Data Plane. Leave it at the default unless your store customized `contentSource.project` to something other than `faststore`.
+
+### Verifying the Content Platform sitemap
+
+After enabling the feature, the first request to any sitemap endpoint triggers background generation. The flow mirrors the hCMS [Verifying the sitemap](#verifying-the-sitemap) section, with these differences:
+
+- The JSON endpoint returns a section named `content-platform-routes` (instead of `cms-routes`):
+
+  ```json
+  [
+    { "name": "apps-routes",             "routes": ["/store-locator/ny"] },
+    { "name": "user-routes",             "routes": ["/about-us", "/contact"] },
+    { "name": "content-platform-routes", "routes": ["/our-story", "/black-friday", "/microsite/holiday"] }
+  ]
+  ```
+
+- The `<sitemapindex>` references `content-platform-routes-N.xml` files:
+
+  ```xml
+  <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    ...
+    <sitemap>
+      <loc>https://{account}.myvtex.com/sitemap/content-platform-routes-0.xml</loc>
+      <lastmod>2026-05-27T...</lastmod>
+    </sitemap>
+  </sitemapindex>
+  ```
+
+- Each `<url>` entry inside `content-platform-routes-N.xml` has the same shape as `cms-routes-N.xml` — `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>` and (for multi-locale stores) the full `<xhtml:link>` alternate set including `hreflang="x-default"`.
+
+### Excluding a Content Platform page from the sitemap
+
+Unlike hCMS — which uses the `disableSitemapEntry` toggle (mapped from a CMS UI toggle) — **Content Platform opt-out is driven exclusively by the `seo.canonical` field** in the page's SEO settings.
+
+To exclude a single page:
+
+1. Open the page in the Content Platform admin (**Storefront > Content > Content**).
+2. Switch to the **Settings** tab → **SEO** section.
+3. Set **Canonical URL** to a URL different from the page's own slug (typically the URL of the equivalent page you want Google to credit instead).
+4. Save and publish. The page will be excluded from the next sitemap regeneration.
+
+> **Why no `noindex` toggle?** The current Content Platform `seo` schema exposes `slug`, `title`, `description`, `canonical` and `titleTemplate` — there is no `noindex` field. We expect the CMS team to add it eventually and will layer it on top of the canonical rule when they do. See the [spec's Decision 10](../specs/cms-routes-in-sitemap-for-faststore.md#decision-10-content-platform-opt-out-via-seo-canonical) for the full rationale.
+
+The existing `disableRoutesTerm` setting (a substring filter applied to all user-defined routes) also applies to Content Platform routes.
+
+### Observability
+
+Every Content Platform regeneration emits these structured events:
+
+| Event | When emitted |
+|---|---|
+| `content-platform-routes-generation-start` | At the start of a generation cycle when `enableContentPlatformRoutes` is the active source. |
+| `content-platform-routes-generation-success` | After a successful generation. Includes counts per content type, ETag hit ratio, total URLs emitted. |
+| `content-platform-routes-generation-error` | On persistent Data Plane failure (after retries). The previous successful VBase entries are kept; served XML does not regress. |
+| `content-platform-entry-hydration-failed` | When a single `getEntry` call throws for non-404 reasons. The entry is skipped for that locale; generation continues. |
+| `cms-routes-ignored-by-mutual-exclusivity` | When both `enableCmsRoutes` and `enableContentPlatformRoutes` are `true`. Emitted once per generation cycle. |
+
+---
+
+## Migrating from hCMS to Content Platform
+
+If your store is on FastStore v3 and the CMS team is upgrading you from the legacy Headless CMS to the new Content Platform, here is the recommended migration path for the sitemap.
+
+### Before you start
+
+- Make sure the CMS team's content migration is **complete** (your pages are visible in the new **Storefront > Content > Content** admin) and that you have **published** the pages you want in the sitemap.
+- Confirm `contentPlatformStoreId` in the Sitemap app settings matches your FastStore `contentSource.project` (default `"faststore"`).
+- Decide which content types should appear in the sitemap. The default allowlist is `["landingPage", "home"]`; if your store has custom routable types (`microsite`, `campaign`, etc.), add them to `contentPlatformContentTypes` before flipping the flag.
+
+### Step 1 — Snapshot the current sitemap
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/_v/public/sitemap/custom-routes" > before.json
+curl "https://{workspace}--{account}.myvtex.com/sitemap.xml"                     > before-index.xml
+```
+
+Keep these files for comparison.
+
+### Step 2 — Flip the flags
+
+In a single PATCH, disable the legacy flag and enable the new one:
+
+```bash
+curl -X PATCH \
+  "https://{workspace}--{account}.myvtex.com/_v/private/apps/vtex.store-sitemap@2.x/settings" \
+  -H "VtexIdclientAutCookie: {token}" \
+  -H "Content-Type: application/json" \
+  -d '{"enableCmsRoutes": false, "enableContentPlatformRoutes": true}'
+```
+
+> If you flip only `enableContentPlatformRoutes: true` and leave `enableCmsRoutes: true`, Content Platform wins by [Decision 8](../specs/cms-routes-in-sitemap-for-faststore.md#decision-8-mutual-exclusivity-between-hcms-legacy-and-content-platform) but a `cms-routes-ignored-by-mutual-exclusivity` log is emitted on every generation. Cleaner to disable the legacy flag.
+
+### Step 3 — Trigger and validate regeneration
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/_v/public/sitemap/custom-routes"
+```
+
+The first response is a `404` with `{ "message": "Custom routes not available. Generation has been triggered." }`. Wait ~1 minute for most stores (longer for large catalogs), then poll again.
+
+When the response returns, verify the migration:
+
+```bash
+# Confirm the active source changed
+curl "https://{workspace}--{account}.myvtex.com/_v/public/sitemap/custom-routes" > after.json
+diff <(jq -r '.[].name' before.json) <(jq -r '.[].name' after.json)
+# Expected diff: -cms-routes  +content-platform-routes
+
+# Compare URL counts (should be similar, give or take new/removed pages)
+jq -r '.[] | select(.name=="cms-routes") | .routes | length'             before.json
+jq -r '.[] | select(.name=="content-platform-routes") | .routes | length' after.json
+```
+
+Inspect the new sub-sitemap:
+
+```bash
+curl "https://{workspace}--{account}.myvtex.com/sitemap.xml" | grep -E 'content-platform-routes|cms-routes'
+# Expected: only content-platform-routes-N.xml references
+curl "https://{workspace}--{account}.myvtex.com/sitemap/content-platform-routes-0.xml" | head -40
+```
+
+### Step 4 — Spot-check important URLs
+
+For each high-traffic landing page or custom-slug page, confirm the URL is present in the new sitemap and that its `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>` and (multi-locale) `<xhtml:link>` set are correct.
+
+If a page is missing:
+- Check its SEO **canonical** field: empty (default) keeps the page in the sitemap; a canonical pointing to a different URL excludes it.
+- Confirm the entry is **published** (not only drafted in the Content Studio) — the Data Plane REST API used by the sitemap only exposes published data.
+- Confirm the entry's content type is listed in the `contentPlatformContentTypes` setting (e.g., custom types like `"microsite"` must be added explicitly).
+- Confirm the entry has been published for the locale you expect — the Data Plane returns `404 Not Found` for locales that have not been published, and the binding is silently skipped.
+
+### Step 5 — Rollback (if needed)
+
+The migration is reversible at any time. To roll back:
+
+```bash
+curl -X PATCH \
+  "https://{workspace}--{account}.myvtex.com/_v/private/apps/vtex.store-sitemap@2.x/settings" \
+  -H "VtexIdclientAutCookie: {token}" \
+  -H "Content-Type: application/json" \
+  -d '{"enableCmsRoutes": true, "enableContentPlatformRoutes": false}'
+```
+
+The next regeneration will serve `cms-routes-N.xml` again. Stale `content-platform-routes-N.xml` files in VBase are not referenced by the `<sitemapindex>` and are ignored on serve — passive cleanup, no manual purge needed.
+
+---
+
+## Known limitations
+
+The following features are **not yet available** and are planned as follow-up work:
+
+| Limitation | Status |
+|---|---|
+| **`noindex` auto-exclusion (hCMS)** — pages marked as `noindex` in hCMS are not yet automatically filtered. Exclude them manually via `disableSitemapEntry` for now. | Waiting on hCMS metadata endpoint (cross-team dependency, Decision 3 of the spec). |
+| **Canonical-mismatch auto-exclusion (hCMS)** — pages whose canonical points to a different URL are not yet automatically filtered. | Same dependency as above. |
+| **Per-page sitemap toggle in hCMS Admin UI** — FastStore hCMS exclusion today is via `seo.canonical` opt-out or `disableRoutesTerm`; there is no dedicated "include in sitemap" toggle on the builder API surface yet. | Use canonical opt-out (see [Excluding a page](#excluding-a-page-from-the-sitemap)). |
+| **URL-level deduplication between `cms-routes` and `user-routes`** — a CMS landing page slug could theoretically overlap with a Rewriter `userRoute` when both `enableNavigationRoutes` and `enableCmsRoutes` are on. Search engines tolerate this; a deduplication step is planned. | Planned follow-up. |
+| **`noindex` auto-exclusion (Content Platform)** — the Content Platform `seo` schema does not expose `noindex` today, so pages marked as such elsewhere (e.g., a custom field) are not automatically filtered. Use `seo.canonical` pointing to another URL as the documented opt-out. | Waiting on the CMS team to add `seo.noindex` to the schema. |
+| **Auto-discovery of routable content types (Content Platform)** — custom content types must be added to the `contentPlatformContentTypes` setting manually. The Data Plane REST API has no schema-listing endpoint. | Planned follow-up: auto-populate via `vtex.admin-cms-graphql`, see [spec Decision 9](../specs/cms-routes-in-sitemap-for-faststore.md#decision-9-routable-type-discovery--settings-allowlist-with-future-graphql-discovery). |
+| **Parallel ingestion of both VTEX CMSs** — the two sources are mutually exclusive per generation. Stores genuinely needing parallel coverage during a long migration must wait for a future enhancement. | Explicitly out of scope of the current increment; revisit on customer demand. |
+| **Non-production reads (Content Platform)** — the Data Plane REST API exposes only published data; drafts live on the Control Plane and are unreachable from this app. | By design / API contract, see [spec invariant 11](../specs/cms-routes-in-sitemap-for-faststore.md#invariants--constraints). |
+
+---
+
+## Reference
+
+- [Spec: cms-routes-in-sitemap-for-faststore](../specs/cms-routes-in-sitemap-for-faststore.md) (Done for hCMS legacy and Content Platform increment)
+- [Architecture: custom routes](./CUSTOM_ROUTES_ARCHITECTURE.md)
+- [Google Sitemap protocol](https://www.sitemaps.org/protocol.html)
+- [Google: localized versions with hreflang](https://developers.google.com/search/docs/specialty/international/localized-versions)
+- [Known Issue: Native sitemap is not fully integrated with FastStore](https://help.vtex.com/known-issues/native-sitemap-is-not-fully-integrated-with-faststore--5IrsqCEtQKPFstqywlV7Nn)
+- [Announcement: Headless CMS stores will be upgraded to the new VTEX CMS (Mar 30, 2026)](https://help.vtex.com/announcements/2026-03-30-headless-cms-stores-will-be-upgraded-to-the-new-vtex-cms)
+- [Developer guide: CMS for FastStore storefronts](https://developers.vtex.com/docs/guides/cms-for-faststore-storefronts)
+- [Developer guide: Upgrading from Headless CMS (legacy) to CMS](https://developers.vtex.com/docs/guides/comparing-headless-cms-legacy-and-cms-features)

--- a/docs/README.md
+++ b/docs/README.md
@@ -184,6 +184,12 @@ If you want to remove a custom route, execute the following mutation, which take
    }
    ```
 
+### CMS routes (FastStore)
+
+If your store runs on FastStore, you can include pages created in VTEX headless CMS — PDPs, PLPs, landing pages, and custom-slug pages — directly in the generated sitemap by enabling the `enableCmsRoutes` setting.
+
+For a complete setup guide, see [CMS routes in sitemap (FastStore)](./CMS_ROUTES.md).
+
 ### Fetching custom routes in JSON format
 
 The `vtex.store-sitemap` app exposes an API endpoint that allows you to retrieve route data in JSON format. This endpoint is useful for external sitemap generation or custom indexing workflows.

--- a/manifest.json
+++ b/manifest.json
@@ -111,6 +111,20 @@
         "host": "{{account}}.vtexcommercestable.com.br",
         "path": "/api/vtexid/credential/validate"
       }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "{{account}}.vtexcommercestable.com.br",
+        "path": "/api/content-platform/data/*"
+      }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "{{account}}.myvtex.com",
+        "path": "/_v/cms/api/*"
+      }
     }
   ],
   "credentialType": "absolute",
@@ -138,6 +152,53 @@
         "description": "This will enable the app routes source, adding to the final sitemap routes defined and exported by the routes.json files from apps built by the store@0.x builder.",
         "type": "boolean",
         "default": true
+      },
+      "enableCmsRoutes": {
+        "title": "Enable CMS routes source (FastStore)",
+        "description": "When enabled, pages published in the VTEX Headless CMS (legacy) are sourced from the CMS builder REST API (`{account}.myvtex.com/_v/cms/api/{projectId}/{contentType}`) and included in the generated sitemap. Routable content types are configurable via `hcmsContentTypes`; the CMS project id via `hcmsProjectId`. Each page is included when published, has an `seo.slug`, and its `seo.canonical` does not point elsewhere. Mutually exclusive with `enableContentPlatformRoutes` — when both are true, Content Platform wins. Defaults to false during rollout.",
+        "type": "boolean",
+        "default": false
+      },
+      "hcmsProjectId": {
+        "title": "Headless CMS project id",
+        "description": "CMS builder project identifier passed to the Headless CMS REST API (path segment `{projectId}`). Defaults to `faststore`, which matches stores that did not customize the CMS builder. Only consumed when `enableCmsRoutes` is on.",
+        "type": "string",
+        "default": "faststore"
+      },
+      "hcmsContentTypes": {
+        "title": "Headless CMS routable content types",
+        "description": "Allowlist of Headless CMS content types ingested into the sitemap. Each type is paginated via the CMS builder API and its pages are emitted using `settings.seo.slug`. Defaults to `[\"landingPage\"]`; add the ids of any other routable content types the store created. Only consumed when `enableCmsRoutes` is on.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "landingPage"
+        ]
+      },
+      "enableContentPlatformRoutes": {
+        "title": "Enable Content Platform routes source (FastStore v3)",
+        "description": "When enabled, pages published in the new VTEX CMS (Content Platform) are sourced from the Data Plane REST API (`{account}.vtexcommercestable.com.br/api/content-platform/data/*`, production-only) and included in the generated sitemap. Routable content types are configurable via `contentPlatformContentTypes`; the store id (FastStore project) via `contentPlatformStoreId`. Per-entry reads honour `seo.slug` and exclude entries whose `seo.canonical` points elsewhere. ETag-cached. Mutually exclusive with `enableCmsRoutes` — when both are true, this flag wins.",
+        "type": "boolean",
+        "default": false
+      },
+      "contentPlatformStoreId": {
+        "title": "Content Platform store id",
+        "description": "FastStore project identifier passed to the Content Platform Data Plane (path segment `{storeId}`). Defaults to `faststore`, which matches stores that did not customize `contentSource.project`. Only consumed when `enableContentPlatformRoutes` is on.",
+        "type": "string",
+        "default": "faststore"
+      },
+      "contentPlatformContentTypes": {
+        "title": "Content Platform routable content types",
+        "description": "Allowlist of Content Platform content types ingested into the sitemap. Each entry is queried via `listEntries` and hydrated per item to pick up `seo.slug` / `seo.canonical`. Defaults to the predefined FastStore types (`landingPage`, `home`); add the keys of any custom routable types the store created. Only consumed when `enableContentPlatformRoutes` is on.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "landingPage",
+          "home"
+        ]
       },
       "disableRoutesTerm": {
         "title": "Disable routes from userRoutes with the following string",

--- a/node/clients/cmsBuilder.ts
+++ b/node/clients/cmsBuilder.ts
@@ -1,0 +1,116 @@
+import { ExternalClient, InstanceOptions, IOContext } from '@vtex/api'
+
+import { withRetriableGet } from './httpRetry'
+
+/**
+ * Read-only client for the VTEX Headless CMS (legacy) builder REST API.
+ */
+
+const CMS_API_PATH = '/_v/cms/api'
+const DEFAULT_PER_PAGE = 100
+
+export interface CmsPageSeo {
+  slug?: string
+  title?: string
+  description?: string
+  canonical?: string
+}
+
+export interface CmsPage {
+  id: string
+  name: string
+  type: string
+  status: string
+  versionId?: string
+  versionStatus?: string
+  settings?: {
+    seo?: CmsPageSeo
+  }
+}
+
+export interface ListPagesResponse {
+  data: CmsPage[]
+  hasNextPage: boolean
+  totalItems: number
+}
+
+export interface ContentType {
+  id: string
+  name: string
+  scopes?: string[]
+  isSingleton?: boolean
+}
+
+export interface ListContentTypesResponse {
+  contentTypes: ContentType[]
+}
+
+export interface ListPagesParams {
+  projectId: string
+  contentType: string
+  page: number
+  perPage?: number
+}
+
+export class CmsBuilder extends ExternalClient {
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(`http://${context.account}.myvtex.com`, context, {
+      ...(options ?? {}),
+      headers: {
+        ...(options?.headers ?? {}),
+        Accept: 'application/json',
+        VtexIdclientAutCookie: context.authToken,
+      },
+    })
+  }
+
+  public listContentTypes = (
+    projectId: string
+  ): Promise<ListContentTypesResponse> =>
+    this.getJson<ListContentTypesResponse>(
+      `${CMS_API_PATH}/${projectId}`,
+      {},
+      'cms-builder-list-content-types'
+    )
+
+  public listPages = (params: ListPagesParams): Promise<ListPagesResponse> =>
+    this.getJson<ListPagesResponse>(
+      `${CMS_API_PATH}/${params.projectId}/${params.contentType}`,
+      {
+        page: String(params.page),
+        perPage: String(params.perPage ?? DEFAULT_PER_PAGE),
+      },
+      'cms-builder-list-pages'
+    )
+
+  public listAllPages = async (
+    projectId: string,
+    contentType: string,
+    maxPages = 100
+  ): Promise<CmsPage[]> => {
+    const all: CmsPage[] = []
+    let page = 1
+    let hasNextPage = false
+    do {
+      // eslint-disable-next-line no-await-in-loop
+      const response = await this.listPages({ contentType, page, projectId })
+      all.push(...(response.data ?? []))
+      hasNextPage = Boolean(response.hasNextPage)
+      page += 1
+    } while (hasNextPage && page <= maxPages)
+    return all
+  }
+
+  private getJson<T>(
+    path: string,
+    params: Record<string, string>,
+    metric: string
+  ): Promise<T> {
+    return withRetriableGet({
+      getStatus: (error: unknown) =>
+        (error as { response?: { status?: number } })?.response?.status,
+      metric,
+      request: () => this.http.get<T>(path, { metric, params }),
+    })
+  }
+}

--- a/node/clients/cmsDataPlane.ts
+++ b/node/clients/cmsDataPlane.ts
@@ -1,0 +1,175 @@
+import { ExternalClient, InstanceOptions, IOContext } from '@vtex/api'
+
+import { withRetriableGet } from './httpRetry'
+
+/**
+ * Read-only client for the VTEX CMS (Content Platform) Data Plane REST API.
+ */
+
+const DATA_PLANE_PATH = '/api/content-platform/data'
+
+export interface EntrySeo {
+  slug: string
+  title?: string
+  description?: string
+  canonical?: string
+}
+
+export interface ContentEntry {
+  id: string
+  name: string
+  updatedAt: string
+  createdAt?: string
+  createdBy?: string | null
+  searchKeywords?: string[]
+}
+
+export interface EntriesList {
+  entries: ContentEntry[]
+  scroll: string | null
+}
+
+export interface PublishedEntry {
+  id: string
+  slug: string
+  seo?: EntrySeo
+  sections?: unknown[]
+  locale_metadata?: {
+    code?: string
+    locale?: string
+  }
+}
+
+export interface DataPlaneListResponse<T> {
+  data?: T
+  etag?: string
+  notModified: boolean
+  notFound?: boolean
+}
+
+export interface ListEntriesParams {
+  accountName: string
+  storeId: string
+  contentType: string
+  locale?: string
+  scroll?: string
+  etag?: string
+}
+
+export interface GetEntryParams {
+  accountName: string
+  storeId: string
+  contentType: string
+  entryId: string
+  locale?: string
+  etag?: string
+}
+
+const isNotModified = (status: number | undefined): boolean => status === 304
+
+const isNotFound = (status: number | undefined): boolean => status === 404
+
+export const listEntriesPath = ({
+  accountName,
+  storeId,
+  contentType,
+}: Pick<ListEntriesParams, 'accountName' | 'storeId' | 'contentType'>): string =>
+  `${DATA_PLANE_PATH}/${accountName}/${storeId}/${contentType}/entries`
+
+export const getEntryPath = ({
+  accountName,
+  storeId,
+  contentType,
+  entryId,
+}: Pick<
+  GetEntryParams,
+  'accountName' | 'storeId' | 'contentType' | 'entryId'
+>): string =>
+  `${DATA_PLANE_PATH}/${accountName}/${storeId}/${contentType}/entries/${entryId}`
+
+export class CmsDataPlane extends ExternalClient {
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(`http://${context.account}.vtexcommercestable.com.br`, context, {
+      ...(options ?? {}),
+      headers: {
+        ...(options?.headers ?? {}),
+        Accept: 'application/json',
+        VtexIdclientAutCookie: context.authToken,
+      },
+    })
+  }
+
+  public listEntries = (
+    params: ListEntriesParams
+  ): Promise<DataPlaneListResponse<EntriesList>> =>
+    this.getJson<EntriesList>(
+      listEntriesPath(params),
+      this.buildListParams(params),
+      params.etag,
+      'cms-data-plane-list-entries'
+    )
+
+  public getEntry = (
+    params: GetEntryParams
+  ): Promise<DataPlaneListResponse<PublishedEntry>> =>
+    this.getJson<PublishedEntry>(
+      getEntryPath(params),
+      this.buildLocaleParams(params.locale),
+      params.etag,
+      'cms-data-plane-get-entry'
+    )
+
+  private buildLocaleParams(
+    locale: string | undefined
+  ): Record<string, string> {
+    return locale ? { locale } : {}
+  }
+
+  private buildListParams(params: ListEntriesParams): Record<string, string> {
+    const query: Record<string, string> = this.buildLocaleParams(params.locale)
+    if (params.scroll) {
+      query.scroll = params.scroll
+    }
+    return query
+  }
+
+  private async getJson<T>(
+    path: string,
+    params: Record<string, string>,
+    etag: string | undefined,
+    metric: string
+  ): Promise<DataPlaneListResponse<T>> {
+    const headers: Record<string, string> = {}
+    if (etag) {
+      headers['If-None-Match'] = etag
+    }
+
+    return withRetriableGet({
+      getStatus: (error: unknown) =>
+        (error as { response?: { status?: number } })?.response?.status,
+      metric,
+      request: async () => {
+        const response = await this.http.getRaw<T>(path, {
+          headers,
+          metric,
+          params,
+          validateStatus: status =>
+            status === 200 || status === 304 || status === 404,
+        })
+        if (isNotModified(response.status)) {
+          return { etag, notModified: true }
+        }
+        if (isNotFound(response.status)) {
+          return { notFound: true, notModified: false }
+        }
+        const newEtag =
+          (response.headers?.etag as string | undefined) ?? etag
+        return {
+          data: response.data,
+          etag: newEtag,
+          notModified: false,
+        }
+      },
+    })
+  }
+}

--- a/node/clients/httpRetry.ts
+++ b/node/clients/httpRetry.ts
@@ -1,0 +1,42 @@
+export const DEFAULT_MAX_RETRIES = 3
+export const DEFAULT_RETRY_DELAY_MS = 1000
+
+export const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => {
+    setTimeout(resolve, ms)
+  })
+
+export const isRetriable5xx = (status: number | undefined): boolean =>
+  typeof status === 'number' && status >= 500 && status < 600
+
+export interface RetriableGetOptions<T> {
+  metric: string
+  maxRetries?: number
+  retryDelayMs?: number
+  request: () => Promise<T>
+  getStatus: (error: unknown) => number | undefined
+}
+
+/**
+ * Execute a GET with bounded linear backoff on 5xx responses.
+ */
+export const withRetriableGet = async <T>({
+  getStatus,
+  maxRetries = DEFAULT_MAX_RETRIES,
+  metric,
+  request,
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+}: RetriableGetOptions<T>): Promise<T> => {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await request()
+    } catch (error) {
+      const status = getStatus(error)
+      if (!isRetriable5xx(status) || attempt >= maxRetries) {
+        throw error
+      }
+      await sleep(retryDelayMs * (attempt + 1))
+    }
+  }
+  throw new Error(`${metric}: exhausted retries without response`)
+}

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,6 +1,8 @@
 import { IOClients, Sphinx, VBase } from '@vtex/api'
 
 import { Catalog } from './catalog'
+import { CmsBuilder } from './cmsBuilder'
+import { CmsDataPlane } from './cmsDataPlane'
 import { GraphQLServer } from './graphqlServer'
 import { VtexID } from './id'
 import { Messages } from './messages'
@@ -48,6 +50,14 @@ export class Clients extends IOClients {
 
   public get sphinx() {
     return this.getOrSet('sphinx', Sphinx)
+  }
+
+  public get cmsDataPlane() {
+    return this.getOrSet('cmsDataPlane', CmsDataPlane)
+  }
+
+  public get cmsBuilder() {
+    return this.getOrSet('cmsBuilder', CmsBuilder)
   }
 
 }

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -40,12 +40,31 @@ declare global {
     pageType: string
   }
 
+  type ChangeFreq =
+    | 'always'
+    | 'hourly'
+    | 'daily'
+    | 'weekly'
+    | 'monthly'
+    | 'yearly'
+    | 'never'
+
   interface Route {
     id: string
     path: string,
     alternates?: AlternateRoute[]
     imagePath?: string
     imageTitle?: string
+    // Optional sitemap protocol tags (sitemaps.org/protocol). When present they
+    // are emitted by URLEntry; absent → tag is omitted, preserving backwards
+    // compatibility with sources that do not annotate routes.
+    changefreq?: ChangeFreq
+    priority?: number
+    lastmod?: string
+    // Origin of the entry, kept for observability / future deduplication. The
+    // XML pipeline does not branch on this field — same downstream shape for
+    // every source (spec Decision 7).
+    source?: 'hcms' | 'content-platform' | 'apps' | 'user'
   }
 
   interface AlternateRoute {

--- a/node/index.ts
+++ b/node/index.ts
@@ -16,6 +16,8 @@ import { binding } from './middlewares/binding'
 import { cache } from './middlewares/cache'
 import { errors } from './middlewares/errors'
 import { generateAppsRoutes } from './middlewares/generateMiddlewares/generateAppsRoutes'
+import { generateCmsRoutes } from './middlewares/generateMiddlewares/generateCmsRoutes'
+import { generateContentPlatformRoutes } from './middlewares/generateMiddlewares/generateContentPlatformRoutes'
 import { generateProductRoutes } from './middlewares/generateMiddlewares/generateProductRoutes'
 import { generateRewriterRoutes } from './middlewares/generateMiddlewares/generateRewriterRoutes'
 import {
@@ -104,6 +106,7 @@ const sitemapPipeline = [
 ]
 const sitemapEntryPipeline = [
   sitemapErrors,
+  settings,
   prepare,
   isCrossBorder,
   sitemapEntry,
@@ -122,6 +125,30 @@ export default new Service<Clients, State, ParamsContext>({
       isCrossBorder,
       generationPrepare,
       generateAppsRoutes,
+    ],
+    /**
+     * @deprecated This event is being deprecated. Sitemap generation in this major version will not be triggered by events.
+     * Use the REST API endpoints instead.
+     */
+    generateCmsRoutes: [
+      throttle,
+      errors,
+      settings,
+      isCrossBorder,
+      generationPrepare,
+      generateCmsRoutes,
+    ],
+    /**
+     * @deprecated This event is being deprecated. Sitemap generation in this major version will not be triggered by events.
+     * Use the REST API endpoints instead.
+     */
+    generateContentPlatformRoutes: [
+      throttle,
+      errors,
+      settings,
+      isCrossBorder,
+      generationPrepare,
+      generateContentPlatformRoutes,
     ],
     /**
      * @deprecated This event is being deprecated. Sitemap generation in this major version will not be triggered by events.

--- a/node/middlewares/customRoutes.test.ts
+++ b/node/middlewares/customRoutes.test.ts
@@ -10,6 +10,10 @@ import * as TypeMoq from 'typemoq'
 import { Clients } from '../clients'
 import { CUSTOM_ROUTES_BUCKET, CUSTOM_ROUTES_FILENAME } from '../utils'
 import { customRoutes } from './customRoutes'
+import {
+  DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+  DEFAULT_CONTENT_PLATFORM_STORE_ID,
+} from './settings'
 
 const vbaseTypeMock = TypeMoq.Mock.ofInstance(VBase)
 const contextMock = TypeMoq.Mock.ofType<Context>()
@@ -75,8 +79,12 @@ describe('Test customRoutes middleware', () => {
       state: {
         ...state.object,
         settings: {
+          contentPlatformContentTypes: DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+          contentPlatformStoreId: DEFAULT_CONTENT_PLATFORM_STORE_ID,
           disableRoutesTerm: '',
           enableAppsRoutes: true,
+          enableCmsRoutes: false,
+          enableContentPlatformRoutes: false,
           enableNavigationRoutes: true,
           enableProductRoutes: true,
           ignoreBindings: false,
@@ -152,5 +160,143 @@ describe('Test customRoutes middleware', () => {
     expect(context.body).toEqual(mockData.data)
     expect(context.state.useLongCacheControl).toBe(true)
     expect(next).toHaveBeenCalled()
+  })
+
+  it('should expose cms-routes when enableCmsRoutes is true', async () => {
+    const mockData = {
+      data: [
+        { name: 'apps-routes', routes: ['/app-1'] },
+        { name: 'user-routes', routes: ['/user-1'] },
+        { name: 'cms-routes', routes: ['/our-story', '/black-friday'] },
+      ],
+      timestamp: Date.now() - 1000 * 60 * 60,
+    }
+    cachedData = mockData
+    context.state.settings.enableCmsRoutes = true
+
+    await customRoutes(context, next)
+
+    expect(context.status).toBe(200)
+    expect(context.body).toEqual(mockData.data)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should omit cms-routes when enableCmsRoutes is false (rollout-gated)', async () => {
+    const mockData = {
+      data: [
+        { name: 'apps-routes', routes: ['/app-1'] },
+        { name: 'user-routes', routes: ['/user-1'] },
+        { name: 'cms-routes', routes: ['/our-story'] },
+      ],
+      timestamp: Date.now() - 1000 * 60 * 60,
+    }
+    cachedData = mockData
+    context.state.settings.enableCmsRoutes = false
+
+    await customRoutes(context, next)
+
+    expect(context.status).toBe(200)
+    expect(context.body).toEqual([
+      { name: 'apps-routes', routes: ['/app-1'] },
+      { name: 'user-routes', routes: ['/user-1'] },
+    ])
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should expose content-platform-routes when enableContentPlatformRoutes is true (US-5)', async () => {
+    const mockData = {
+      data: [
+        { name: 'apps-routes', routes: ['/app-1'] },
+        { name: 'user-routes', routes: ['/user-1'] },
+        { name: 'cms-routes', routes: [] },
+        {
+          name: 'content-platform-routes',
+          routes: ['/our-story', '/microsite/holiday'],
+        },
+      ],
+      timestamp: Date.now() - 1000 * 60 * 60,
+    }
+    cachedData = mockData
+    context.state.settings.enableContentPlatformRoutes = true
+
+    await customRoutes(context, next)
+
+    expect(context.status).toBe(200)
+    expect(context.body).toEqual([
+      { name: 'apps-routes', routes: ['/app-1'] },
+      { name: 'user-routes', routes: ['/user-1'] },
+      {
+        name: 'content-platform-routes',
+        routes: ['/our-story', '/microsite/holiday'],
+      },
+    ])
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should omit content-platform-routes when its flag is off (US-5 — invariant 9)', async () => {
+    const mockData = {
+      data: [
+        { name: 'apps-routes', routes: ['/app-1'] },
+        { name: 'user-routes', routes: ['/user-1'] },
+        { name: 'content-platform-routes', routes: ['/our-story'] },
+      ],
+      timestamp: Date.now() - 1000 * 60 * 60,
+    }
+    cachedData = mockData
+    context.state.settings.enableContentPlatformRoutes = false
+
+    await customRoutes(context, next)
+
+    expect(context.status).toBe(200)
+    expect(context.body).toEqual([
+      { name: 'apps-routes', routes: ['/app-1'] },
+      { name: 'user-routes', routes: ['/user-1'] },
+    ])
+  })
+
+  it('exposes ONLY content-platform-routes (not cms-routes) when both flags are on — Content Platform wins (US-5 / Decision 8)', async () => {
+    const mockData = {
+      data: [
+        { name: 'apps-routes', routes: ['/app-1'] },
+        { name: 'user-routes', routes: ['/user-1'] },
+        { name: 'cms-routes', routes: ['/hcms-page'] },
+        { name: 'content-platform-routes', routes: ['/cp-page'] },
+      ],
+      timestamp: Date.now() - 1000 * 60 * 60,
+    }
+    cachedData = mockData
+    context.state.settings.enableCmsRoutes = true
+    context.state.settings.enableContentPlatformRoutes = true
+
+    await customRoutes(context, next)
+
+    expect(context.status).toBe(200)
+    expect(context.body).toEqual([
+      { name: 'apps-routes', routes: ['/app-1'] },
+      { name: 'user-routes', routes: ['/user-1'] },
+      { name: 'content-platform-routes', routes: ['/cp-page'] },
+    ])
+  })
+
+  it('returns only apps-routes + user-routes when both CMS flags are off (US-6 — backwards compatibility)', async () => {
+    const mockData = {
+      data: [
+        { name: 'apps-routes', routes: ['/app-1'] },
+        { name: 'user-routes', routes: ['/user-1'] },
+        { name: 'cms-routes', routes: ['/hcms-page'] },
+        { name: 'content-platform-routes', routes: ['/cp-page'] },
+      ],
+      timestamp: Date.now() - 1000 * 60 * 60,
+    }
+    cachedData = mockData
+    context.state.settings.enableCmsRoutes = false
+    context.state.settings.enableContentPlatformRoutes = false
+
+    await customRoutes(context, next)
+
+    expect(context.body).toEqual([
+      { name: 'apps-routes', routes: ['/app-1'] },
+      { name: 'user-routes', routes: ['/user-1'] },
+    ])
   })
 })

--- a/node/middlewares/customRoutes.ts
+++ b/node/middlewares/customRoutes.ts
@@ -1,6 +1,10 @@
 import { Logger, VBase } from '@vtex/api'
 
 import { MultipleCustomRoutesGenerationError } from '../errors'
+import {
+  resolveActiveCmsSource,
+  shouldIncludeCustomRoutesSection,
+} from '../services/cmsSources'
 import { generateCustomRoutes } from './generateMiddlewares/generateCustomRoutes'
 import {
   CONFIG_BUCKET,
@@ -257,10 +261,20 @@ export async function customRoutes(ctx: Context, next: () => Promise<void>) {
       triggerCustomRoutesGeneration(ctx)
     }
 
-    // Filter data based on enableAppsRoutes setting
-    const filteredData = settings.enableAppsRoutes
-      ? cachedData.data
-      : cachedData.data.filter(item => item.name !== 'apps-routes')
+    // Filter data based on which sources are enabled. When a flag is off the
+    // corresponding section is omitted entirely so consumers see the feature
+    // as if it did not exist (invariant 9 — settings gating). Mutual
+    // exclusivity (Decision 8 / FR-10 / invariant 10) drops `cms-routes`
+    // whenever Content Platform is the active source, even if the legacy
+    // flag also happens to be on, so the response advertises only ONE CMS
+    // section per request.
+    const activeCmsSource = resolveActiveCmsSource(settings)
+    const filteredData = cachedData.data.filter(item => {
+      if (item.name === 'apps-routes' && !settings.enableAppsRoutes) {
+        return false
+      }
+      return shouldIncludeCustomRoutesSection(item.name, activeCmsSource)
+    })
 
     // Return cached data
     ctx.status = 200

--- a/node/middlewares/generateMiddlewares/generateCmsRoutes.test.ts
+++ b/node/middlewares/generateMiddlewares/generateCmsRoutes.test.ts
@@ -1,0 +1,394 @@
+import {
+  IOContext,
+  Logger,
+  RequestConfig,
+  Tenant,
+  TenantClient,
+  VBase,
+  VBaseSaveResponse,
+} from '@vtex/api'
+import * as TypeMoq from 'typemoq'
+
+import { CmsBuilder, CmsPage } from '../../clients/cmsBuilder'
+import { Clients } from '../../clients'
+import {
+  CMS_ROUTES_PREFIX,
+  CMS_ROUTES_MAX_URLS_PER_FILE,
+  getBucket,
+  hashString,
+} from '../../utils'
+import {
+  DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+  DEFAULT_CONTENT_PLATFORM_STORE_ID,
+  DEFAULT_HCMS_CONTENT_TYPES,
+  DEFAULT_HCMS_PROJECT_ID,
+} from '../settings'
+import { generateCmsRoutes } from './generateCmsRoutes'
+import {
+  CMS_ROUTES_INDEX,
+  SitemapEntry,
+  SitemapIndex,
+} from './utils'
+
+const tenantTypeMock = TypeMoq.Mock.ofInstance(TenantClient)
+const cmsBuilderTypeMock = TypeMoq.Mock.ofInstance(CmsBuilder)
+const vbaseTypeMock = TypeMoq.Mock.ofInstance(VBase)
+const contextMock = TypeMoq.Mock.ofType<EventContext>()
+const ioContext = TypeMoq.Mock.ofType<IOContext>()
+const state = TypeMoq.Mock.ofType<State>()
+const loggerMock = TypeMoq.Mock.ofType<Logger>()
+
+let next: any
+
+// The default store binding id resolved from the tenant mock below.
+const DEFAULT_BINDING_ID = '1'
+
+interface BuildContextOptions {
+  pagesByContentType: Record<string, CmsPage[]>
+  disableRoutesTerm?: string
+}
+
+const page = (overrides: Partial<CmsPage> & { slug?: string | null }): CmsPage => {
+  const { slug, ...rest } = overrides
+  const seo =
+    slug === undefined
+      ? undefined
+      : { canonical: rest.settings?.seo?.canonical, slug: slug ?? undefined }
+  return {
+    id: rest.id ?? 'page-id',
+    name: rest.name ?? 'Page',
+    settings: seo ? { seo } : rest.settings,
+    status: rest.status ?? 'published',
+    type: rest.type ?? 'landingPage',
+  }
+}
+
+const buildContext = ({
+  pagesByContentType,
+  disableRoutesTerm = '',
+}: BuildContextOptions): EventContext => {
+  // tslint:disable-next-line:max-classes-per-file
+  const vbase = class VBaseMock extends vbaseTypeMock.object {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public jsonData: Record<string, any> = {}
+
+    constructor() {
+      super(ioContext.object)
+    }
+
+    public getJSON = async <T>(
+      bucket: string,
+      file: string,
+      nullOrUndefined?: boolean | undefined
+    ): Promise<T> => {
+      if (!this.jsonData[bucket]?.[file] && nullOrUndefined) {
+        return (null as unknown) as T
+      }
+      return Promise.resolve(this.jsonData[bucket][file] as T)
+    }
+
+    public saveJSON = async <T>(
+      bucket: string,
+      file: string,
+      data: T
+    ): Promise<VBaseSaveResponse> => {
+      if (!this.jsonData[bucket]) {
+        this.jsonData[bucket] = {}
+      }
+      this.jsonData[bucket][file] = data
+      return Promise.resolve(({
+        updated: true,
+      } as unknown) as VBaseSaveResponse)
+    }
+  }
+
+  // tslint:disable-next-line:max-classes-per-file
+  const tenant = class TenantMock extends tenantTypeMock.object {
+    constructor() {
+      super(ioContext.object)
+    }
+
+    public info = async (_?: RequestConfig) => {
+      return {
+        bindings: [
+          {
+            id: DEFAULT_BINDING_ID,
+            targetProduct: 'vtex-storefront',
+          },
+          {
+            id: '2',
+            targetProduct: 'vtex-storefront',
+          },
+        ],
+      } as Tenant
+    }
+  }
+
+  // tslint:disable-next-line:max-classes-per-file
+  const cmsBuilder = class CmsBuilderMock extends cmsBuilderTypeMock.object {
+    constructor() {
+      super(ioContext.object)
+    }
+
+    public listAllPages = async (_projectId: string, contentType: string) =>
+      pagesByContentType[contentType] ?? []
+  }
+
+  // tslint:disable-next-line:max-classes-per-file
+  const ClientsImpl = class ClientsMock extends Clients {
+    get vbase() {
+      return this.getOrSet('vbase', vbase)
+    }
+
+    get tenant() {
+      return this.getOrSet('tenant', tenant)
+    }
+
+    get cmsBuilder() {
+      return this.getOrSet('cmsBuilder', cmsBuilder)
+    }
+  }
+
+  return {
+    ...contextMock.object,
+    body: {
+      generationId: 'gen-1',
+    },
+    clients: new ClientsImpl({}, ioContext.object),
+    state: {
+      ...state.object,
+      settings: {
+        contentPlatformContentTypes: DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+        contentPlatformStoreId: DEFAULT_CONTENT_PLATFORM_STORE_ID,
+        disableRoutesTerm,
+        enableAppsRoutes: true,
+        enableCmsRoutes: true,
+        enableContentPlatformRoutes: false,
+        enableNavigationRoutes: true,
+        enableProductRoutes: true,
+        hcmsContentTypes: DEFAULT_HCMS_CONTENT_TYPES,
+        hcmsProjectId: DEFAULT_HCMS_PROJECT_ID,
+        ignoreBindings: false,
+      },
+    },
+    vtex: {
+      ...ioContext.object,
+      logger: loggerMock.object,
+    },
+  } as EventContext
+}
+
+const bucketFor = (bindingId: string) => getBucket(CMS_ROUTES_PREFIX, hashString(bindingId))
+
+const collectPaths = (entries: SitemapEntry[]): string[] =>
+  entries.reduce<string[]>(
+    (acc, entry) => acc.concat(entry.routes.map(r => r.path)),
+    []
+  )
+
+const readSavedPaths = async (
+  context: EventContext,
+  bindingId = DEFAULT_BINDING_ID
+): Promise<string[]> => {
+  const { vbase } = context.clients
+  const index = await vbase.getJSON<SitemapIndex>(
+    bucketFor(bindingId),
+    CMS_ROUTES_INDEX,
+    true
+  )
+  if (!index) {
+    return []
+  }
+  const entries = await Promise.all(
+    index.index.map(file =>
+      vbase.getJSON<SitemapEntry>(bucketFor(bindingId), file, true)
+    )
+  )
+  return collectPaths(entries)
+}
+
+describe('generateCmsRoutes', () => {
+  beforeEach(() => {
+    next = jest.fn()
+  })
+
+  it('emits published Headless CMS slugs under the default store binding', async () => {
+    const context = buildContext({
+      pagesByContentType: {
+        landingPage: [
+          page({ id: '1', slug: '/our-story' }),
+          page({ id: '2', slug: '/black-friday' }),
+        ],
+      },
+    })
+    await generateCmsRoutes(context, next)
+
+    expect(next).toBeCalled()
+    const paths = (await readSavedPaths(context)).sort()
+    expect(paths).toEqual(['/black-friday', '/our-story'])
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor(DEFAULT_BINDING_ID),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    expect(index?.index).toEqual(['hcms-routes-0'])
+    expect(index?.index).not.toContain('cms-routes-0')
+  })
+
+  it('sets alternates to a single self entry pointing at the default binding', async () => {
+    const context = buildContext({
+      pagesByContentType: {
+        landingPage: [page({ id: '1', slug: '/our-story' })],
+      },
+    })
+    await generateCmsRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor(DEFAULT_BINDING_ID),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    const entry = await vbase.getJSON<SitemapEntry>(
+      bucketFor(DEFAULT_BINDING_ID),
+      index.index[0],
+      true
+    )
+    expect(entry.routes[0].alternates).toEqual([
+      { bindingId: DEFAULT_BINDING_ID, path: '/our-story' },
+    ])
+  })
+
+  it('excludes draft pages (only published reach the sitemap)', async () => {
+    const context = buildContext({
+      pagesByContentType: {
+        landingPage: [
+          page({ id: '1', slug: '/keep' }),
+          page({ id: '2', slug: '/wip', status: 'draft' }),
+        ],
+      },
+    })
+    await generateCmsRoutes(context, next)
+    expect(await readSavedPaths(context)).toEqual(['/keep'])
+  })
+
+  it('excludes pages without a slug and the homepage (slug "/")', async () => {
+    const context = buildContext({
+      pagesByContentType: {
+        landingPage: [
+          page({ id: '1', slug: '/our-story' }),
+          page({ id: '2', slug: null }),
+          page({ id: '3', slug: '/' }),
+        ],
+      },
+    })
+    await generateCmsRoutes(context, next)
+    expect(await readSavedPaths(context)).toEqual(['/our-story'])
+  })
+
+  it('excludes pages whose canonical points to a different URL, keeps self-canonical', async () => {
+    const context = buildContext({
+      pagesByContentType: {
+        landingPage: [
+          page({
+            id: '1',
+            settings: { seo: { canonical: '/other', slug: '/promo-old' } },
+            slug: '/promo-old',
+          }),
+          page({
+            id: '2',
+            settings: { seo: { canonical: '/self', slug: '/self' } },
+            slug: '/self',
+          }),
+        ],
+      },
+    })
+    await generateCmsRoutes(context, next)
+    expect(await readSavedPaths(context)).toEqual(['/self'])
+  })
+
+  it('honors disableRoutesTerm by filtering out matching substrings', async () => {
+    const context = buildContext({
+      disableRoutesTerm: '/internal/',
+      pagesByContentType: {
+        landingPage: [
+          page({ id: '1', slug: '/keep' }),
+          page({ id: '2', slug: '/internal/staging-only' }),
+        ],
+      },
+    })
+    await generateCmsRoutes(context, next)
+    expect(await readSavedPaths(context)).toEqual(['/keep'])
+  })
+
+  it('chunks routes into multiple files when CMS_ROUTES_MAX_URLS_PER_FILE is exceeded', async () => {
+    const overflowCount = CMS_ROUTES_MAX_URLS_PER_FILE + 5
+    const pages: CmsPage[] = Array.from({ length: overflowCount }).map((_, i) =>
+      page({ id: `cms-${i}`, slug: `/page-${i}` })
+    )
+    const context = buildContext({ pagesByContentType: { landingPage: pages } })
+    await generateCmsRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor(DEFAULT_BINDING_ID),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    expect(index.index.length).toBe(2)
+
+    const first = await vbase.getJSON<SitemapEntry>(
+      bucketFor(DEFAULT_BINDING_ID),
+      index.index[0],
+      true
+    )
+    const second = await vbase.getJSON<SitemapEntry>(
+      bucketFor(DEFAULT_BINDING_ID),
+      index.index[1],
+      true
+    )
+    expect(first.routes.length).toBe(CMS_ROUTES_MAX_URLS_PER_FILE)
+    expect(second.routes.length).toBe(5)
+  })
+
+  it('skips generation when enableCmsRoutes is off and does not touch VBase', async () => {
+    const context = buildContext({
+      pagesByContentType: {
+        landingPage: [page({ id: '1', slug: '/our-story' })],
+      },
+    })
+    context.state.settings.enableCmsRoutes = false
+    await generateCmsRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor(DEFAULT_BINDING_ID),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    expect(index).toBeNull()
+    expect(next).toBeCalled()
+  })
+
+  it('skips generation and does NOT touch VBase when Content Platform is the active source (US-6 / Decision 8)', async () => {
+    const context = buildContext({
+      pagesByContentType: {
+        landingPage: [page({ id: '1', slug: '/our-story' })],
+      },
+    })
+    context.state.settings.enableCmsRoutes = true
+    context.state.settings.enableContentPlatformRoutes = true
+    await generateCmsRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor(DEFAULT_BINDING_ID),
+      CMS_ROUTES_INDEX,
+      true
+    )
+    expect(index).toBeNull()
+    expect(next).toBeCalled()
+  })
+})

--- a/node/middlewares/generateMiddlewares/generateCmsRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateCmsRoutes.ts
@@ -1,0 +1,103 @@
+import { getDefaultStoreBinding } from '../../resources/bindings'
+import { fetchEligibleHcmsSlugs } from '../../services/hcmsRoutes'
+import { resolveActiveCmsSource } from '../../services/cmsSources'
+import {
+  CMS_ROUTES_MAX_BYTES_PER_FILE,
+  CMS_ROUTES_MAX_URLS_PER_FILE,
+  CMS_ROUTES_PREFIX,
+} from '../../utils'
+import { CMS_ROUTES_INDEX, saveRoutesChunks } from './utils'
+
+export const CMS_ROUTES_DEFAULT_CHANGEFREQ: ChangeFreq = 'weekly'
+export const CMS_ROUTES_DEFAULT_PRIORITY = 0.5
+
+const toRoute = (slug: string, bindingId: string): Route => ({
+  alternates: [{ bindingId, path: slug }],
+  changefreq: CMS_ROUTES_DEFAULT_CHANGEFREQ,
+  id: `hcms:${slug}`,
+  path: slug,
+  priority: CMS_ROUTES_DEFAULT_PRIORITY,
+  source: 'hcms',
+})
+
+const saveBindingChunks = (
+  ctx: Context | EventContext,
+  bindingId: string,
+  routes: Route[]
+) =>
+  saveRoutesChunks(
+    ctx,
+    bindingId,
+    routes,
+    CMS_ROUTES_PREFIX,
+    CMS_ROUTES_PREFIX,
+    CMS_ROUTES_INDEX,
+    CMS_ROUTES_MAX_URLS_PER_FILE,
+    CMS_ROUTES_MAX_BYTES_PER_FILE
+  )
+
+export async function generateCmsRoutes(
+  ctx: Context | EventContext,
+  next?: () => Promise<void>
+) {
+  const {
+    state: { settings },
+    vtex: { logger },
+  } = ctx
+
+  if (!settings?.enableCmsRoutes) {
+    logger.info({
+      message: 'CMS routes generation skipped: enableCmsRoutes is off',
+      type: 'cms-routes-generation-skipped',
+    })
+    if (next) {
+      await next()
+    }
+    return
+  }
+
+  if (resolveActiveCmsSource(settings) !== 'hcms') {
+    logger.info({
+      message: 'CMS routes generation skipped: source is not active',
+      type: 'cms-routes-generation-skipped',
+    })
+    if (next) {
+      await next()
+    }
+    return
+  }
+
+  const startTime = Date.now()
+  logger.info({
+    message: 'CMS routes generation started',
+    type: 'cms-routes-generation-started',
+  })
+
+  try {
+    const slugs = await fetchEligibleHcmsSlugs(ctx)
+    const bindingId = await getDefaultStoreBinding(ctx as Context)
+    const routes = slugs.map(slug => toRoute(slug, bindingId))
+
+    const totalFiles = await saveBindingChunks(ctx, bindingId, routes)
+
+    logger.info({
+      message: 'CMS routes generation complete',
+      type: 'cms-routes-generation-complete',
+      durationMs: Date.now() - startTime,
+      bindings: 1,
+      totalFiles,
+      totalRoutes: routes.length,
+    })
+  } catch (error) {
+    logger.error({
+      error,
+      message: 'CMS routes generation failed',
+      type: 'cms-routes-generation-error',
+    })
+    throw error
+  } finally {
+    if (next) {
+      await next()
+    }
+  }
+}

--- a/node/middlewares/generateMiddlewares/generateContentPlatformRoutes.test.ts
+++ b/node/middlewares/generateMiddlewares/generateContentPlatformRoutes.test.ts
@@ -1,0 +1,866 @@
+import {
+  IOContext,
+  Logger,
+  RequestConfig,
+  Tenant,
+  TenantClient,
+} from '@vtex/api'
+import * as TypeMoq from 'typemoq'
+
+import { Clients } from '../../clients'
+import {
+  CmsDataPlane,
+  ContentEntry,
+  DataPlaneListResponse,
+  EntriesList,
+  PublishedEntry,
+} from '../../clients/cmsDataPlane'
+import {
+  cacheFileNameFor,
+  CachedEntry,
+  CONTENT_PLATFORM_CACHE_BUCKET,
+} from '../../services/contentPlatformCache'
+import {
+  createMemoryVBaseMock,
+  LoggerCapture,
+  makeLogger,
+} from '../../test/fixtures/cmsTestFixtures'
+import {
+  CONTENT_PLATFORM_ROUTES_PREFIX,
+  getBucket,
+  hashString,
+} from '../../utils'
+import { generateContentPlatformRoutes } from './generateContentPlatformRoutes'
+import {
+  CONTENT_PLATFORM_ROUTES_INDEX,
+  SitemapEntry,
+  SitemapIndex,
+} from './utils'
+
+const tenantTypeMock = TypeMoq.Mock.ofInstance(TenantClient)
+const cmsDataPlaneTypeMock = TypeMoq.Mock.ofInstance(CmsDataPlane)
+const contextMock = TypeMoq.Mock.ofType<EventContext>()
+const ioContext = TypeMoq.Mock.ofType<IOContext>()
+const state = TypeMoq.Mock.ofType<State>()
+
+const bucketFor = (bindingId: string) =>
+  getBucket(CONTENT_PLATFORM_ROUTES_PREFIX, hashString(bindingId))
+
+const collectPaths = (entries: SitemapEntry[]): string[] =>
+  entries.reduce<string[]>(
+    (acc, entry) => acc.concat(entry.routes.map(r => r.path)),
+    []
+  )
+
+interface DataPlaneMockBehavior {
+  /**
+   * Map of `contentType` → ordered pages. Each call to `listEntries` for a
+   * given contentType returns the next page; subsequent calls walk the
+   * cursor until the last page (which carries `scroll: null`).
+   */
+  listings: Record<string, EntriesList[]>
+  /**
+   * Map of `${contentType}:${entryId}:${locale}` → published entry payload.
+   * Missing keys are treated as `404 notFound` (a locale not published for
+   * this entry — multi-locale fan-out skips that binding silently).
+   */
+  entriesByLocaleKey: Record<string, PublishedEntry>
+  /**
+   * Map of `${contentType}:${entryId}:${locale}` → ETag returned by the Data
+   * Plane on a fresh 200 response. When set, this is the ETag the cache
+   * layer persists.
+   */
+  etagByKey?: Record<string, string>
+  /**
+   * Keys whose `getEntry` call should respond `304 Not Modified` whenever
+   * the caller sends an `If-None-Match` matching `etagByKey[key]`. Used to
+   * test the cache hit path.
+   */
+  notModifiedKeys?: Set<string>
+}
+
+interface BuildContextOptions {
+  dataPlane: DataPlaneMockBehavior
+  enableCmsRoutes?: boolean
+  enableContentPlatformRoutes?: boolean
+  disableRoutesTerm?: string
+  bindings?: Tenant['bindings']
+  account?: string
+  contentPlatformStoreId?: string
+  contentPlatformContentTypes?: string[]
+  /**
+   * Pre-existing entries in the Content Platform cache bucket. Each key is
+   * the VBase file name (already base64url-encoded) under
+   * `CONTENT_PLATFORM_CACHE_BUCKET`, and the value is the deserialized
+   * cached entry. Used to seed cache-hit scenarios.
+   */
+  initialCache?: Record<string, CachedEntry>
+}
+
+const defaultBindings = ([
+  {
+    canonicalBaseAddress: 'www.host.com',
+    defaultLocale: 'en-US',
+    id: '1',
+    targetProduct: 'vtex-storefront',
+  },
+  {
+    canonicalBaseAddress: 'www.host.com/br',
+    defaultLocale: 'pt-BR',
+    id: '2',
+    targetProduct: 'vtex-storefront',
+  },
+] as unknown) as Tenant['bindings']
+
+const singleEnBinding = ([
+  {
+    canonicalBaseAddress: 'www.host.com',
+    defaultLocale: 'en-US',
+    id: '1',
+    targetProduct: 'vtex-storefront',
+  },
+] as unknown) as Tenant['bindings']
+
+const buildContext = (options: BuildContextOptions): EventContext => {
+  const {
+    dataPlane,
+    enableCmsRoutes = false,
+    enableContentPlatformRoutes = true,
+    disableRoutesTerm = '',
+    bindings = defaultBindings,
+    account = 'pm2023team2',
+    contentPlatformStoreId,
+    contentPlatformContentTypes,
+    initialCache,
+  } = options
+  const logger = makeLogger()
+
+  const VBaseMockClass = createMemoryVBaseMock(ioContext.object, {
+    initialData: initialCache
+      ? { [CONTENT_PLATFORM_CACHE_BUCKET]: { ...initialCache } }
+      : undefined,
+  })
+
+  // tslint:disable-next-line:max-classes-per-file
+  const vbaseImpl = class extends VBaseMockClass {}
+
+  // tslint:disable-next-line:max-classes-per-file
+  const tenant = class TenantMock extends tenantTypeMock.object {
+    constructor() {
+      super(ioContext.object)
+    }
+
+    public info = async (_?: RequestConfig) => ({ bindings } as Tenant)
+  }
+
+  let listEntriesCalls = 0
+  let getEntryCalls = 0
+  const listingCursors: Record<string, number> = {}
+
+  // tslint:disable-next-line:max-classes-per-file
+  const cmsDataPlane = class CmsDataPlaneMock extends cmsDataPlaneTypeMock.object {
+    constructor() {
+      super(ioContext.object)
+    }
+
+    public listEntries = async ({
+      contentType,
+    }: {
+      contentType: string
+    }): Promise<DataPlaneListResponse<EntriesList>> => {
+      listEntriesCalls += 1
+      const pages = dataPlane.listings[contentType] ?? []
+      const cursor = listingCursors[contentType] ?? 0
+      const page = pages[cursor]
+      listingCursors[contentType] = cursor + 1
+      if (!page) {
+        return {
+          data: { entries: [], scroll: null },
+          notModified: false,
+        }
+      }
+      return { data: page, notModified: false }
+    }
+
+    public getEntry = async ({
+      contentType,
+      entryId,
+      locale,
+      etag,
+    }: {
+      contentType: string
+      entryId: string
+      locale?: string
+      etag?: string
+    }): Promise<DataPlaneListResponse<PublishedEntry>> => {
+      getEntryCalls += 1
+      const key = `${contentType}:${entryId}:${locale ?? ''}`
+      const responseEtag = dataPlane.etagByKey?.[key]
+      if (
+        etag &&
+        responseEtag &&
+        etag === responseEtag &&
+        dataPlane.notModifiedKeys?.has(key)
+      ) {
+        return { etag, notModified: true }
+      }
+      const entry = dataPlane.entriesByLocaleKey[key]
+      if (!entry) {
+        return { notFound: true, notModified: false }
+      }
+      return { data: entry, etag: responseEtag, notModified: false }
+    }
+  }
+
+  // tslint:disable-next-line:max-classes-per-file
+  const ClientsImpl = class ClientsMock extends Clients {
+    get vbase() {
+      return this.getOrSet('vbase', vbaseImpl)
+    }
+
+    get tenant() {
+      return this.getOrSet('tenant', tenant)
+    }
+
+    get cmsDataPlane() {
+      return this.getOrSet('cmsDataPlane', cmsDataPlane)
+    }
+  }
+
+  const context = {
+    ...contextMock.object,
+    body: {
+      generationId: 'gen-1',
+    },
+    clients: new ClientsImpl({}, ioContext.object),
+    state: {
+      ...state.object,
+      settings: {
+        contentPlatformContentTypes,
+        contentPlatformStoreId,
+        disableRoutesTerm,
+        enableAppsRoutes: true,
+        enableCmsRoutes,
+        enableContentPlatformRoutes,
+        enableNavigationRoutes: true,
+        enableProductRoutes: true,
+        ignoreBindings: false,
+      },
+    },
+    vtex: {
+      ...ioContext.object,
+      account,
+      logger: (logger as unknown) as Logger,
+    },
+  } as EventContext
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(context as any).__logger = logger
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(context as any).__listEntriesCalls = () => listEntriesCalls
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(context as any).__getEntryCalls = () => getEntryCalls
+
+  return context
+}
+
+const makeListingEntry = (
+  overrides: Partial<ContentEntry> & Pick<ContentEntry, 'id'>
+): ContentEntry => ({
+  createdAt: '2026-01-01T00:00:00.000Z',
+  createdBy: null,
+  name: overrides.name ?? `Entry ${overrides.id}`,
+  searchKeywords: [],
+  updatedAt: '2026-05-27T18:14:36.148Z',
+  ...overrides,
+})
+
+/**
+ * Build a mock `PublishedEntry` that mirrors the real Content Platform Data
+ * Plane response shape: SEO metadata lives at the **root level** under `seo`,
+ * confirmed via direct API inspection. The `slug` field is the CMS internal
+ * name key (distinct from the public URL in `seo.slug`).
+ */
+const makePublishedEntry = (
+  overrides: Partial<PublishedEntry> & Pick<PublishedEntry, 'id' | 'seo'>
+): PublishedEntry => ({
+  sections: [],
+  slug: overrides.slug ?? `entry-${overrides.id}`,
+  ...overrides,
+})
+
+describe('generateContentPlatformRoutes', () => {
+  let next: jest.Mock
+
+  beforeEach(() => {
+    next = jest.fn()
+  })
+
+  it('ingests a landingPage entry using seo.slug as the sitemap path and updatedAt as lastmod (US-1)', async () => {
+    const context = buildContext({
+      dataPlane: {
+        entriesByLocaleKey: {
+          'landingPage:lp-1:en-US': makePublishedEntry({
+            id: 'lp-1',
+            seo: {
+              canonical: '',
+              slug: '/teste-sitemap-landing-page',
+            },
+            slug: 'sitemap-landing-page-test',
+          }),
+        },
+        listings: {
+          landingPage: [
+            {
+              entries: [
+                makeListingEntry({
+                  id: 'lp-1',
+                  name: 'Landing Page',
+                  updatedAt: '2026-05-27T18:14:36.148Z',
+                }),
+              ],
+              scroll: null,
+            },
+          ],
+        },
+      },
+    })
+
+    await generateContentPlatformRoutes(context, next)
+    expect(next).toBeCalled()
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    expect(index).not.toBeNull()
+    const entries = await Promise.all(
+      index.index.map(file =>
+        vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true)
+      )
+    )
+    expect(collectPaths(entries)).toEqual(['/teste-sitemap-landing-page'])
+    expect(entries[0].routes[0].lastmod).toBe('2026-05-27T18:14:36.148Z')
+    expect(entries[0].routes[0].source).toBe('content-platform')
+  })
+
+  it('skips generation entirely when enableContentPlatformRoutes is off (invariant 9 — settings gating)', async () => {
+    const context = buildContext({
+      dataPlane: { entriesByLocaleKey: {}, listings: { landingPage: [] } },
+      enableContentPlatformRoutes: false,
+    })
+
+    await generateContentPlatformRoutes(context, next)
+    expect(next).toBeCalled()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((context as any).__listEntriesCalls()).toBe(0)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    expect(index).toBeNull()
+  })
+
+  it('does not emit mutual-exclusivity log (handled by generateSitemap)', async () => {
+    const context = buildContext({
+      dataPlane: { entriesByLocaleKey: {}, listings: { landingPage: [] } },
+      enableCmsRoutes: true,
+      enableContentPlatformRoutes: true,
+    })
+
+    await generateContentPlatformRoutes(context, next)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const logger = (context as any).__logger as LoggerCapture
+    const mutexCalls = logger.info.mock.calls.filter(
+      call => call[0]?.type === 'cms-routes-ignored-by-mutual-exclusivity'
+    )
+    expect(mutexCalls.length).toBe(0)
+  })
+
+  it('excludes entries whose canonical points to a URL different from their own slug (Decision 10 — canonical-only opt-out)', async () => {
+    const context = buildContext({
+      dataPlane: {
+        entriesByLocaleKey: {
+          'landingPage:keep:en-US': makePublishedEntry({
+            id: 'keep',
+            seo: { canonical: '/promo-new', slug: '/promo-new' },
+          }),
+          'landingPage:old:en-US': makePublishedEntry({
+            id: 'old',
+            seo: { canonical: '/promo-new', slug: '/promo-old' },
+          }),
+        },
+        listings: {
+          landingPage: [
+            {
+              entries: [
+                makeListingEntry({ id: 'keep' }),
+                makeListingEntry({ id: 'old' }),
+              ],
+              scroll: null,
+            },
+          ],
+        },
+      },
+    })
+
+    await generateContentPlatformRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    const entries = await Promise.all(
+      index.index.map(file =>
+        vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true)
+      )
+    )
+    expect(collectPaths(entries)).toEqual(['/promo-new'])
+  })
+
+  it('treats empty-string canonical as "no override" (Data Plane default — Decision 10)', async () => {
+    const context = buildContext({
+      dataPlane: {
+        entriesByLocaleKey: {
+          'landingPage:lp-1:en-US': makePublishedEntry({
+            id: 'lp-1',
+            seo: { canonical: '', slug: '/our-story' },
+          }),
+        },
+        listings: {
+          landingPage: [
+            {
+              entries: [makeListingEntry({ id: 'lp-1' })],
+              scroll: null,
+            },
+          ],
+        },
+      },
+    })
+
+    await generateContentPlatformRoutes(context, next)
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    const entries = await Promise.all(
+      index.index.map(file =>
+        vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true)
+      )
+    )
+    expect(collectPaths(entries)).toEqual(['/our-story'])
+  })
+
+  it('paginates the listing via scroll cursor until the Data Plane returns null', async () => {
+    const context = buildContext({
+      dataPlane: {
+        entriesByLocaleKey: {
+          'landingPage:lp-1:en-US': makePublishedEntry({
+            id: 'lp-1',
+            seo: { canonical: '', slug: '/a' },
+          }),
+          'landingPage:lp-2:en-US': makePublishedEntry({
+            id: 'lp-2',
+            seo: { canonical: '', slug: '/b' },
+          }),
+          'landingPage:lp-3:en-US': makePublishedEntry({
+            id: 'lp-3',
+            seo: { canonical: '', slug: '/c' },
+          }),
+        },
+        listings: {
+          landingPage: [
+            {
+              entries: [makeListingEntry({ id: 'lp-1' })],
+              scroll: 'cursor-1',
+            },
+            {
+              entries: [
+                makeListingEntry({ id: 'lp-2' }),
+                makeListingEntry({ id: 'lp-3' }),
+              ],
+              scroll: null,
+            },
+          ],
+        },
+      },
+    })
+
+    await generateContentPlatformRoutes(context, next)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((context as any).__listEntriesCalls()).toBeGreaterThanOrEqual(2)
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    const entries = await Promise.all(
+      index.index.map(file =>
+        vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true)
+      )
+    )
+    expect(collectPaths(entries).sort()).toEqual(['/a', '/b', '/c'])
+  })
+
+  it('honors contentPlatformContentTypes setting when an explicit allowlist is provided', async () => {
+    const context = buildContext({
+      contentPlatformContentTypes: ['microsite'],
+      dataPlane: {
+        entriesByLocaleKey: {
+          'microsite:m-1:en-US': makePublishedEntry({
+            id: 'm-1',
+            seo: { canonical: '', slug: '/microsite/holiday' },
+          }),
+        },
+        listings: {
+          microsite: [
+            {
+              entries: [makeListingEntry({ id: 'm-1' })],
+              scroll: null,
+            },
+          ],
+        },
+      },
+    })
+
+    await generateContentPlatformRoutes(context, next)
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    const entries = await Promise.all(
+      index.index.map(file =>
+        vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true)
+      )
+    )
+    expect(collectPaths(entries)).toEqual(['/microsite/holiday'])
+  })
+
+  it('falls back to the default allowlist when contentPlatformContentTypes is missing or empty', async () => {
+    const context = buildContext({
+      contentPlatformContentTypes: [],
+      dataPlane: {
+        entriesByLocaleKey: {
+          'landingPage:lp-1:en-US': makePublishedEntry({
+            id: 'lp-1',
+            seo: { canonical: '', slug: '/our-story' },
+          }),
+        },
+        listings: {
+          landingPage: [
+            {
+              entries: [makeListingEntry({ id: 'lp-1' })],
+              scroll: null,
+            },
+          ],
+        },
+      },
+    })
+    await generateContentPlatformRoutes(context, next)
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    const entries = await Promise.all(
+      index.index.map(file =>
+        vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true)
+      )
+    )
+    expect(collectPaths(entries)).toEqual(['/our-story'])
+  })
+
+  it('emits one URL per actually-published locale and groups alternates from real publications (US-3 multi-locale fidelity)', async () => {
+    const context = buildContext({
+      bindings: defaultBindings,
+      dataPlane: {
+        entriesByLocaleKey: {
+          'landingPage:lp-1:en-US': makePublishedEntry({
+            id: 'lp-1',
+            locale_metadata: { code: 'en-US', locale: 'en-US' },
+            seo: { canonical: '', slug: '/about' },
+          }),
+          'landingPage:lp-1:pt-BR': makePublishedEntry({
+            id: 'lp-1',
+            locale_metadata: { code: 'pt-BR', locale: 'pt-BR' },
+            seo: { canonical: '', slug: '/sobre' },
+          }),
+        },
+        listings: {
+          landingPage: [
+            {
+              entries: [makeListingEntry({ id: 'lp-1' })],
+              scroll: null,
+            },
+          ],
+        },
+      },
+    })
+
+    await generateContentPlatformRoutes(context, next)
+
+    const { vbase } = context.clients
+    const indexEn = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    const indexPt = await vbase.getJSON<SitemapIndex>(
+      bucketFor('2'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    const enEntry = await vbase.getJSON<SitemapEntry>(
+      bucketFor('1'),
+      indexEn.index[0],
+      true
+    )
+    const ptEntry = await vbase.getJSON<SitemapEntry>(
+      bucketFor('2'),
+      indexPt.index[0],
+      true
+    )
+    expect(enEntry.routes[0].path).toBe('/about')
+    expect(ptEntry.routes[0].path).toBe('/sobre')
+    expect(enEntry.routes[0].alternates).toEqual([
+      { bindingId: '1', path: '/about' },
+      { bindingId: '2', path: '/sobre' },
+    ])
+    expect(ptEntry.routes[0].alternates).toEqual([
+      { bindingId: '1', path: '/about' },
+      { bindingId: '2', path: '/sobre' },
+    ])
+  })
+
+  it('does NOT synthesize alternates for locales the editor did not publish (404 → silent skip)', async () => {
+    const context = buildContext({
+      bindings: defaultBindings,
+      dataPlane: {
+        entriesByLocaleKey: {
+          'landingPage:lp-en-only:en-US': makePublishedEntry({
+            id: 'lp-en-only',
+            seo: { canonical: '', slug: '/about' },
+          }),
+        },
+        listings: {
+          landingPage: [
+            {
+              entries: [makeListingEntry({ id: 'lp-en-only' })],
+              scroll: null,
+            },
+          ],
+        },
+      },
+    })
+
+    await generateContentPlatformRoutes(context, next)
+
+    const { vbase } = context.clients
+    const indexEn = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    const indexPt = await vbase.getJSON<SitemapIndex>(
+      bucketFor('2'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    expect(indexPt).toBeNull()
+    const enEntry = await vbase.getJSON<SitemapEntry>(
+      bucketFor('1'),
+      indexEn.index[0],
+      true
+    )
+    expect(enEntry.routes[0].alternates).toEqual([
+      { bindingId: '1', path: '/about' },
+    ])
+  })
+
+  it('writes only the en-US bucket for stores with a single binding (smoke parity)', async () => {
+    const context = buildContext({
+      bindings: singleEnBinding,
+      dataPlane: {
+        entriesByLocaleKey: {
+          'landingPage:lp-1:en-US': makePublishedEntry({
+            id: 'lp-1',
+            seo: { canonical: '', slug: '/teste-sitemap-landing-page' },
+          }),
+        },
+        listings: {
+          landingPage: [
+            {
+              entries: [makeListingEntry({ id: 'lp-1' })],
+              scroll: null,
+            },
+          ],
+        },
+      },
+    })
+
+    await generateContentPlatformRoutes(context, next)
+
+    const { vbase } = context.clients
+    const indexPt = await vbase.getJSON<SitemapIndex>(
+      bucketFor('2'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    expect(indexPt).toBeNull()
+    const indexEn = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    expect(indexEn).not.toBeNull()
+  })
+
+  it('persists the Data Plane ETag in VBase on a fresh 200 response (invariant 13 — ETag cache write)', async () => {
+    const context = buildContext({
+      bindings: singleEnBinding,
+      dataPlane: {
+        entriesByLocaleKey: {
+          'landingPage:lp-1:en-US': makePublishedEntry({
+            id: 'lp-1',
+            seo: { canonical: '', slug: '/our-story' },
+          }),
+        },
+        etagByKey: { 'landingPage:lp-1:en-US': 'etag-fresh' },
+        listings: {
+          landingPage: [
+            {
+              entries: [makeListingEntry({ id: 'lp-1' })],
+              scroll: null,
+            },
+          ],
+        },
+      },
+    })
+
+    await generateContentPlatformRoutes(context, next)
+    const cached = await context.clients.vbase.getJSON<CachedEntry>(
+      CONTENT_PLATFORM_CACHE_BUCKET,
+      cacheFileNameFor({
+        contentType: 'landingPage',
+        entryId: 'lp-1',
+        locale: 'en-US',
+      }),
+      true
+    )
+    expect(cached).not.toBeNull()
+    expect(cached.etag).toBe('etag-fresh')
+    expect(cached.entry.seo?.slug).toBe('/our-story')
+  })
+
+  it('reuses the cached PublishedEntry when the Data Plane returns 304 (invariant 13 — ETag cache hit)', async () => {
+    const fileName = cacheFileNameFor({
+      contentType: 'landingPage',
+      entryId: 'lp-1',
+      locale: 'en-US',
+    })
+    const seedCachedEntry = makePublishedEntry({
+      id: 'lp-1',
+      seo: { canonical: '', slug: '/cached-from-previous-run' },
+    })
+    const context = buildContext({
+      bindings: singleEnBinding,
+      dataPlane: {
+        // The Data Plane will respond 304, so the listing-only payload is
+        // returned but the body intentionally does NOT contain the entry —
+        // the middleware must read it from the cache, not the live response.
+        entriesByLocaleKey: {},
+        etagByKey: { 'landingPage:lp-1:en-US': 'etag-prev' },
+        listings: {
+          landingPage: [
+            {
+              entries: [makeListingEntry({ id: 'lp-1' })],
+              scroll: null,
+            },
+          ],
+        },
+        notModifiedKeys: new Set(['landingPage:lp-1:en-US']),
+      },
+      initialCache: {
+        [fileName]: {
+          cachedAt: '2026-05-26T00:00:00.000Z',
+          entry: seedCachedEntry,
+          etag: 'etag-prev',
+        },
+      },
+    })
+
+    await generateContentPlatformRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    const entries = await Promise.all(
+      index.index.map(file =>
+        vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true)
+      )
+    )
+    expect(collectPaths(entries)).toEqual(['/cached-from-previous-run'])
+  })
+
+  it('honors disableRoutesTerm by filtering out matching substrings', async () => {
+    const context = buildContext({
+      dataPlane: {
+        entriesByLocaleKey: {
+          'landingPage:keep:en-US': makePublishedEntry({
+            id: 'keep',
+            seo: { canonical: '', slug: '/keep' },
+          }),
+          'landingPage:hide:en-US': makePublishedEntry({
+            id: 'hide',
+            seo: { canonical: '', slug: '/internal/staging-only' },
+          }),
+        },
+        listings: {
+          landingPage: [
+            {
+              entries: [
+                makeListingEntry({ id: 'keep' }),
+                makeListingEntry({ id: 'hide' }),
+              ],
+              scroll: null,
+            },
+          ],
+        },
+      },
+      disableRoutesTerm: '/internal/',
+    })
+
+    await generateContentPlatformRoutes(context, next)
+
+    const { vbase } = context.clients
+    const index = await vbase.getJSON<SitemapIndex>(
+      bucketFor('1'),
+      CONTENT_PLATFORM_ROUTES_INDEX,
+      true
+    )
+    const entries = await Promise.all(
+      index.index.map(file =>
+        vbase.getJSON<SitemapEntry>(bucketFor('1'), file, true)
+      )
+    )
+    expect(collectPaths(entries)).toEqual(['/keep'])
+  })
+})

--- a/node/middlewares/generateMiddlewares/generateContentPlatformRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateContentPlatformRoutes.ts
@@ -1,0 +1,414 @@
+import { Binding } from '@vtex/api'
+
+import {
+  ContentEntry,
+  EntriesList,
+  PublishedEntry,
+} from '../../clients/cmsDataPlane'
+import {
+  DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+  DEFAULT_CONTENT_PLATFORM_STORE_ID,
+} from '../settings'
+import {
+  readCachedEntry,
+  writeCachedEntry,
+} from '../../services/contentPlatformCache'
+import { isEligibleCmsPath } from '../../services/cmsEligibility'
+import { resolveActiveCmsSource } from '../../services/cmsSources'
+import {
+  CMS_ROUTES_MAX_BYTES_PER_FILE,
+  CMS_ROUTES_MAX_URLS_PER_FILE,
+  CONTENT_PLATFORM_ROUTES_PREFIX,
+  TENANT_CACHE_TTL_S,
+} from '../../utils'
+import {
+  CONTENT_PLATFORM_ROUTES_INDEX,
+  saveRoutesChunks,
+} from './utils'
+
+/**
+ * Defaults applied to every Content Platform URL (FR-5).
+ */
+export const CONTENT_PLATFORM_DEFAULT_CHANGEFREQ: ChangeFreq = 'weekly'
+export const CONTENT_PLATFORM_DEFAULT_PRIORITY = 0.5
+
+interface BindingCandidate {
+  bindingId: string
+  path: string
+}
+
+interface RouteCandidate {
+  /** Stable identifier of the entry across locales — used to group alternates. */
+  entryId: string
+  candidate: BindingCandidate
+  /** Listing-level `updatedAt` — the source of truth for `<lastmod>`. */
+  updatedAt: string
+}
+
+interface BuildRouteArgs {
+  entryId: string
+  candidate: BindingCandidate
+  alternates: AlternateRoute[]
+  updatedAt: string
+}
+
+const toRoute = ({
+  entryId,
+  candidate,
+  alternates,
+  updatedAt,
+}: BuildRouteArgs): Route => ({
+  alternates,
+  changefreq: CONTENT_PLATFORM_DEFAULT_CHANGEFREQ,
+  id: `${entryId}:${candidate.bindingId}`,
+  lastmod: updatedAt,
+  path: candidate.path,
+  priority: CONTENT_PLATFORM_DEFAULT_PRIORITY,
+  source: 'content-platform',
+})
+
+const saveBindingChunks = (
+  ctx: Context | EventContext,
+  bindingId: string,
+  routes: Route[]
+) =>
+  saveRoutesChunks(
+    ctx,
+    bindingId,
+    routes,
+    CONTENT_PLATFORM_ROUTES_PREFIX,
+    CONTENT_PLATFORM_ROUTES_PREFIX,
+    CONTENT_PLATFORM_ROUTES_INDEX,
+    CMS_ROUTES_MAX_URLS_PER_FILE,
+    CMS_ROUTES_MAX_BYTES_PER_FILE
+  )
+
+const indexEntriesByBinding = (
+  candidates: RouteCandidate[]
+): Map<string, Route[]> => {
+  const byEntry = new Map<string, RouteCandidate[]>()
+  for (const item of candidates) {
+    const group = byEntry.get(item.entryId) ?? []
+    group.push(item)
+    byEntry.set(item.entryId, group)
+  }
+
+  const byId = new Map<string, Route[]>()
+  for (const group of byEntry.values()) {
+    const alternates: AlternateRoute[] = group.map(({ candidate }) => ({
+      bindingId: candidate.bindingId,
+      path: candidate.path,
+    }))
+    for (const { entryId, candidate, updatedAt } of group) {
+      const route = toRoute({ alternates, candidate, entryId, updatedAt })
+      const bucket = byId.get(candidate.bindingId) ?? []
+      bucket.push(route)
+      byId.set(candidate.bindingId, bucket)
+    }
+  }
+  return byId
+}
+
+interface HydrateEntryArgs {
+  accountName: string
+  storeId: string
+  contentType: string
+  entryId: string
+  locale?: string
+}
+
+/**
+ * Hydrate a listing entry into a fully-resolved `PublishedEntry` (with root-
+ * level `seo.slug` and `seo.canonical`) by calling `getEntry` per item,
+ * scoped to a locale. Backed by a VBase ETag cache so steady-state runs
+ * collapse to cheap `304 Not Modified` exchanges: only entries the editor
+ * actually touched re-serialize through the Data Plane.
+ *
+ * Returns `null` for hard failures or when the entry is missing for the
+ * requested locale (404 is treated as "skip this binding" — spec invariant
+ * "no synthesized alternates").
+ */
+const hydrateEntry = async (
+  ctx: Context | EventContext,
+  args: HydrateEntryArgs
+): Promise<PublishedEntry | null> => {
+  const {
+    clients: { cmsDataPlane, vbase },
+    vtex: { logger },
+  } = ctx
+  if (!args.locale) {
+    return null
+  }
+  const cacheKey = {
+    contentType: args.contentType,
+    entryId: args.entryId,
+    locale: args.locale,
+  }
+  const cached = await readCachedEntry(vbase, cacheKey)
+  try {
+    const response = await cmsDataPlane.getEntry({
+      accountName: args.accountName,
+      contentType: args.contentType,
+      entryId: args.entryId,
+      etag: cached?.etag,
+      locale: args.locale,
+      storeId: args.storeId,
+    })
+    if (response.notFound) {
+      return null
+    }
+    if (response.notModified && cached) {
+      return cached.entry
+    }
+    if (response.data) {
+      if (response.etag) {
+        await writeCachedEntry(
+          vbase,
+          cacheKey,
+          response.etag,
+          response.data
+        )
+      }
+      return response.data
+    }
+    return null
+  } catch (error) {
+    logger.warn({
+      contentType: args.contentType,
+      entryId: args.entryId,
+      error: error?.message ?? String(error),
+      locale: args.locale,
+      message: 'Content Platform: failed to hydrate entry; skipping',
+      type: 'content-platform-entry-hydration-failed',
+    })
+    return null
+  }
+}
+
+const isEligible = (
+  entry: PublishedEntry,
+  disableRoutesTerm: string
+): boolean => {
+  const slug = entry.seo?.slug
+  if (!slug) {
+    return false
+  }
+  return isEligibleCmsPath({
+    canonical: entry.seo?.canonical,
+    disableRoutesTerm,
+    slug,
+  })
+}
+
+const listAllEntries = async (
+  ctx: Context | EventContext,
+  accountName: string,
+  storeId: string,
+  contentType: string
+): Promise<ContentEntry[]> => {
+  const {
+    clients: { cmsDataPlane },
+  } = ctx
+  const all: ContentEntry[] = []
+  let scroll: string | undefined
+  // Cursor-based pagination — repeat until the Data Plane returns `null`.
+  // Each call is independent for retry/backoff purposes.
+  do {
+    // eslint-disable-next-line no-await-in-loop
+    const response = await cmsDataPlane.listEntries({
+      accountName,
+      contentType,
+      scroll,
+      storeId,
+    })
+    const data = response.data as EntriesList | undefined
+    if (!data?.entries) {
+      break
+    }
+    all.push(...data.entries)
+    scroll = data.scroll ?? undefined
+  } while (scroll)
+  return all
+}
+
+/**
+ * Bindings with no `defaultLocale` cannot be fanned-out — the Data Plane
+ * needs an explicit locale per call. The earlier behaviour silently dropped
+ * them via the locale-match fallback; we keep that semantics with an
+ * explicit filter.
+ */
+const localeForBinding = (binding: Binding): string | null =>
+  binding.defaultLocale?.trim() || null
+
+const ingestContentType = async (
+  ctx: Context | EventContext,
+  bindings: Binding[],
+  accountName: string,
+  storeId: string,
+  contentType: string,
+  disableRoutesTerm: string
+): Promise<RouteCandidate[]> => {
+  const listing = await listAllEntries(ctx, accountName, storeId, contentType)
+  const results: RouteCandidate[] = []
+  for (const entry of listing) {
+    const hydratedByBinding = await Promise.all(
+      bindings.map(async binding => {
+        const locale = localeForBinding(binding)
+        if (!locale) {
+          return null
+        }
+        const published = await hydrateEntry(ctx, {
+          accountName,
+          contentType,
+          entryId: entry.id,
+          locale,
+          storeId,
+        })
+        if (!published || !isEligible(published, disableRoutesTerm)) {
+          return null
+        }
+        const slug = published.seo?.slug
+        if (!slug) {
+          return null
+        }
+        return { binding, slug }
+      })
+    )
+    for (const hydrated of hydratedByBinding) {
+      if (!hydrated) {
+        continue
+      }
+      results.push({
+        candidate: { bindingId: hydrated.binding.id, path: hydrated.slug },
+        entryId: entry.id,
+        updatedAt: entry.updatedAt,
+      })
+    }
+  }
+  return results
+}
+
+const fetchStoreBindings = async (
+  ctx: Context | EventContext
+): Promise<Binding[]> => {
+  const {
+    clients: { tenant },
+  } = ctx
+  const tenantInfo = await tenant.info({
+    forceMaxAge: TENANT_CACHE_TTL_S,
+  })
+  return (tenantInfo.bindings ?? []).filter(
+    b => b.targetProduct === 'vtex-storefront'
+  )
+}
+
+/**
+ * Ingest Content Platform routes for every store binding and persist them to
+ * VBase under `content-platform-routes_*`. P2.1 wires this against the real
+ * Content Platform Data Plane API (host `vtexcommercestable.com.br`, path
+ * `/api/content-platform/data/*`) with a hardcoded allowlist of routable
+ * content types (`landingPage`, `home`). P2.2 lifts the allowlist into a
+ * setting, persists ETags across runs and fans out per-locale calls per
+ * binding.
+ *
+ * Mutually exclusive with `generateCmsRoutes` (spec Decision 8 / FR-10): the
+ * mutex log fires when both flags are on; the hCMS skip itself happens in
+ * `generateCmsRoutes`.
+ */
+export async function generateContentPlatformRoutes(
+  ctx: Context | EventContext,
+  next?: () => Promise<void>
+) {
+  const {
+    state: { settings },
+    vtex: { account, logger },
+  } = ctx
+
+  const activeSource = resolveActiveCmsSource(settings)
+
+  if (activeSource !== 'content-platform') {
+    logger.info({
+      activeSource,
+      message:
+        'Content Platform routes generation skipped: source is not active',
+      type: 'content-platform-routes-generation-skipped',
+    })
+    if (next) {
+      await next()
+    }
+    return
+  }
+
+  const disableRoutesTerm = settings?.disableRoutesTerm || ''
+  const startTime = Date.now()
+  logger.info({
+    message: 'Content Platform routes generation started',
+    type: 'content-platform-routes-generation-start',
+  })
+
+  try {
+    const bindings = await fetchStoreBindings(ctx)
+    const accountName = account
+    const storeId =
+      settings?.contentPlatformStoreId?.trim() ||
+      DEFAULT_CONTENT_PLATFORM_STORE_ID
+    const contentTypes =
+      settings?.contentPlatformContentTypes &&
+      settings.contentPlatformContentTypes.length > 0
+        ? settings.contentPlatformContentTypes
+        : DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES
+
+    const perTypeCounts: Record<string, number> = {}
+    const allCandidates: RouteCandidate[] = []
+    for (const contentType of contentTypes) {
+      // eslint-disable-next-line no-await-in-loop
+      const candidates = await ingestContentType(
+        ctx,
+        bindings,
+        accountName,
+        storeId,
+        contentType,
+        disableRoutesTerm
+      )
+      perTypeCounts[contentType] = candidates.length
+      allCandidates.push(...candidates)
+    }
+
+    const byBinding = indexEntriesByBinding(allCandidates)
+    const bindingIds = Array.from(byBinding.keys())
+    const fileCounts = await Promise.all(
+      bindingIds.map(bindingId =>
+        saveBindingChunks(ctx, bindingId, byBinding.get(bindingId)!)
+      )
+    )
+
+    const totalRoutes = Array.from(byBinding.values()).reduce(
+      (sum, routes) => sum + routes.length,
+      0
+    )
+    const totalFiles = fileCounts.reduce((sum, n) => sum + n, 0)
+
+    logger.info({
+      accountName,
+      bindings: bindingIds.length,
+      durationMs: Date.now() - startTime,
+      message: 'Content Platform routes generation complete',
+      perTypeCounts,
+      storeId,
+      totalFiles,
+      totalRoutes,
+      type: 'content-platform-routes-generation-success',
+    })
+  } catch (error) {
+    logger.error({
+      error,
+      message: 'Content Platform routes generation failed',
+      type: 'content-platform-routes-generation-error',
+    })
+    throw error
+  } finally {
+    if (next) {
+      await next()
+    }
+  }
+}

--- a/node/middlewares/generateMiddlewares/generateCustomRoutes.ts
+++ b/node/middlewares/generateMiddlewares/generateCustomRoutes.ts
@@ -1,6 +1,11 @@
 import { getDefaultStoreBinding } from '../../resources/bindings'
 import { clearCustomRoutesGenerationLock } from '../customRoutes'
-import { getAppsRoutes, getUserRoutes } from '../../services/routes'
+import {
+  getAppsRoutes,
+  getCmsRoutes,
+  getContentPlatformRoutes,
+  getUserRoutes,
+} from '../../services/routes'
 import { CUSTOM_ROUTES_BUCKET, CUSTOM_ROUTES_FILENAME } from '../../utils'
 
 export async function generateCustomRoutes(ctx: Context) {
@@ -35,22 +40,33 @@ export async function generateCustomRoutes(ctx: Context) {
       vtex: ctx.vtex,
     } as Context
 
-    const [appsRoutes, userRoutes] = await Promise.all([
+    const [appsRoutes, userRoutes, cmsRoutes, contentPlatformRoutes] = await Promise.all([
       getAppsRoutes(routeCtx),
       getUserRoutes(routeCtx),
+      getCmsRoutes(routeCtx),
+      getContentPlatformRoutes(routeCtx),
     ])
 
     logger.info({
       message: 'Routes fetched',
       appsRoutesCount: appsRoutes.length,
+      cmsRoutesCount: cmsRoutes.length,
+      contentPlatformRoutesCount: contentPlatformRoutes.length,
       userRoutesCount: userRoutes.length,
     })
 
+    // Both CMS sources are always written to the cache; the served-time
+    // mutex filter in `customRoutes.ts` decides which one is exposed for
+    // any given request (spec Decision 8 / FR-10). Each `get*Routes`
+    // service already returns `[]` for the inactive source, so the
+    // payload reflects the active surface at generation time.
     const customRoutesData: CustomRoutesData = {
       timestamp: Date.now(),
       data: [
         { name: 'apps-routes', routes: appsRoutes },
         { name: 'user-routes', routes: userRoutes },
+        { name: 'cms-routes', routes: cmsRoutes },
+        { name: 'content-platform-routes', routes: contentPlatformRoutes },
       ],
     }
 

--- a/node/middlewares/generateMiddlewares/generateRewriterRoutes.test.ts
+++ b/node/middlewares/generateMiddlewares/generateRewriterRoutes.test.ts
@@ -95,7 +95,7 @@ describe('Test rewriter routes generation', () => {
       return []
     }
 
-    public listInternals = async (_: number, cursor: Maybe<string>) => {
+    public listInternalsWithRetry = async (_: number, cursor: Maybe<string>) => {
       switch(cursor) {
         case 'NEXT':
           return {
@@ -192,6 +192,7 @@ describe('Test rewriter routes generation', () => {
         event: GENERATE_REWRITER_ROUTES_EVENT,
         payload: {
           count: 1,
+          disableRoutesTerm: undefined,
           generationId: '1',
           next: 'NEXT',
           report: { category: 1, 'user-canonical': 1, userRoute: 1 },

--- a/node/middlewares/generateMiddlewares/generateSitemap.test.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.test.ts
@@ -2,9 +2,15 @@ import { Events, IOContext, Logger } from '@vtex/api'
 import * as TypeMoq from 'typemoq'
 
 import { Clients } from '../../clients'
+import {
+  DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+  DEFAULT_CONTENT_PLATFORM_STORE_ID,
+} from '../settings'
 import { generateSitemap } from './generateSitemap'
 import {
   GENERATE_APPS_ROUTES_EVENT,
+  GENERATE_CMS_ROUTES_EVENT,
+  GENERATE_CONTENT_PLATFORM_ROUTES_EVENT,
   GENERATE_PRODUCT_ROUTES_EVENT,
   GENERATE_REWRITER_ROUTES_EVENT,
 } from './utils'
@@ -23,6 +29,7 @@ const DEFAULT_APPS_ROUTES_PAYLOAD = {
 
 const DEFAULT_REWRITER_ROUTES_PAYLOAD = {
   count: 0,
+  disableRoutesTerm: '',
   generationId: '1',
   next: null,
   report: {},
@@ -71,8 +78,12 @@ describe('Test generate sitemap', () => {
       state: {
         ...state.object,
         settings: {
+          contentPlatformContentTypes: DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+          contentPlatformStoreId: DEFAULT_CONTENT_PLATFORM_STORE_ID,
           disableRoutesTerm: '',
           enableAppsRoutes: true,
+          enableCmsRoutes: true,
+          enableContentPlatformRoutes: false,
           enableNavigationRoutes: true,
           enableProductRoutes: true,
           ignoreBindings: false,
@@ -102,12 +113,21 @@ describe('Test generate sitemap', () => {
       GENERATE_APPS_ROUTES_EVENT,
       DEFAULT_APPS_ROUTES_PAYLOAD
     )
+    expect(eventSent).toHaveBeenCalledWith(
+      '',
+      GENERATE_CMS_ROUTES_EVENT,
+      { generationId: '1' }
+    )
   })
 
   it('Should send only enabled events', async () => {
     context.state.settings = {
+      contentPlatformContentTypes: DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+      contentPlatformStoreId: DEFAULT_CONTENT_PLATFORM_STORE_ID,
       disableRoutesTerm: '',
       enableAppsRoutes: true,
+      enableCmsRoutes: true,
+      enableContentPlatformRoutes: false,
       enableNavigationRoutes: true,
       enableProductRoutes: false,
       ignoreBindings: false,
@@ -124,12 +144,23 @@ describe('Test generate sitemap', () => {
       GENERATE_APPS_ROUTES_EVENT,
       DEFAULT_APPS_ROUTES_PAYLOAD
     )
-    expect(eventSent).toHaveBeenCalledTimes(2)
+    // hCMS event also fires because enableCmsRoutes is on and Content
+    // Platform is off (active source resolves to 'hcms' per Decision 8).
+    expect(eventSent).toHaveBeenCalledWith(
+      '',
+      GENERATE_CMS_ROUTES_EVENT,
+      { generationId: '1' }
+    )
+    expect(eventSent).toHaveBeenCalledTimes(3)
 
     jest.clearAllMocks()
     context.state.settings = {
+      contentPlatformContentTypes: DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+      contentPlatformStoreId: DEFAULT_CONTENT_PLATFORM_STORE_ID,
       disableRoutesTerm: '',
       enableAppsRoutes: false,
+      enableCmsRoutes: true,
+      enableContentPlatformRoutes: false,
       enableNavigationRoutes: false,
       enableProductRoutes: true,
       ignoreBindings: false,
@@ -141,6 +172,92 @@ describe('Test generate sitemap', () => {
       GENERATE_PRODUCT_ROUTES_EVENT,
       DEFAULT_PRODUCT_ROUTES_PAYLOAD
     )
+    expect(eventSent).toHaveBeenCalledWith(
+      '',
+      GENERATE_CMS_ROUTES_EVENT,
+      { generationId: '1' }
+    )
+    expect(eventSent).toHaveBeenCalledTimes(2)
+  })
+
+  it('emits GENERATE_CONTENT_PLATFORM_ROUTES_EVENT (not the hCMS event) when the Content Platform flag wins (US-6 / Decision 8)', async () => {
+    context.state.settings = {
+      contentPlatformContentTypes: DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+      contentPlatformStoreId: DEFAULT_CONTENT_PLATFORM_STORE_ID,
+      disableRoutesTerm: '',
+      enableAppsRoutes: false,
+      enableCmsRoutes: true,
+      enableContentPlatformRoutes: true,
+      enableNavigationRoutes: false,
+      enableProductRoutes: false,
+      ignoreBindings: false,
+    }
+
+    await generateSitemap(context)
+    expect(eventSent).toHaveBeenCalledWith(
+      '',
+      GENERATE_CONTENT_PLATFORM_ROUTES_EVENT,
+      { generationId: '1' }
+    )
+    // hCMS event MUST NOT fire when Content Platform is the active source.
+    const cmsCall = eventSent.mock.calls.find(
+      ([, event]) => event === GENERATE_CMS_ROUTES_EVENT
+    )
+    expect(cmsCall).toBeUndefined()
     expect(eventSent).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits cms-routes-ignored-by-mutual-exclusivity once per generation when both flags are on (US-6 / Decision 8)', async () => {
+    const infoSpy = jest.fn()
+    context.vtex.logger = {
+      ...loggerMock.object,
+      info: infoSpy,
+    } as unknown as Logger
+    context.state.settings = {
+      contentPlatformContentTypes: DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+      contentPlatformStoreId: DEFAULT_CONTENT_PLATFORM_STORE_ID,
+      disableRoutesTerm: '',
+      enableAppsRoutes: false,
+      enableCmsRoutes: true,
+      enableContentPlatformRoutes: true,
+      enableNavigationRoutes: false,
+      enableProductRoutes: false,
+      ignoreBindings: false,
+    }
+
+    await generateSitemap(context)
+
+    expect(
+      infoSpy.mock.calls.some(
+        call => call[0]?.type === 'cms-routes-ignored-by-mutual-exclusivity'
+      )
+    ).toBe(true)
+    expect(eventSent).toHaveBeenCalledWith(
+      '',
+      GENERATE_CONTENT_PLATFORM_ROUTES_EVENT,
+      { generationId: '1' }
+    )
+  })
+
+  it('emits NEITHER CMS source event when both flags are off (US-6 — backwards compatibility)', async () => {
+    context.state.settings = {
+      contentPlatformContentTypes: DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+      contentPlatformStoreId: DEFAULT_CONTENT_PLATFORM_STORE_ID,
+      disableRoutesTerm: '',
+      enableAppsRoutes: true,
+      enableCmsRoutes: false,
+      enableContentPlatformRoutes: false,
+      enableNavigationRoutes: true,
+      enableProductRoutes: true,
+      ignoreBindings: false,
+    }
+
+    await generateSitemap(context)
+    const cmsCall = eventSent.mock.calls.find(
+      ([, event]) =>
+        event === GENERATE_CMS_ROUTES_EVENT ||
+        event === GENERATE_CONTENT_PLATFORM_ROUTES_EVENT
+    )
+    expect(cmsCall).toBeUndefined()
   })
 })

--- a/node/middlewares/generateMiddlewares/generateSitemap.ts
+++ b/node/middlewares/generateMiddlewares/generateSitemap.ts
@@ -1,3 +1,8 @@
+import {
+  getCmsGenerateEvent,
+  logCmsMutualExclusivityIfNeeded,
+  resolveActiveCmsSource,
+} from '../../services/cmsSources'
 import { startSitemapGeneration } from '../../utils'
 import { MultipleSitemapGenerationError } from './../../errors'
 
@@ -28,7 +33,12 @@ const DEFAULT_REWRITER_ROUTES_PAYLOAD = {
 }
 
 export async function generateSitemap(ctx: EventContext) {
-  const { clients: { events }, body: { generationId }, state: { settings } }  = ctx
+  const {
+    clients: { events },
+    body: { generationId },
+    state: { settings },
+    vtex: { logger },
+  } = ctx
   const disableRoutesTerm = settings.disableRoutesTerm
   if (settings.enableNavigationRoutes) {
     events.sendEvent('', GENERATE_REWRITER_ROUTES_EVENT, {
@@ -49,5 +59,13 @@ export async function generateSitemap(ctx: EventContext) {
 
   if (settings.enableAppsRoutes) {
     events.sendEvent('', GENERATE_APPS_ROUTES_EVENT, { generationId })
+  }
+
+  logCmsMutualExclusivityIfNeeded(settings, logger)
+
+  const activeCmsSource = resolveActiveCmsSource(settings)
+  const cmsEvent = getCmsGenerateEvent(activeCmsSource)
+  if (cmsEvent) {
+    events.sendEvent('', cmsEvent, { generationId })
   }
 }

--- a/node/middlewares/generateMiddlewares/utils.ts
+++ b/node/middlewares/generateMiddlewares/utils.ts
@@ -3,18 +3,28 @@ import { uniqBy } from 'ramda'
 import { Product, SalesChannel } from 'vtex.catalog-graphql'
 
 import { Messages } from '../../clients/messages'
-import { CONFIG_BUCKET, getBucket, hashString, TENANT_CACHE_TTL_S } from '../../utils'
+import {
+  CONFIG_BUCKET,
+  getBucket,
+  hashString,
+  TENANT_CACHE_TTL_S,
+} from '../../utils'
 
 export const RAW_DATA_PREFIX = `${LINKED ? 'L' : ''}C`
 
 export const REWRITER_ROUTES_INDEX = 'rewriterRoutesIndex.json'
 export const PRODUCT_ROUTES_INDEX = 'productRoutesIndex.json'
 export const APPS_ROUTES_INDEX = 'appsRoutesIndex.json'
+export const CMS_ROUTES_INDEX = 'cmsRoutesIndex.json'
+export const CONTENT_PLATFORM_ROUTES_INDEX = 'contentPlatformRoutesIndex.json'
 
 export const GENERATE_SITEMAP_EVENT = 'sitemap.generate'
 export const GENERATE_REWRITER_ROUTES_EVENT = 'sitemap.generate:rewriter-routes'
 export const GENERATE_PRODUCT_ROUTES_EVENT = 'sitemap.generate:product-routes'
 export const GENERATE_APPS_ROUTES_EVENT = 'sitemap.generate:apps-routes'
+export const GENERATE_CMS_ROUTES_EVENT = 'sitemap.generate:cms-routes'
+export const GENERATE_CONTENT_PLATFORM_ROUTES_EVENT =
+  'sitemap.generate:content-platform-routes'
 export const GROUP_ENTRIES_EVENT = 'sitemap.generate:group-entries'
 
 export const DEFAULT_CONFIG: Config = {
@@ -42,6 +52,90 @@ export const uniq = <T>(array: T[]) => array.filter((value, idx) => array.indexO
 export const createFileName = (entity: string, count: number) => `${entity}-${count}`
 
 export const splitFileName = (file: string) => file.split('-')
+
+// Rough JSON byte size estimate — adequate as a proxy for serialized output
+// because XML produced from each Route is within a constant factor of its JSON.
+export const estimateRouteBytes = (route: Route): number =>
+  JSON.stringify(route).length
+
+export interface ChunkAccumulator {
+  chunks: Route[][]
+  current: Route[]
+  currentBytes: number
+}
+
+export const newAccumulator = (): ChunkAccumulator => ({
+  chunks: [],
+  current: [],
+  currentBytes: 0,
+})
+
+export const pushRoute = (
+  acc: ChunkAccumulator,
+  route: Route,
+  maxUrlsPerFile: number,
+  maxBytesPerFile: number
+) => {
+  const routeBytes = estimateRouteBytes(route)
+  const wouldExceedUrls = acc.current.length >= maxUrlsPerFile
+  const wouldExceedBytes =
+    acc.current.length > 0 &&
+    acc.currentBytes + routeBytes > maxBytesPerFile
+  if (wouldExceedUrls || wouldExceedBytes) {
+    acc.chunks.push(acc.current)
+    acc.current = []
+    acc.currentBytes = 0
+  }
+  acc.current.push(route)
+  acc.currentBytes += routeBytes
+}
+
+export const flushAccumulator = (acc: ChunkAccumulator): Route[][] => {
+  if (acc.current.length > 0) {
+    acc.chunks.push(acc.current)
+    acc.current = []
+    acc.currentBytes = 0
+  }
+  return acc.chunks
+}
+
+export const saveRoutesChunks = async (
+  ctx: Context | EventContext,
+  bindingId: string,
+  routes: Route[],
+  bucketPrefix: string,
+  fileNamePrefix: string,
+  indexFile: string,
+  maxUrlsPerFile: number,
+  maxBytesPerFile: number
+): Promise<number> => {
+  const {
+    clients: { vbase },
+  } = ctx
+  const bucket = getBucket(bucketPrefix, hashString(bindingId))
+  const acc = newAccumulator()
+  for (const route of routes) {
+    pushRoute(acc, route, maxUrlsPerFile, maxBytesPerFile)
+  }
+  const chunks = flushAccumulator(acc)
+  const lastUpdated = currentDate()
+  const fileNames: string[] = []
+  // Sequential writes keep order predictable across runs (determinism per invariant 6).
+  for (let i = 0; i < chunks.length; i += 1) {
+    const fileName = createFileName(fileNamePrefix, i)
+    // eslint-disable-next-line no-await-in-loop
+    await vbase.saveJSON<SitemapEntry>(bucket, fileName, {
+      lastUpdated,
+      routes: chunks[i],
+    })
+    fileNames.push(fileName)
+  }
+  await vbase.saveJSON<SitemapIndex>(bucket, indexFile, {
+    index: fileNames,
+    lastUpdated,
+  })
+  return fileNames.length
+}
 
 export const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 

--- a/node/middlewares/robots.test.ts
+++ b/node/middlewares/robots.test.ts
@@ -1,0 +1,52 @@
+import { ensureSitemapDirective } from './robots'
+
+describe('ensureSitemapDirective', () => {
+  const sitemapUrl = 'https://example.com/sitemap.xml'
+
+  it('appends the directive to a body that has no Sitemap line', () => {
+    const body = 'User-agent: *\nDisallow: /admin'
+    const result = ensureSitemapDirective(body, sitemapUrl)
+    expect(result).toContain('User-agent: *')
+    expect(result).toContain('Disallow: /admin')
+    expect(result).toContain(`Sitemap: ${sitemapUrl}`)
+  })
+
+  it('returns the body unchanged when a Sitemap directive already exists', () => {
+    const body = `User-agent: *\nDisallow:\nSitemap: ${sitemapUrl}`
+    const result = ensureSitemapDirective(body, sitemapUrl)
+    expect(result).toEqual(body)
+  })
+
+  it('detects an existing Sitemap directive case-insensitively (invariant 8)', () => {
+    const body = 'User-agent: *\nsITEmap: https://example.com/other.xml'
+    const result = ensureSitemapDirective(body, sitemapUrl)
+    expect(result).toEqual(body)
+    expect((result.match(/sitemap\s*:/gi) || []).length).toBe(1)
+  })
+
+  it('detects an existing Sitemap directive even when indented with whitespace', () => {
+    const body = `User-agent: *\n   Sitemap: ${sitemapUrl}`
+    const result = ensureSitemapDirective(body, sitemapUrl)
+    expect(result).toEqual(body)
+  })
+
+  it('writes a single-line file when given an empty body', () => {
+    const result = ensureSitemapDirective(undefined, sitemapUrl)
+    expect(result).toContain(`Sitemap: ${sitemapUrl}`)
+  })
+
+  it('is idempotent across repeated calls', () => {
+    const initial = 'User-agent: *\nDisallow:'
+    const once = ensureSitemapDirective(initial, sitemapUrl)
+    const twice = ensureSitemapDirective(once, sitemapUrl)
+    expect(twice).toEqual(once)
+    expect((twice.match(/sitemap\s*:/gi) || []).length).toBe(1)
+  })
+
+  it('does not duplicate the directive when the existing Sitemap URL differs', () => {
+    const body = 'User-agent: *\nSitemap: https://old.example.com/sitemap.xml'
+    const result = ensureSitemapDirective(body, sitemapUrl)
+    expect(result).toEqual(body)
+    expect(result).not.toContain(sitemapUrl)
+  })
+})

--- a/node/middlewares/robots.ts
+++ b/node/middlewares/robots.ts
@@ -10,6 +10,36 @@ interface RobotsFile {
 
 const SITEMAP_BUILD_FILE = 'dist/vtex.store-sitemap/build.json'
 
+// Multiline, case-insensitive — matches "Sitemap:" anywhere in the file at the
+// start of a (possibly indented) line. Mirrors how robots.txt parsers detect
+// the directive.
+const SITEMAP_DIRECTIVE_REGEX = /^\s*Sitemap\s*:/im
+
+/**
+ * Idempotently inject a `Sitemap:` directive into a robots.txt body.
+ *
+ * - Returns the body unchanged when a `Sitemap:` line is already present
+ *   (case-insensitive, leading-whitespace-tolerant — Decision 6 of the spec).
+ * - When the body is empty/undefined, returns a single-line file containing
+ *   the directive.
+ * - Otherwise appends the directive after a blank line, preserving content.
+ *
+ * Pure helper — exported for unit testing (US-4 acceptance criteria).
+ */
+export const ensureSitemapDirective = (
+  robotsBody: string | undefined,
+  sitemapUrl: string
+): string => {
+  if (!robotsBody) {
+    return `Sitemap: ${sitemapUrl}\n`
+  }
+  if (SITEMAP_DIRECTIVE_REGEX.test(robotsBody)) {
+    return robotsBody
+  }
+  const trimmed = robotsBody.replace(/\s+$/, '')
+  return `${trimmed}\n\nSitemap: ${sitemapUrl}\n`
+}
+
 const getRobotForBinding = async (
   bindingId: string,
   account: string,
@@ -49,6 +79,14 @@ export async function robots(ctx: Context) {
   }
   if (!data || !binding?.id) {
     data = await robotsDataSource.fromLegacy(account)
+  }
+
+  // Decision 6 of the spec: guarantee a `Sitemap:` directive is present so
+  // crawlers can always discover the sitemap. Idempotent — never duplicates an
+  // existing directive added manually by the merchant.
+  const forwardedHost = ctx.get('x-forwarded-host')
+  if (forwardedHost) {
+    data = ensureSitemapDirective(data, `https://${forwardedHost}/sitemap.xml`)
   }
 
   ctx.set('Content-Type', 'text/plain')

--- a/node/middlewares/settings.test.ts
+++ b/node/middlewares/settings.test.ts
@@ -2,7 +2,7 @@ import { Apps, IOContext, Logger, RequestTracingConfig } from '@vtex/api'
 import * as TypeMoq from 'typemoq'
 
 import { Clients } from '../clients'
-import { APPS_ROUTES_INDEX, PRODUCT_ROUTES_INDEX, REWRITER_ROUTES_INDEX } from './generateMiddlewares/utils'
+import { APPS_ROUTES_INDEX, CMS_ROUTES_INDEX, PRODUCT_ROUTES_INDEX, REWRITER_ROUTES_INDEX } from './generateMiddlewares/utils'
 import { settings } from './settings'
 
 const appsTypeMock = TypeMoq.Mock.ofInstance(Apps)
@@ -81,5 +81,35 @@ describe('Test settings middleware', () => {
     }
     await settings(context, next)
     expect(context.state.enabledIndexFiles).toStrictEqual([])
+  })
+
+  it('Should NOT include CMS_ROUTES_INDEX in enabledIndexFiles when enableCmsRoutes is true (CMS uses its own bucket)', async () => {
+    const appClient = context.clients.apps as any
+    appClient.settings = {
+      enableAppsRoutes: false,
+      enableCmsRoutes: true,
+      enableNavigationRoutes: false,
+      enableProductRoutes: false,
+    }
+    await settings(context, next)
+    expect(context.state.enabledIndexFiles).not.toContain(CMS_ROUTES_INDEX)
+    expect(context.state.enabledIndexFiles).toStrictEqual([])
+  })
+
+  it('Should omit CMS_ROUTES_INDEX when enableCmsRoutes is false (default rollout state)', async () => {
+    const appClient = context.clients.apps as any
+    appClient.settings = {
+      enableAppsRoutes: true,
+      enableCmsRoutes: false,
+      enableNavigationRoutes: true,
+      enableProductRoutes: true,
+    }
+    await settings(context, next)
+    expect(context.state.enabledIndexFiles).not.toContain(CMS_ROUTES_INDEX)
+    expect(context.state.enabledIndexFiles).toStrictEqual([
+      APPS_ROUTES_INDEX,
+      REWRITER_ROUTES_INDEX,
+      PRODUCT_ROUTES_INDEX,
+    ])
   })
 })

--- a/node/middlewares/settings.ts
+++ b/node/middlewares/settings.ts
@@ -9,6 +9,37 @@ export interface Settings {
   enableAppsRoutes: boolean
   enableProductRoutes: boolean
   enableNavigationRoutes: boolean
+  enableCmsRoutes: boolean
+  enableContentPlatformRoutes: boolean
+  /**
+   * Headless CMS (legacy) project id used as `{projectId}` in the CMS builder
+   * REST path (`/_v/cms/api/{projectId}/...`). Defaults to `faststore`, which
+   * matches stores that did not customize the CMS builder. Only consumed when
+   * `enableCmsRoutes` is on. Optional: the settings middleware always fills it
+   * from `DEFAULT_SETTINGS`, and readers fall back to `faststore`.
+   */
+  hcmsProjectId?: string
+  /**
+   * Allowlist of Headless CMS content types ingested into the sitemap. Each
+   * type is paginated via the CMS builder API and its pages are emitted using
+   * `settings.seo.slug`. Defaults to `["landingPage"]`; add the ids of any
+   * other routable content types the store created. Only consumed when
+   * `enableCmsRoutes` is on. Optional: the settings middleware always fills it
+   * from `DEFAULT_SETTINGS`, and readers fall back to the default list.
+   */
+  hcmsContentTypes?: string[]
+  /**
+   * FastStore project id used as `{storeId}` in the Content Platform Data
+   * Plane path. Defaults to `faststore` — matches stores that did not
+   * customize `contentSource.project`.
+   */
+  contentPlatformStoreId: string
+  /**
+   * Allowlist of routable content types ingested by the Content Platform
+   * source. Defaults to the predefined FastStore types. Custom types only
+   * need to be added here once.
+   */
+  contentPlatformContentTypes: string[]
   ignoreBindings: boolean
   disableRoutesTerm: string
 }
@@ -16,19 +47,46 @@ export interface Settings {
 const VTEX_APP_ID = process.env.VTEX_APP_ID!
 const VTEX_APP_AT_MAJOR = appIdToAppAtMajor(VTEX_APP_ID)
 
-const DEFAULT_SETTINGS = {
+export const DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES: string[] = [
+  'landingPage',
+  'home',
+]
+
+export const DEFAULT_CONTENT_PLATFORM_STORE_ID = 'faststore'
+
+export const DEFAULT_HCMS_CONTENT_TYPES: string[] = ['landingPage']
+
+export const DEFAULT_HCMS_PROJECT_ID = 'faststore'
+
+const DEFAULT_SETTINGS: Settings = {
+  contentPlatformContentTypes: DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+  contentPlatformStoreId: DEFAULT_CONTENT_PLATFORM_STORE_ID,
   disableRoutesTerm: '',
   enableAppsRoutes: true,
+  enableCmsRoutes: false,
+  enableContentPlatformRoutes: false,
   enableNavigationRoutes: true,
   enableProductRoutes: true,
+  hcmsContentTypes: DEFAULT_HCMS_CONTENT_TYPES,
+  hcmsProjectId: DEFAULT_HCMS_PROJECT_ID,
   ignoreBindings: false,
 }
 
-const INDEX_MAP = {
+// CMS / Content Platform routes use dedicated per-binding buckets (spec
+// Decision 1 / Decision 7) and are composed into /sitemap.xml via dedicated
+// reads in sitemap.ts — not via enabledIndexFiles / the shared production
+// bucket.
+const INDEX_MAP: Record<keyof Settings, string> = {
+  contentPlatformContentTypes: '',
+  contentPlatformStoreId: '',
   disableRoutesTerm: '',
   enableAppsRoutes: APPS_ROUTES_INDEX,
+  enableCmsRoutes: '',
+  enableContentPlatformRoutes: '',
   enableNavigationRoutes: REWRITER_ROUTES_INDEX,
   enableProductRoutes: PRODUCT_ROUTES_INDEX,
+  hcmsContentTypes: '',
+  hcmsProjectId: '',
   ignoreBindings: '',
 }
 

--- a/node/middlewares/sitemap.test.ts
+++ b/node/middlewares/sitemap.test.ts
@@ -3,15 +3,29 @@ import * as TypeMoq from 'typemoq'
 
 import {
   APPS_ROUTES_INDEX,
+  CMS_ROUTES_INDEX,
+  CONTENT_PLATFORM_ROUTES_INDEX,
   PRODUCT_ROUTES_INDEX,
   REWRITER_ROUTES_INDEX,
 } from './generateMiddlewares/utils'
 
+import { Catalog } from '../clients/catalog'
 import { Clients } from '../clients'
-import { EXTENDED_INDEX_FILE } from '../utils'
+import {
+  CMS_ROUTES_PREFIX,
+  CONTENT_PLATFORM_ROUTES_PREFIX,
+  EXTENDED_INDEX_FILE,
+  getBucket,
+  hashString,
+} from '../utils'
+import {
+  DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+  DEFAULT_CONTENT_PLATFORM_STORE_ID,
+} from './settings'
 import { sitemap } from './sitemap'
 
 const vbaseTypeMock = TypeMoq.Mock.ofInstance(VBase)
+const catalogTypeMock = TypeMoq.Mock.ofInstance(Catalog)
 const contextMock = TypeMoq.Mock.ofType<Context>()
 const ioContext = TypeMoq.Mock.ofType<IOContext>()
 const state = TypeMoq.Mock.ofType<State>()
@@ -22,6 +36,14 @@ const removeSpaces = (str: string) => str.replace(/(\r\n|\n|\r|\s)/gm, '')
 describe('Test sitemap middleware', () => {
   let context: Context
   let hasExtendedFiles: boolean
+  let hasCmsRoutesFiles: boolean
+  let hasContentPlatformRoutesFiles: boolean
+
+  const cmsBucket = getBucket(CMS_ROUTES_PREFIX, hashString('1'))
+  const contentPlatformBucket = getBucket(
+    CONTENT_PLATFORM_ROUTES_PREFIX,
+    hashString('1')
+  )
 
   const vbase = class VBaseMock extends vbaseTypeMock.object {
     constructor() {
@@ -29,10 +51,29 @@ describe('Test sitemap middleware', () => {
     }
 
     public getJSON = async <T>(
-      _: string,
+      bucket: string,
       file: string,
       __?: boolean | undefined
     ): Promise<T> => {
+      if (file === CMS_ROUTES_INDEX && bucket === cmsBucket) {
+        return ((hasCmsRoutesFiles
+          ? {
+              index: ['hcms-routes-0'],
+              lastUpdated: '2019-12-04',
+            }
+          : null) as unknown) as T
+      }
+      if (
+        file === CONTENT_PLATFORM_ROUTES_INDEX &&
+        bucket === contentPlatformBucket
+      ) {
+        return ((hasContentPlatformRoutesFiles
+          ? {
+              index: ['cms-routes-0'],
+              lastUpdated: '2019-12-04',
+            }
+          : null) as unknown) as T
+      }
       switch (file) {
         case APPS_ROUTES_INDEX:
           return ({
@@ -91,6 +132,8 @@ describe('Test sitemap middleware', () => {
     }
 
     hasExtendedFiles = false
+    hasCmsRoutesFiles = false
+    hasContentPlatformRoutesFiles = false
     context = {
       ...contextMock.object,
       clients: new ClientsImpl({}, ioContext.object),
@@ -107,11 +150,16 @@ describe('Test sitemap middleware', () => {
         ],
         forwardedHost: 'www.host.com',
         forwardedPath: '/sitemap/file1.xml',
+        isCrossBorder: true,
         matchingBindings: [matchingBindings[0]],
         rootPath: '',
         settings: {
+          contentPlatformContentTypes: DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+          contentPlatformStoreId: DEFAULT_CONTENT_PLATFORM_STORE_ID,
           disableRoutesTerm: '',
           enableAppsRoutes: true,
+          enableCmsRoutes: false,
+          enableContentPlatformRoutes: false,
           enableNavigationRoutes: true,
           enableProductRoutes: true,
           ignoreBindings: false,
@@ -339,5 +387,219 @@ describe('Test sitemap middleware', () => {
       </sitemapindex>`
       )
     )
+  })
+
+  it('Should append hcms-routes sub-sitemaps to <sitemapindex> when enableCmsRoutes is on (US-1)', async () => {
+    hasCmsRoutesFiles = true
+    context.state.settings.enableCmsRoutes = true
+    await sitemap(context, next)
+    expect(context.body).toContain(
+      '<loc>https://www.host.com/sitemap/hcms-routes-0.xml</loc>'
+    )
+  })
+
+  it('Should NOT read or append hcms-routes when enableCmsRoutes is off (invariant 9)', async () => {
+    hasCmsRoutesFiles = true
+    context.state.settings.enableCmsRoutes = false
+    await sitemap(context, next)
+    expect(context.body).not.toContain('hcms-routes-0')
+  })
+
+  it('Should append cms-routes sub-sitemaps to <sitemapindex> when enableContentPlatformRoutes is on (US-1 — Content Platform)', async () => {
+    hasContentPlatformRoutesFiles = true
+    context.state.settings.enableContentPlatformRoutes = true
+    await sitemap(context, next)
+    expect(context.body).toContain(
+      '<loc>https://www.host.com/sitemap/cms-routes-0.xml</loc>'
+    )
+  })
+
+  it('Should NOT read cms-routes when its flag is off (invariant 9)', async () => {
+    hasContentPlatformRoutesFiles = true
+    context.state.settings.enableContentPlatformRoutes = false
+    await sitemap(context, next)
+    expect(context.body).not.toContain('cms-routes-0')
+  })
+
+  it('Should reference ONLY cms-routes (not hcms-routes) when both flags are on — Content Platform wins (US-6 / Decision 8)', async () => {
+    hasCmsRoutesFiles = true
+    hasContentPlatformRoutesFiles = true
+    context.state.settings.enableCmsRoutes = true
+    context.state.settings.enableContentPlatformRoutes = true
+    await sitemap(context, next)
+    expect(context.body).toContain(
+      '<loc>https://www.host.com/sitemap/cms-routes-0.xml</loc>'
+    )
+    expect(context.body).not.toContain('hcms-routes-0')
+  })
+
+  it('Should reference hcms-routes (not cms-routes) when only enableCmsRoutes is on (Decision 8 — hCMS wins)', async () => {
+    hasCmsRoutesFiles = true
+    hasContentPlatformRoutesFiles = true
+    context.state.settings.enableCmsRoutes = true
+    context.state.settings.enableContentPlatformRoutes = false
+    await sitemap(context, next)
+    expect(context.body).toContain('hcms-routes-0')
+    // Use full path to avoid 'hcms-routes-0' matching as a substring of 'cms-routes-0'
+    expect(context.body).not.toContain('/sitemap/cms-routes-0.xml')
+  })
+})
+
+describe('Test sitemap middleware — single-binding catalog path', () => {
+  const catalogSitemapXml = `<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+      <loc>https://www.host.com/sitemap/brand-0.xml</loc>
+      <lastmod>2019-12-04</lastmod>
+    </sitemap>
+    <sitemap>
+      <loc>https://www.host.com/sitemap/product-0.xml</loc>
+      <lastmod>2019-12-04</lastmod>
+    </sitemap>
+  </sitemapindex>`
+
+  const cmsBucket = getBucket(CMS_ROUTES_PREFIX, hashString('1'))
+  const contentPlatformBucket = getBucket(
+    CONTENT_PLATFORM_ROUTES_PREFIX,
+    hashString('1')
+  )
+
+  let hasCmsRoutesFiles: boolean
+  let hasContentPlatformRoutesFiles: boolean
+
+  const vbase = class VBaseMock extends vbaseTypeMock.object {
+    constructor() {
+      super(ioContext.object)
+    }
+
+    public getJSON = async <T>(
+      bucket: string,
+      file: string,
+      __?: boolean | undefined
+    ): Promise<T> => {
+      if (file === CMS_ROUTES_INDEX && bucket === cmsBucket) {
+        return ((hasCmsRoutesFiles
+          ? {
+              index: ['hcms-routes-0'],
+              lastUpdated: '2019-12-04',
+            }
+          : null) as unknown) as T
+      }
+      if (
+        file === CONTENT_PLATFORM_ROUTES_INDEX &&
+        bucket === contentPlatformBucket
+      ) {
+        return ((hasContentPlatformRoutesFiles
+          ? {
+              index: ['cms-routes-0'],
+              lastUpdated: '2019-12-04',
+            }
+          : null) as unknown) as T
+      }
+      return (null as unknown) as T
+    }
+  }
+
+  const catalog = class CatalogMock extends catalogTypeMock.object {
+    constructor() {
+      super(ioContext.object)
+    }
+
+    public getSitemap = async () => catalogSitemapXml
+  }
+
+  const next = jest.fn()
+
+  const baseSettings = {
+    contentPlatformContentTypes: DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+    contentPlatformStoreId: DEFAULT_CONTENT_PLATFORM_STORE_ID,
+    disableRoutesTerm: '',
+    enableAppsRoutes: true,
+    enableCmsRoutes: false,
+    enableContentPlatformRoutes: false,
+    enableNavigationRoutes: true,
+    enableProductRoutes: true,
+    ignoreBindings: false,
+  }
+
+  const buildContext = (settings: typeof baseSettings): Context =>
+    ({
+      ...contextMock.object,
+      clients: new (class ClientsMock extends Clients {
+        get vbase() {
+          return this.getOrSet('vbase', vbase)
+        }
+
+        get catalog() {
+          return this.getOrSet('catalog', catalog)
+        }
+      })({}, ioContext.object),
+      headers: {
+        'x-forwarded-host': 'www.host.com',
+      },
+      state: {
+        binding: { id: '1' } as Binding,
+        forwardedHost: 'www.host.com',
+        forwardedPath: 'sitemap.xml',
+        isCrossBorder: false,
+        rootPath: '',
+        settings,
+      },
+      vtex: {
+        ...ioContext.object,
+        logger: loggerMock.object,
+      },
+    } as unknown as Context)
+
+  beforeEach(() => {
+    hasCmsRoutesFiles = false
+    hasContentPlatformRoutesFiles = false
+  })
+
+  it('returns catalog XML unchanged when no CMS source is enabled', async () => {
+    const ctx = buildContext(baseSettings)
+    await sitemap(ctx, next)
+    expect(removeSpaces(ctx.body)).toStrictEqual(removeSpaces(catalogSitemapXml))
+    expect(ctx.body).not.toContain('hcms-routes-0')
+    expect(ctx.body).not.toContain('cms-routes-0')
+  })
+
+  it('merges hcms-routes into catalog sitemapindex when enableCmsRoutes is on', async () => {
+    hasCmsRoutesFiles = true
+    const ctx = buildContext({ ...baseSettings, enableCmsRoutes: true })
+    await sitemap(ctx, next)
+    expect(ctx.body).toContain(
+      '<loc>https://www.host.com/sitemap/brand-0.xml</loc>'
+    )
+    expect(ctx.body).toContain(
+      '<loc>https://www.host.com/sitemap/hcms-routes-0.xml</loc>'
+    )
+  })
+
+  it('merges content-platform-routes into catalog sitemapindex when enableContentPlatformRoutes is on', async () => {
+    hasContentPlatformRoutesFiles = true
+    const ctx = buildContext({
+      ...baseSettings,
+      enableContentPlatformRoutes: true,
+    })
+    await sitemap(ctx, next)
+    expect(ctx.body).toContain(
+      '<loc>https://www.host.com/sitemap/cms-routes-0.xml</loc>'
+    )
+    expect(ctx.body).not.toContain('hcms-routes-0')
+  })
+
+  it('merges only content-platform-routes when both CMS flags are on (Decision 8)', async () => {
+    hasCmsRoutesFiles = true
+    hasContentPlatformRoutesFiles = true
+    const ctx = buildContext({
+      ...baseSettings,
+      enableCmsRoutes: true,
+      enableContentPlatformRoutes: true,
+    })
+    await sitemap(ctx, next)
+    expect(ctx.body).toContain(
+      '<loc>https://www.host.com/sitemap/cms-routes-0.xml</loc>'
+    )
+    expect(ctx.body).not.toContain('hcms-routes-0')
   })
 })

--- a/node/middlewares/sitemap.ts
+++ b/node/middlewares/sitemap.ts
@@ -1,6 +1,8 @@
 import * as cheerio from 'cheerio'
 
 import { MultipleSitemapGenerationError } from '../errors'
+import { mergeActiveCmsIndexIntoCatalogXml } from '../services/cmsServing'
+import { readCmsIndex, resolveActiveCmsSource } from '../services/cmsSources'
 import {
   EXTENDED_INDEX_FILE,
   xmlTruncateNodes,
@@ -9,7 +11,10 @@ import {
   SitemapNotFound,
   startSitemapGeneration,
 } from '../utils'
-import { currentDate, SitemapIndex } from './generateMiddlewares/utils'
+import {
+  currentDate,
+  SitemapIndex,
+} from './generateMiddlewares/utils'
 
 const sitemapIndexEntry = (
   forwardedHost: string,
@@ -50,6 +55,7 @@ const sitemapIndex = async (ctx: Context) => {
       bucket,
       rootPath,
       bindingAddress,
+      settings,
     },
     clients: { vbase },
   } = ctx
@@ -61,6 +67,9 @@ const sitemapIndex = async (ctx: Context) => {
     }
   )
 
+  const activeCmsSource = resolveActiveCmsSource(settings)
+  const cmsIndexPromise = readCmsIndex(activeCmsSource, vbase, binding.id)
+
   const rawIndexFiles = await Promise.all([
     ...enabledIndexFiles.map(indexFile =>
       vbase.getJSON<SitemapIndex>(bucket, indexFile, true)
@@ -70,9 +79,10 @@ const sitemapIndex = async (ctx: Context) => {
       EXTENDED_INDEX_FILE,
       true
     ),
+    cmsIndexPromise,
   ])
 
-  const indexFiles = rawIndexFiles.filter(Boolean)
+  const indexFiles = rawIndexFiles.filter(Boolean) as SitemapIndex[]
 
   if (indexFiles.length === 0) {
     throw new SitemapNotFound('Sitemap not found')
@@ -165,7 +175,7 @@ async function legacySitemap(ctx: Context) {
   })
 
   const hasBindingIdentifier = rootPath || bindingAddress
-  let $: any
+  let $: ReturnType<typeof cheerio.load>
   try {
     if (hasBindingIdentifier || settings.ignoreBindings) {
       $ = await sitemapIndex(ctx)
@@ -180,9 +190,9 @@ async function legacySitemap(ctx: Context) {
       ctx.status = 404
       ctx.body = 'Generating sitemap...'
       ctx.vtex.logger.error(err.message)
-      await startSitemapGeneration(ctx).catch(err => {
-        if (!(err instanceof MultipleSitemapGenerationError)) {
-          throw err
+      await startSitemapGeneration(ctx).catch(catchErr => {
+        if (!(catchErr instanceof MultipleSitemapGenerationError)) {
+          throw catchErr
         }
       })
     }
@@ -196,7 +206,10 @@ async function catalogSitemap(ctx: Context) {
   const {
     clients: { catalog },
     headers: { 'x-forwarded-host': forwardedHost },
-    state: { isCrossBorder, forwardedPath },
+    state: {
+      forwardedPath,
+      isCrossBorder,
+    },
     vtex: { logger },
   } = ctx
 
@@ -210,5 +223,5 @@ async function catalogSitemap(ctx: Context) {
   })
 
   const sitemapData = await catalog.getSitemap(forwardedHost, forwardedPath)
-  ctx.body = sitemapData
+  ctx.body = await mergeActiveCmsIndexIntoCatalogXml(sitemapData, ctx)
 }

--- a/node/middlewares/sitemap.ts
+++ b/node/middlewares/sitemap.ts
@@ -195,6 +195,7 @@ async function legacySitemap(ctx: Context) {
           throw catchErr
         }
       })
+      return
     }
     throw err
   }

--- a/node/middlewares/sitemapEntry.test.ts
+++ b/node/middlewares/sitemapEntry.test.ts
@@ -1,10 +1,27 @@
 import { Binding, IOContext, Logger, VBase } from '@vtex/api'
 import * as TypeMoq from 'typemoq'
 
+import { Catalog } from '../clients/catalog'
 import { Clients } from '../clients'
+import {
+  createMemoryVBaseMock,
+  CmsActiveSettings,
+  defaultCmsServingSettings,
+} from '../test/fixtures/cmsTestFixtures'
+import {
+  CMS_ROUTES_PREFIX,
+  CONTENT_PLATFORM_ROUTES_PREFIX,
+  getBucket,
+  hashString,
+} from '../utils'
+import {
+  DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+  DEFAULT_CONTENT_PLATFORM_STORE_ID,
+} from './settings'
 import { sitemapEntry, URLEntry } from './sitemapEntry'
 
 const vbaseTypeMock = TypeMoq.Mock.ofInstance(VBase)
+const catalogTypeMock = TypeMoq.Mock.ofInstance(Catalog)
 const contextMock = TypeMoq.Mock.ofType<Context>()
 const ioContext = TypeMoq.Mock.ofType<IOContext>()
 const state = TypeMoq.Mock.ofType<State>()
@@ -79,6 +96,7 @@ describe('Test sitemap entry', () => {
         bucket: 'bucket',
         forwardedHost: 'host.com',
         forwardedPath: '/sitemap/file1.xml',
+        isCrossBorder: true,
         matchingBindings: [
           {
             canonicalBaseAddress: 'www.host.com',
@@ -97,6 +115,17 @@ describe('Test sitemap entry', () => {
           },
         ] as Binding[],
         rootPath: '',
+        settings: {
+          contentPlatformContentTypes: DEFAULT_CONTENT_PLATFORM_CONTENT_TYPES,
+          contentPlatformStoreId: DEFAULT_CONTENT_PLATFORM_STORE_ID,
+          disableRoutesTerm: '',
+          enableAppsRoutes: true,
+          enableCmsRoutes: false,
+          enableContentPlatformRoutes: false,
+          enableNavigationRoutes: true,
+          enableProductRoutes: true,
+          ignoreBindings: false,
+        },
       },
       vtex: {
         ...ioContext.object,
@@ -149,7 +178,7 @@ describe('Test sitemap entry', () => {
     ))
   })
 
-  it('Should create a correct sitemap entry with localization', async () => {
+  it('Should create a correct sitemap entry with localization (self + x-default per spec Decision 5)', async () => {
     const alternates: AlternateRoute[] = [
       {
         bindingId: '1',
@@ -172,14 +201,16 @@ describe('Test sitemap entry', () => {
     expect(removeSpaces(entry)).toStrictEqual(removeSpaces(
     `<url>
       <loc>https://host.com/pear</loc>
+      <xhtml:link rel="alternate" hreflang="en-US" href="https://host.com/pear"/>
       <xhtml:link rel="alternate" hreflang="pt-BR" href="https://www.host.com/br/pera"/>
       <xhtml:link rel="alternate" hreflang="de-DE" href="https://www.host.com/de/brine"/>
+      <xhtml:link rel="alternate" hreflang="x-default" href="https://host.com/pear"/>
       <lastmod>2019-12-04</lastmod>
      </url>`
     ))
   })
 
-  it('Should create a correct sitemap entry with localization with binding address querystring', async () => {
+  it('Should create a correct sitemap entry with localization with binding address querystring (self + x-default)', async () => {
     const alternates: AlternateRoute[] = [
       {
         bindingId: '1',
@@ -209,11 +240,122 @@ describe('Test sitemap entry', () => {
     expect(removeSpaces(entry)).toStrictEqual(removeSpaces(
     `<url>
       <loc>https://host.com/pear?__bindingAddress=www.host.com/es</loc>
+      <xhtml:link rel="alternate" hreflang="en-US" href="https://host.com/pear?__bindingAddress=www.host.com/es"/>
       <xhtml:link rel="alternate" hreflang="pt-BR" href="https://host.com/pera?__bindingAddress=www.host.com/br"/>
       <xhtml:link rel="alternate" hreflang="de-DE" href="https://host.com/brine?__bindingAddress=www.host.com/de"/>
+      <xhtml:link rel="alternate" hreflang="x-default" href="https://host.com/pear?__bindingAddress=www.host.com/es"/>
       <lastmod>2019-12-04</lastmod>
      </url>`
     ))
+  })
+
+  it('Should emit no alternates for a single-binding store (US-3 negative case)', async () => {
+    const alternates: AlternateRoute[] = [
+      {
+        bindingId: '1',
+        path: '/pear',
+      },
+    ]
+    const route: Route = {
+      ...defaultRoute,
+      alternates,
+    }
+    const singleBindingContext = {
+      ...context,
+      state: {
+        ...context.state,
+        matchingBindings: [
+          {
+            canonicalBaseAddress: 'www.host.com',
+            defaultLocale: 'en-US',
+            id: '1',
+          },
+        ] as any[],
+      },
+    }
+    const entry = URLEntry(singleBindingContext, route, defaultLastUpdated)
+    expect(entry).not.toContain('xhtml:link')
+    expect(entry).not.toContain('x-default')
+  })
+
+  it('Should emit x-default pointing at the default binding even when current binding is not the default (US-3)', async () => {
+    const alternates: AlternateRoute[] = [
+      {
+        bindingId: '1',
+        path: '/pear',
+      },
+      {
+        bindingId: '2',
+        path: '/pera',
+      },
+      {
+        bindingId: '3',
+        path: '/brine',
+      },
+    ]
+    const route: Route = {
+      ...defaultRoute,
+      alternates,
+    }
+    const ptBrCurrent = {
+      ...context,
+      state: {
+        ...context.state,
+        binding: { id: '2' } as any,
+      },
+    }
+    const entry = URLEntry(ptBrCurrent, route, defaultLastUpdated)
+    // self alternate uses forwardedHost
+    expect(entry).toContain(
+      '<xhtml:link rel="alternate" hreflang="pt-BR" href="https://host.com/pera"/>'
+    )
+    // x-default points at the FIRST matching binding (default), via its canonicalBaseAddress
+    expect(entry).toContain(
+      '<xhtml:link rel="alternate" hreflang="x-default" href="https://www.host.com/pear"/>'
+    )
+  })
+
+  it('Should emit changefreq and priority tags when the route declares them (FR-5)', async () => {
+    const route: Route = {
+      ...defaultRoute,
+      changefreq: 'daily',
+      priority: 0.8,
+    }
+    const singleBindingContext = {
+      ...context,
+      state: {
+        ...context.state,
+        matchingBindings: [
+          {
+            canonicalBaseAddress: 'www.host.com',
+            defaultLocale: 'en-US',
+            id: '1',
+          },
+        ] as any[],
+      },
+    }
+    const entry = URLEntry(singleBindingContext, route, defaultLastUpdated)
+    expect(entry).toContain('<changefreq>daily</changefreq>')
+    expect(entry).toContain('<priority>0.8</priority>')
+  })
+
+  it('Should NOT emit changefreq/priority when the route omits them (backwards compat invariant 7)', async () => {
+    const singleBindingContext = {
+      ...context,
+      state: {
+        ...context.state,
+        matchingBindings: [
+          {
+            canonicalBaseAddress: 'www.host.com',
+            defaultLocale: 'en-US',
+            id: '1',
+          },
+        ] as any[],
+      },
+    }
+    const entry = URLEntry(singleBindingContext, defaultRoute, defaultLastUpdated)
+    expect(entry).not.toContain('<changefreq>')
+    expect(entry).not.toContain('<priority>')
   })
 
   it('Should create a correct sitemap entry with root path', async () => {
@@ -267,5 +409,284 @@ describe('Test sitemap entry', () => {
       <lastmod>2019-12-04</lastmod>
      </url>`
     ))
+  })
+
+  describe('CMS-source bucket fallback (US-1 / US-6)', () => {
+    const buildBucketAwareContext = (
+      activeSettings: CmsActiveSettings,
+      vbaseImpl: any
+    ) =>
+      ({
+        ...contextMock.object,
+        // tslint:disable-next-line:max-classes-per-file
+        clients: new (class ClientsMock extends Clients {
+          get vbase() {
+            return this.getOrSet('vbase', vbaseImpl)
+          }
+        })({}, ioContext.object),
+        state: {
+          ...state.object,
+          binding: { id: 'b1' } as Binding,
+          bucket: 'production-bucket',
+          forwardedPath: '/sitemap/cms-routes-0.xml',
+          isCrossBorder: true,
+          matchingBindings: [
+            {
+              canonicalBaseAddress: 'www.host.com',
+              defaultLocale: 'en-US',
+              id: 'b1',
+            },
+          ] as Binding[],
+          rootPath: '',
+          settings: defaultCmsServingSettings(activeSettings),
+        },
+        vtex: {
+          ...ioContext.object,
+          logger: loggerMock.object,
+        },
+      } as unknown) as Context
+
+    it('falls back to the content-platform-routes bucket when serving /sitemap/cms-routes-N.xml (Decision 7)', async () => {
+      const cpBucket = getBucket(CONTENT_PLATFORM_ROUTES_PREFIX, hashString('b1'))
+      const VBaseMockClass = createMemoryVBaseMock(ioContext.object, {
+        initialData: {
+          [cpBucket]: {
+            'cms-routes-0': {
+              lastUpdated: '2026-05-20',
+              routes: [
+                {
+                  id: 'lp-1',
+                  path: '/our-story',
+                  source: 'content-platform',
+                },
+              ],
+            },
+          },
+        },
+      })
+
+      const ctx = buildBucketAwareContext(
+        { enableCmsRoutes: false, enableContentPlatformRoutes: true },
+        VBaseMockClass
+      )
+      await sitemapEntry(ctx, next)
+      expect(ctx.body).toContain('<loc>https://undefined/our-story</loc>')
+    })
+
+    it('does NOT fall back to content-platform-routes bucket when its flag is off (invariant 9)', async () => {
+      const cpBucket = getBucket(CONTENT_PLATFORM_ROUTES_PREFIX, hashString('b1'))
+      const VBaseMockClass = createMemoryVBaseMock(ioContext.object, {
+        initialData: {
+          [cpBucket]: {
+            'cms-routes-0': {
+              lastUpdated: '2026-05-20',
+              routes: [{ id: 'lp-1', path: '/our-story' }],
+            },
+          },
+        },
+      })
+
+      const ctx = buildBucketAwareContext(
+        { enableCmsRoutes: false, enableContentPlatformRoutes: false },
+        VBaseMockClass
+      )
+      await sitemapEntry(ctx, next)
+      expect(ctx.status).toBe(404)
+    })
+
+    it('falls back to cms-routes bucket (NOT content-platform) when hCMS wins (Decision 8)', async () => {
+      const cmsBucket = getBucket(CMS_ROUTES_PREFIX, hashString('b1'))
+      const VBaseMockClass = createMemoryVBaseMock(ioContext.object, {
+        initialData: {
+          [cmsBucket]: {
+            'hcms-routes-0': {
+              lastUpdated: '2026-05-20',
+              routes: [{ id: 'cms-1', path: '/our-story-hcms' }],
+            },
+          },
+        },
+      })
+
+      const ctx = buildBucketAwareContext(
+        { enableCmsRoutes: true, enableContentPlatformRoutes: false },
+        VBaseMockClass
+      )
+      ctx.state.forwardedPath = '/sitemap/hcms-routes-0.xml'
+      await sitemapEntry(ctx, next)
+      expect(ctx.body).toContain('our-story-hcms')
+    })
+  })
+
+  describe('single-binding catalog path (US-1)', () => {
+    const buildCatalogContext = (
+      activeSettings: {
+        enableCmsRoutes: boolean
+        enableContentPlatformRoutes: boolean
+      },
+      vbaseImpl: any,
+      catalogImpl: any,
+      forwardedPath: string
+    ) =>
+      ({
+        ...contextMock.object,
+        clients: new (class ClientsMock extends Clients {
+          get vbase() {
+            return this.getOrSet('vbase', vbaseImpl)
+          }
+
+          get catalog() {
+            return this.getOrSet('catalog', catalogImpl)
+          }
+        })({}, ioContext.object),
+        headers: {
+          'x-forwarded-host': 'www.host.com',
+        },
+        state: {
+          ...state.object,
+          binding: { id: 'b1' } as Binding,
+          forwardedHost: 'www.host.com',
+          forwardedPath,
+          isCrossBorder: false,
+          matchingBindings: [
+            {
+              canonicalBaseAddress: 'www.host.com',
+              defaultLocale: 'en-US',
+              id: 'b1',
+            },
+          ] as Binding[],
+          rootPath: '',
+          settings: {
+            disableRoutesTerm: '',
+            enableAppsRoutes: true,
+            enableCmsRoutes: activeSettings.enableCmsRoutes,
+            enableContentPlatformRoutes:
+              activeSettings.enableContentPlatformRoutes,
+            enableNavigationRoutes: true,
+            enableProductRoutes: true,
+            ignoreBindings: false,
+          },
+        },
+        vtex: {
+          ...ioContext.object,
+          logger: loggerMock.object,
+        },
+      } as unknown) as Context
+
+    it('serves hcms-routes from VBase before falling back to catalog proxy', async () => {
+      const cmsBucket = getBucket(CMS_ROUTES_PREFIX, hashString('b1'))
+      const vbaseImpl = class VBaseMock extends vbaseTypeMock.object {
+        public jsonData: Record<string, Record<string, any>> = {
+          [cmsBucket]: {
+            'hcms-routes-0': {
+              lastUpdated: '2026-05-20',
+              routes: [{ id: 'cms-1', path: '/landing-page' }],
+            },
+          },
+        }
+        constructor() {
+          super(ioContext.object)
+        }
+        public getJSON = async <T>(
+          bucket: string,
+          file: string,
+          nullable?: boolean
+        ): Promise<T> => {
+          if (this.jsonData[bucket]?.[file]) {
+            return this.jsonData[bucket][file] as T
+          }
+          if (nullable) {
+            return (null as unknown) as T
+          }
+          return (null as unknown) as T
+        }
+      }
+      const getSitemap = jest.fn(async () => 'catalog-xml')
+      const catalogImpl = class CatalogMock extends catalogTypeMock.object {
+        constructor() {
+          super(ioContext.object)
+        }
+        public getSitemap = getSitemap
+      }
+
+      const ctx = buildCatalogContext(
+        { enableCmsRoutes: true, enableContentPlatformRoutes: false },
+        vbaseImpl,
+        catalogImpl,
+        '/sitemap/hcms-routes-0.xml'
+      )
+      await sitemapEntry(ctx, next)
+      expect(ctx.body).toContain('<loc>https://www.host.com/landing-page</loc>')
+      expect(getSitemap).not.toHaveBeenCalled()
+    })
+
+    it('falls back to catalog proxy when CMS file is not in VBase', async () => {
+      const catalogXml = '<urlset><url><loc>https://www.host.com/p/1</loc></url></urlset>'
+      const getSitemap = jest.fn(async () => catalogXml)
+      const catalogImpl = class CatalogMock extends catalogTypeMock.object {
+        constructor() {
+          super(ioContext.object)
+        }
+        public getSitemap = getSitemap
+      }
+      const vbaseImpl = class VBaseMock extends vbaseTypeMock.object {
+        constructor() {
+          super(ioContext.object)
+        }
+        public getJSON = async <T>(): Promise<T> => (null as unknown) as T
+      }
+
+      const ctx = buildCatalogContext(
+        { enableCmsRoutes: true, enableContentPlatformRoutes: false },
+        vbaseImpl,
+        catalogImpl,
+        '/sitemap/product-0.xml'
+      )
+      await sitemapEntry(ctx, next)
+      expect(getSitemap).toHaveBeenCalledWith(
+        'www.host.com',
+        '/sitemap/product-0.xml'
+      )
+      expect(ctx.body).toBe(catalogXml)
+      expect(ctx.status).toBe(200)
+    })
+
+    it('does not read CMS bucket when enableCmsRoutes is off', async () => {
+      const catalogXml = '<urlset><url><loc>https://www.host.com/p/1</loc></url></urlset>'
+      const getSitemap = jest.fn(async () => catalogXml)
+      let vbaseCalled = false
+      const vbaseImpl = class VBaseMock extends vbaseTypeMock.object {
+        constructor() {
+          super(ioContext.object)
+        }
+        public getJSON = async <T>(
+          _bucket: string,
+          _file: string,
+          nullable?: boolean
+        ): Promise<T> => {
+          vbaseCalled = true
+          if (nullable) {
+            return (null as unknown) as T
+          }
+          return (null as unknown) as T
+        }
+      }
+      const catalogImpl = class CatalogMock extends catalogTypeMock.object {
+        constructor() {
+          super(ioContext.object)
+        }
+        public getSitemap = getSitemap
+      }
+
+      const ctx = buildCatalogContext(
+        { enableCmsRoutes: false, enableContentPlatformRoutes: false },
+        vbaseImpl,
+        catalogImpl,
+        '/sitemap/hcms-routes-0.xml'
+      )
+      await sitemapEntry(ctx, next)
+      expect(vbaseCalled).toBe(false)
+      expect(getSitemap).toHaveBeenCalled()
+      expect(ctx.body).toBe(catalogXml)
+    })
   })
 })

--- a/node/middlewares/sitemapEntry.ts
+++ b/node/middlewares/sitemapEntry.ts
@@ -2,52 +2,160 @@ import { Binding } from '@vtex/api'
 import * as cheerio from 'cheerio'
 import RouteParser from 'route-parser'
 
+import {
+  serveCmsEntryFromCandidateBuckets,
+  serveCmsEntryFromVBase,
+} from '../services/cmsServing'
 import { SITEMAP_URL } from '../utils'
 import { SitemapEntry } from './generateMiddlewares/utils'
 
 const getBinding = (bindingId: string, bindings: Binding[]) =>
   bindings.find(binding => binding.id === bindingId)
 
+const getDefaultMatchingBinding = (
+  matchingBindings: Binding[]
+): Binding | undefined =>
+  matchingBindings.find(b => b.targetProduct === 'vtex-storefront') ??
+  matchingBindings[0]
+
+interface LocaleHrefArgs {
+  alternate: AlternateRoute
+  alternateBinding: Binding
+  bindingAddress?: string
+  currentBindingId: string
+  forwardedHost: string
+  rootPath: string
+}
+
+const buildLocaleHref = ({
+  alternate,
+  alternateBinding,
+  bindingAddress,
+  currentBindingId,
+  forwardedHost,
+  rootPath,
+}: LocaleHrefArgs): string => {
+  if (alternate.bindingId === currentBindingId) {
+    const querystring = bindingAddress
+      ? `?__bindingAddress=${bindingAddress}`
+      : ''
+    return `https://${forwardedHost}${rootPath}${alternate.path}${querystring}`
+  }
+  if (bindingAddress) {
+    return `https://${forwardedHost}${alternate.path}?__bindingAddress=${alternateBinding.canonicalBaseAddress}`
+  }
+  return `https://${alternateBinding.canonicalBaseAddress}${alternate.path}`
+}
+
+const buildLocalization = (
+  ctx: Context,
+  route: Route
+): string => {
+  const {
+    state: {
+      binding,
+      bindingAddress,
+      forwardedHost,
+      rootPath,
+      matchingBindings,
+    },
+  } = ctx
+
+  if (!matchingBindings || matchingBindings.length <= 1) {
+    return ''
+  }
+  if (!route.alternates || route.alternates.length === 0) {
+    return ''
+  }
+
+  const lines: string[] = []
+  for (const alternate of route.alternates) {
+    const alternateBinding = getBinding(alternate.bindingId, matchingBindings)
+    if (!alternateBinding) {
+      continue
+    }
+    const href = buildLocaleHref({
+      alternate,
+      alternateBinding,
+      bindingAddress,
+      currentBindingId: binding.id,
+      forwardedHost,
+      rootPath,
+    })
+    const locale = alternateBinding.defaultLocale
+    lines.push(
+      `<xhtml:link rel="alternate" hreflang="${locale}" href="${href}"/>`
+    )
+  }
+
+  const defaultBinding = getDefaultMatchingBinding(matchingBindings)
+  if (defaultBinding) {
+    const defaultAlternate =
+      route.alternates.find(a => a.bindingId === defaultBinding.id) ??
+      ({ bindingId: defaultBinding.id, path: route.path } as AlternateRoute)
+    const defaultHref = buildLocaleHref({
+      alternate: defaultAlternate,
+      alternateBinding: defaultBinding,
+      bindingAddress,
+      currentBindingId: binding.id,
+      forwardedHost,
+      rootPath,
+    })
+    lines.push(
+      `<xhtml:link rel="alternate" hreflang="x-default" href="${defaultHref}"/>`
+    )
+  }
+
+  return lines.join('\n')
+}
+
+const renderSitemapEntryXml = (
+  ctx: Context,
+  routesInfo: SitemapEntry
+): string => {
+  const $ = cheerio.load(
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
+    {
+      xmlMode: true,
+    }
+  )
+  const { routes, lastUpdated } = routesInfo
+  const entryXML = routes.map((route: Route) =>
+    URLEntry(ctx, route, lastUpdated)
+  )
+  $('urlset').append(entryXML.join('\n'))
+  return $.xml()
+}
+
 export const URLEntry = (
   ctx: Context,
   route: Route,
   lastUpdated: string
 ): string => {
-  const { state: {
-    binding,
-    bindingAddress,
-    forwardedHost,
-    rootPath,
-    matchingBindings,
-  },
+  const {
+    state: { bindingAddress, forwardedHost, rootPath },
   } = ctx
   const querystring = bindingAddress
     ? `?__bindingAddress=${bindingAddress}`
     : ''
   const loc = `https://${forwardedHost}${rootPath}${route.path}${querystring}`
-  const localization = route.alternates && route.alternates.length > 1
-    ? route.alternates.map(
-      ({ bindingId, path }) => {
-        const alternateBinding = getBinding(bindingId, matchingBindings)
-        if (bindingId === binding.id || !alternateBinding) {
-            return ''
-          }
-          const { canonicalBaseAddress, defaultLocale: locale } = alternateBinding
-          const href = querystring
-            ? `https://${forwardedHost}${path}?__bindingAddress=${canonicalBaseAddress}`
-            : `https://${canonicalBaseAddress}${path}`
-          return `<xhtml:link rel="alternate" hreflang="${locale}" href="${href}"/>`
-        }
-       )
-      .join('\n')
+  const localization = buildLocalization(ctx, route)
+  const lastmodValue = route.lastmod || lastUpdated
+  const changefreqTag = route.changefreq
+    ? `<changefreq>${route.changefreq}</changefreq>`
     : ''
+  const priorityTag =
+    typeof route.priority === 'number'
+      ? `<priority>${route.priority.toFixed(1)}</priority>`
+      : ''
   let entry = `
       <loc>${loc}</loc>
       ${localization}
-      <lastmod>${lastUpdated}</lastmod>
+      <lastmod>${lastmodValue}</lastmod>
+      ${changefreqTag}
+      ${priorityTag}
     `
   if (route.imagePath && route.imageTitle) {
-    // add image metainfo
     entry = `
     <image:image>
       <image:loc>${route.imagePath}</image:loc>
@@ -73,7 +181,6 @@ export async function sitemapEntry(ctx: Context, next: () => Promise<void>) {
 
 async function legacySitemapEntry(ctx: Context) {
   const {
-    clients: { vbase },
     state: { forwardedPath, bucket },
     vtex: { logger },
   } = ctx
@@ -96,19 +203,11 @@ async function legacySitemapEntry(ctx: Context) {
   }
 
   const { path } = sitemapParams
-
-  const $: any = cheerio.load(
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
-    {
-      xmlMode: true,
-    }
-  )
-
   const fileName = path.split('.')[0]
-  const maybeRoutesInfo = await vbase.getJSON<SitemapEntry>(
-    bucket,
+  const maybeRoutesInfo = await serveCmsEntryFromCandidateBuckets(
+    ctx,
     fileName,
-    true
+    bucket
   )
 
   if (!maybeRoutesInfo) {
@@ -125,14 +224,7 @@ async function legacySitemapEntry(ctx: Context) {
     return
   }
 
-  const { routes, lastUpdated } = maybeRoutesInfo as SitemapEntry
-  const entryXML = routes.map((route: Route) =>
-    URLEntry(ctx, route, lastUpdated)
-  )
-
-  $('urlset').append(entryXML.join('\n'))
-
-  ctx.body = $.xml()
+  ctx.body = renderSitemapEntryXml(ctx, maybeRoutesInfo)
 }
 
 async function catalogSitemapEntry(ctx: Context) {
@@ -150,6 +242,21 @@ async function catalogSitemapEntry(ctx: Context) {
       forwardedPath,
     },
   })
+
+  const sitemapRoute = new RouteParser(SITEMAP_URL)
+  const sitemapParams = sitemapRoute.match(forwardedPath)
+
+  if (sitemapParams) {
+    const { path } = sitemapParams
+    const fileName = path.split('.')[0]
+    const maybeRoutesInfo = await serveCmsEntryFromVBase(ctx, fileName)
+
+    if (maybeRoutesInfo) {
+      ctx.body = renderSitemapEntryXml(ctx, maybeRoutesInfo)
+      ctx.status = 200
+      return
+    }
+  }
 
   ctx.body = await catalog.getSitemap(forwardedHost, forwardedPath)
   ctx.status = 200

--- a/node/service.json
+++ b/node/service.json
@@ -45,6 +45,14 @@
       "sender": "vtex.store-sitemap",
       "keys": ["sitemap.generate:apps-routes"]
     },
+    "generateCmsRoutes": {
+      "sender": "vtex.store-sitemap",
+      "keys": ["sitemap.generate:cms-routes"]
+    },
+    "generateContentPlatformRoutes": {
+      "sender": "vtex.store-sitemap",
+      "keys": ["sitemap.generate:content-platform-routes"]
+    },
     "groupEntries": {
       "sender": "vtex.store-sitemap",
       "keys": ["sitemap.generate:group-entries"]

--- a/node/services/cmsEligibility.test.ts
+++ b/node/services/cmsEligibility.test.ts
@@ -1,0 +1,56 @@
+import {
+  isEligibleCmsPath,
+  isExcludedByCanonical,
+  matchesDisableRoutesTerm,
+} from './cmsEligibility'
+
+describe('cmsEligibility', () => {
+  describe('isExcludedByCanonical', () => {
+    it('treats empty or self-referencing canonical as not excluded', () => {
+      expect(isExcludedByCanonical('/page', undefined)).toBe(false)
+      expect(isExcludedByCanonical('/page', '')).toBe(false)
+      expect(isExcludedByCanonical('/page', '  ')).toBe(false)
+      expect(isExcludedByCanonical('/page', '/page')).toBe(false)
+    })
+
+    it('excludes when canonical points elsewhere', () => {
+      expect(isExcludedByCanonical('/page', '/other')).toBe(true)
+    })
+  })
+
+  describe('matchesDisableRoutesTerm', () => {
+    it('matches substrings when term is non-empty', () => {
+      expect(matchesDisableRoutesTerm('/internal/foo', '/internal/')).toBe(
+        true
+      )
+      expect(matchesDisableRoutesTerm('/public', '/internal/')).toBe(false)
+      expect(matchesDisableRoutesTerm('/public', '')).toBe(false)
+    })
+  })
+
+  describe('isEligibleCmsPath', () => {
+    it('requires slug and honors canonical and disableRoutesTerm', () => {
+      expect(
+        isEligibleCmsPath({
+          canonical: '/other',
+          disableRoutesTerm: '',
+          slug: '/page',
+        })
+      ).toBe(false)
+      expect(
+        isEligibleCmsPath({
+          canonical: '/page',
+          disableRoutesTerm: '/staging',
+          slug: '/staging-page',
+        })
+      ).toBe(false)
+      expect(
+        isEligibleCmsPath({
+          canonical: '/page',
+          disableRoutesTerm: '',
+          slug: '/page',
+        })
+      ).toBe(true)
+    })
+  })
+})

--- a/node/services/cmsEligibility.ts
+++ b/node/services/cmsEligibility.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared eligibility rules for CMS route sources (hCMS and Content Platform).
+ */
+
+/** Canonical opt-out: non-empty canonical pointing away from the page's own slug. */
+export const isExcludedByCanonical = (
+  ownSlug: string,
+  canonical: string | undefined
+): boolean => {
+  if (!canonical) {
+    return false
+  }
+  const trimmed = canonical.trim()
+  if (trimmed === '') {
+    return false
+  }
+  return trimmed !== ownSlug
+}
+
+export const matchesDisableRoutesTerm = (
+  path: string,
+  term: string
+): boolean => Boolean(term) && path.includes(term)
+
+export const isEligibleCmsPath = (args: {
+  slug: string | undefined
+  canonical: string | undefined
+  disableRoutesTerm: string
+}): boolean => {
+  const { slug, canonical, disableRoutesTerm } = args
+  if (!slug) {
+    return false
+  }
+  if (isExcludedByCanonical(slug, canonical)) {
+    return false
+  }
+  if (matchesDisableRoutesTerm(slug, disableRoutesTerm)) {
+    return false
+  }
+  return true
+}

--- a/node/services/cmsServing.ts
+++ b/node/services/cmsServing.ts
@@ -1,0 +1,136 @@
+import * as cheerio from 'cheerio'
+
+import { SitemapEntry, SitemapIndex } from '../middlewares/generateMiddlewares/utils'
+import { xmlTruncateNodes } from '../utils'
+import {
+  ActiveCmsSource,
+  readCmsIndex,
+  resolveActiveCmsSource,
+  resolveCmsBucket,
+} from './cmsSources'
+
+const sitemapIndexEntry = (
+  forwardedHost: string,
+  rootPath: string,
+  entry: string,
+  lastUpdated: string,
+  bindingAddress?: string
+) => {
+  const querystring = bindingAddress
+    ? `?__bindingAddress=${bindingAddress}`
+    : ''
+  return `<sitemap>
+      <loc>https://${forwardedHost}${rootPath}/sitemap/${entry}.xml${querystring}</loc>
+      <lastmod>${lastUpdated}</lastmod>
+    </sitemap>`
+}
+
+export const mergeCmsIndexIntoCatalogXml = (
+  catalogXml: string,
+  cmsIndex: SitemapIndex,
+  forwardedHost: string,
+  rootPath: string,
+  bindingAddress?: string
+): string => {
+  const $ = cheerio.load(catalogXml, { xmlMode: true })
+  const sitemapIndexEl = $('sitemapindex')
+  if (!sitemapIndexEl.length || !cmsIndex.index?.length) {
+    return catalogXml
+  }
+
+  const indexXML = cmsIndex.index.map(entry =>
+    sitemapIndexEntry(
+      forwardedHost,
+      rootPath,
+      entry,
+      cmsIndex.lastUpdated,
+      bindingAddress
+    )
+  )
+  sitemapIndexEl.append(xmlTruncateNodes(indexXML))
+  return $.xml()
+}
+
+export const mergeActiveCmsIndexIntoCatalogXml = async (
+  catalogXml: string,
+  ctx: Context
+): Promise<string> => {
+  const {
+    clients: { vbase },
+    state: { binding, bindingAddress, forwardedHost, rootPath, settings },
+  } = ctx
+
+  if (!binding?.id) {
+    return catalogXml
+  }
+
+  const activeCmsSource = resolveActiveCmsSource(settings)
+  const cmsIndex = await readCmsIndex(activeCmsSource, vbase, binding.id)
+
+  if (!cmsIndex?.index?.length) {
+    return catalogXml
+  }
+
+  return mergeCmsIndexIntoCatalogXml(
+    catalogXml,
+    cmsIndex,
+    forwardedHost,
+    rootPath,
+    bindingAddress
+  )
+}
+
+export const serveCmsEntryFromVBase = async (
+  ctx: Context,
+  fileName: string,
+  activeCmsSource?: ActiveCmsSource
+): Promise<SitemapEntry | null> => {
+  const {
+    clients: { vbase },
+    state: { binding, settings },
+  } = ctx
+
+  const source = activeCmsSource ?? resolveActiveCmsSource(settings)
+  const cmsBucket =
+    binding?.id != null ? resolveCmsBucket(source, binding.id) : null
+
+  if (!cmsBucket) {
+    return null
+  }
+
+  return vbase.getJSON<SitemapEntry>(cmsBucket, fileName, true)
+}
+
+export const serveCmsEntryFromCandidateBuckets = async (
+  ctx: Context,
+  fileName: string,
+  productionBucket: string
+): Promise<SitemapEntry | null> => {
+  const {
+    clients: { vbase },
+    state: { binding, settings },
+  } = ctx
+
+  const activeCmsSource = resolveActiveCmsSource(settings)
+  const cmsBucket =
+    binding?.id != null
+      ? resolveCmsBucket(activeCmsSource, binding.id)
+      : null
+  const candidateBuckets = [productionBucket, cmsBucket].filter(
+    (b): b is string => b != null
+  )
+
+  for (const candidateBucket of candidateBuckets) {
+    // eslint-disable-next-line no-await-in-loop
+    const maybeRoutesInfo = await vbase.getJSON<SitemapEntry>(
+      candidateBucket,
+      fileName,
+      true
+    )
+    if (maybeRoutesInfo) {
+      return maybeRoutesInfo
+    }
+  }
+
+  return null
+}

--- a/node/services/cmsSources.ts
+++ b/node/services/cmsSources.ts
@@ -1,0 +1,163 @@
+import { Logger, VBase } from '@vtex/api'
+
+import {
+  CMS_ROUTES_INDEX,
+  CONTENT_PLATFORM_ROUTES_INDEX,
+  GENERATE_CMS_ROUTES_EVENT,
+  GENERATE_CONTENT_PLATFORM_ROUTES_EVENT,
+  SitemapEntry,
+  SitemapIndex,
+} from '../middlewares/generateMiddlewares/utils'
+import { Settings } from '../middlewares/settings'
+import {
+  CMS_ROUTES_PREFIX,
+  CONTENT_PLATFORM_ROUTES_PREFIX,
+  getBucket,
+  hashString,
+} from '../utils'
+
+export type ActiveCmsSource = 'hcms' | 'content-platform' | 'none'
+
+export interface CmsSourceDefinition {
+  id: Exclude<ActiveCmsSource, 'none'>
+  bucketPrefix: string
+  indexFile: string
+  generateEvent: string
+  customRoutesSectionName: string
+}
+
+export const CMS_SOURCES: Record<
+  Exclude<ActiveCmsSource, 'none'>,
+  CmsSourceDefinition
+> = {
+  hcms: {
+    bucketPrefix: CMS_ROUTES_PREFIX,
+    customRoutesSectionName: 'cms-routes',
+    generateEvent: GENERATE_CMS_ROUTES_EVENT,
+    id: 'hcms',
+    indexFile: CMS_ROUTES_INDEX,
+  },
+  'content-platform': {
+    bucketPrefix: CONTENT_PLATFORM_ROUTES_PREFIX,
+    customRoutesSectionName: 'content-platform-routes',
+    generateEvent: GENERATE_CONTENT_PLATFORM_ROUTES_EVENT,
+    id: 'content-platform',
+    indexFile: CONTENT_PLATFORM_ROUTES_INDEX,
+  },
+}
+
+/**
+ * Resolve which CMS source produces emitted XML / JSON for this generation
+ * (invariant 10 — single active CMS source / spec Decision 8).
+ */
+export const resolveActiveCmsSource = (
+  settings: Partial<Settings> | undefined
+): ActiveCmsSource => {
+  if (settings?.enableContentPlatformRoutes) {
+    return 'content-platform'
+  }
+  if (settings?.enableCmsRoutes) {
+    return 'hcms'
+  }
+  return 'none'
+}
+
+export const isCmsMutualExclusivityConflict = (
+  settings: Partial<Settings> | undefined
+): boolean =>
+  Boolean(settings?.enableCmsRoutes && settings?.enableContentPlatformRoutes)
+
+export const logCmsMutualExclusivityIfNeeded = (
+  settings: Partial<Settings> | undefined,
+  logger: Logger
+): void => {
+  if (!isCmsMutualExclusivityConflict(settings)) {
+    return
+  }
+  logger.info({
+    message:
+      'Both enableCmsRoutes and enableContentPlatformRoutes are on; Content Platform wins per Decision 8',
+    type: 'cms-routes-ignored-by-mutual-exclusivity',
+  })
+}
+
+export const getCmsSourceDefinition = (
+  activeSource: Exclude<ActiveCmsSource, 'none'>
+): CmsSourceDefinition => CMS_SOURCES[activeSource]
+
+/** VBase bucket for the active CMS source, or `null` when none is enabled. */
+export const resolveCmsBucket = (
+  activeCmsSource: ActiveCmsSource,
+  bindingId: string
+): string | null => {
+  if (activeCmsSource === 'none') {
+    return null
+  }
+  const { bucketPrefix } = getCmsSourceDefinition(activeCmsSource)
+  return getBucket(bucketPrefix, hashString(bindingId))
+}
+
+export const readCmsIndex = (
+  activeCmsSource: ActiveCmsSource,
+  vbase: VBase,
+  bindingId: string
+): Promise<SitemapIndex | null> => {
+  if (activeCmsSource === 'none') {
+    return Promise.resolve(null)
+  }
+  const { bucketPrefix, indexFile } = getCmsSourceDefinition(activeCmsSource)
+  return vbase.getJSON<SitemapIndex>(
+    getBucket(bucketPrefix, hashString(bindingId)),
+    indexFile,
+    true
+  )
+}
+
+export const readCmsRoutesFromIndex = async (
+  activeCmsSource: ActiveCmsSource,
+  vbase: VBase,
+  bindingId: string
+): Promise<string[]> => {
+  const index = await readCmsIndex(activeCmsSource, vbase, bindingId)
+  if (!index?.index?.length) {
+    return []
+  }
+  const bucket = resolveCmsBucket(activeCmsSource, bindingId)
+  if (!bucket) {
+    return []
+  }
+  const entries = await Promise.all(
+    index.index.map(file => vbase.getJSON<SitemapEntry>(bucket, file, true))
+  )
+  return entries.reduce<string[]>((acc, entry) => {
+    if (!entry?.routes) {
+      return acc
+    }
+    for (const route of entry.routes) {
+      acc.push(route.path)
+    }
+    return acc
+  }, [])
+}
+
+export const getCmsGenerateEvent = (
+  activeCmsSource: ActiveCmsSource
+): string | null => {
+  if (activeCmsSource === 'none') {
+    return null
+  }
+  return getCmsSourceDefinition(activeCmsSource).generateEvent
+}
+
+export const shouldIncludeCustomRoutesSection = (
+  sectionName: string,
+  activeCmsSource: ActiveCmsSource
+): boolean => {
+  if (sectionName === 'cms-routes') {
+    return activeCmsSource === 'hcms'
+  }
+  if (sectionName === 'content-platform-routes') {
+    return activeCmsSource === 'content-platform'
+  }
+  return true
+}

--- a/node/services/contentPlatformCache.ts
+++ b/node/services/contentPlatformCache.ts
@@ -1,0 +1,80 @@
+import { VBase } from '@vtex/api'
+
+import { PublishedEntry } from '../clients/cmsDataPlane'
+
+/**
+ * VBase bucket holding the Content Platform Data Plane ETag cache. One file
+ * per `(contentType, entryId, locale)` triple, populated whenever the Data
+ * Plane returns `200 OK` with an ETag. Subsequent runs send the cached ETag
+ * via `If-None-Match`; on a `304 Not Modified` the cached payload is reused
+ * verbatim, which short-circuits the per-locale fan-out and keeps the
+ * sitemap stable even when the Data Plane briefly fails.
+ *
+ * Each file is small (~6KB for the smoke landing page, dominated by the
+ * locale_metadata SVG), and the layout reads at most one file per per-entry
+ * per-locale per generation — at FastStore scale the bucket stays well below
+ * VBase's per-bucket file ceiling. Stale entries are not eagerly deleted:
+ * `listEntries` is the authoritative listing, so a cache row that no longer
+ * has a corresponding entry just sits there harmlessly until a future
+ * garbage-collection pass (not implemented yet).
+ */
+export const CONTENT_PLATFORM_CACHE_BUCKET = 'content-platform-data-cache'
+
+export interface CachedEntry {
+  etag: string
+  entry: PublishedEntry
+  cachedAt: string
+}
+
+export interface ContentPlatformCacheKey {
+  contentType: string
+  entryId: string
+  locale: string
+}
+
+/**
+ * Build the VBase file name for a cache key. Each component is base64url
+ * encoded so unusual characters in `entryId` (UUIDs are safe, but a custom
+ * content type could conceivably include slashes or whitespace) don't
+ * collide or break VBase routing. Exposed for tests that seed the cache.
+ */
+export const cacheFileNameFor = ({
+  contentType,
+  entryId,
+  locale,
+}: ContentPlatformCacheKey): string => {
+  const safe = (raw: string) =>
+    Buffer.from(raw)
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/g, '')
+  return `${safe(contentType)}__${safe(entryId)}__${safe(locale)}.json`
+}
+
+export const readCachedEntry = async (
+  vbase: VBase,
+  key: ContentPlatformCacheKey
+): Promise<CachedEntry | null> =>
+  vbase.getJSON<CachedEntry | null>(
+    CONTENT_PLATFORM_CACHE_BUCKET,
+    cacheFileNameFor(key),
+    true
+  )
+
+export const writeCachedEntry = async (
+  vbase: VBase,
+  key: ContentPlatformCacheKey,
+  etag: string,
+  entry: PublishedEntry
+): Promise<void> => {
+  await vbase.saveJSON<CachedEntry>(
+    CONTENT_PLATFORM_CACHE_BUCKET,
+    cacheFileNameFor(key),
+    {
+      cachedAt: new Date().toISOString(),
+      entry,
+      etag,
+    }
+  )
+}

--- a/node/services/hcmsRoutes.ts
+++ b/node/services/hcmsRoutes.ts
@@ -1,0 +1,72 @@
+import { CmsPage } from '../clients/cmsBuilder'
+import {
+  isEligibleCmsPath,
+} from './cmsEligibility'
+import {
+  DEFAULT_HCMS_CONTENT_TYPES,
+  DEFAULT_HCMS_PROJECT_ID,
+  Settings,
+} from '../middlewares/settings'
+
+/**
+ * A Headless CMS page is eligible for the sitemap when it is published, has a
+ * public `seo.slug`, is not the homepage (`/` is framework-owned), is not
+ * opted out via canonical, and does not match the merchant's
+ * `disableRoutesTerm`.
+ */
+export const isEligibleHcmsPage = (
+  page: CmsPage,
+  disableRoutesTerm: string
+): boolean => {
+  if (page.status !== 'published') {
+    return false
+  }
+  const slug = page.settings?.seo?.slug
+  if (!slug || slug === '/') {
+    return false
+  }
+  return isEligibleCmsPath({
+    canonical: page.settings?.seo?.canonical,
+    disableRoutesTerm,
+    slug,
+  })
+}
+
+const resolveProjectId = (settings: Partial<Settings> | undefined): string =>
+  settings?.hcmsProjectId?.trim() || DEFAULT_HCMS_PROJECT_ID
+
+const resolveContentTypes = (
+  settings: Partial<Settings> | undefined
+): string[] =>
+  settings?.hcmsContentTypes && settings.hcmsContentTypes.length > 0
+    ? settings.hcmsContentTypes
+    : DEFAULT_HCMS_CONTENT_TYPES
+
+export const fetchEligibleHcmsSlugs = async (
+  ctx: Context | EventContext
+): Promise<string[]> => {
+  const {
+    clients: { cmsBuilder },
+    state: { settings },
+  } = ctx
+
+  const disableRoutesTerm = settings?.disableRoutesTerm || ''
+  const projectId = resolveProjectId(settings)
+  const contentTypes = resolveContentTypes(settings)
+
+  const slugs = new Set<string>()
+  for (const contentType of contentTypes) {
+    // eslint-disable-next-line no-await-in-loop
+    const pages = await cmsBuilder.listAllPages(projectId, contentType)
+    for (const cmsPage of pages) {
+      if (!isEligibleHcmsPage(cmsPage, disableRoutesTerm)) {
+        continue
+      }
+      const slug = cmsPage.settings?.seo?.slug
+      if (slug) {
+        slugs.add(slug)
+      }
+    }
+  }
+  return Array.from(slugs)
+}

--- a/node/services/routes.test.ts
+++ b/node/services/routes.test.ts
@@ -1,0 +1,70 @@
+import {
+  resolveActiveCmsSource,
+  shouldIncludeCustomRoutesSection,
+} from './cmsSources'
+
+describe('resolveActiveCmsSource (spec Decision 8 / FR-10)', () => {
+  it('returns none when both flags are off', () => {
+    expect(
+      resolveActiveCmsSource({
+        enableCmsRoutes: false,
+        enableContentPlatformRoutes: false,
+      })
+    ).toBe('none')
+  })
+
+  it('returns hcms when only enableCmsRoutes is on', () => {
+    expect(
+      resolveActiveCmsSource({
+        enableCmsRoutes: true,
+        enableContentPlatformRoutes: false,
+      })
+    ).toBe('hcms')
+  })
+
+  it('returns content-platform when only enableContentPlatformRoutes is on', () => {
+    expect(
+      resolveActiveCmsSource({
+        enableCmsRoutes: false,
+        enableContentPlatformRoutes: true,
+      })
+    ).toBe('content-platform')
+  })
+
+  it('returns content-platform when both flags are on (Decision 8 tie-breaker)', () => {
+    expect(
+      resolveActiveCmsSource({
+        enableCmsRoutes: true,
+        enableContentPlatformRoutes: true,
+      })
+    ).toBe('content-platform')
+  })
+
+  it('returns none for undefined or empty settings', () => {
+    expect(resolveActiveCmsSource(undefined)).toBe('none')
+    expect(resolveActiveCmsSource({})).toBe('none')
+  })
+})
+
+describe('shouldIncludeCustomRoutesSection', () => {
+  it('includes only the active CMS section', () => {
+    expect(shouldIncludeCustomRoutesSection('cms-routes', 'hcms')).toBe(true)
+    expect(
+      shouldIncludeCustomRoutesSection('cms-routes', 'content-platform')
+    ).toBe(false)
+    expect(
+      shouldIncludeCustomRoutesSection('content-platform-routes', 'hcms')
+    ).toBe(false)
+    expect(
+      shouldIncludeCustomRoutesSection(
+        'content-platform-routes',
+        'content-platform'
+      )
+    ).toBe(true)
+  })
+
+  it('passes through non-CMS sections', () => {
+    expect(shouldIncludeCustomRoutesSection('user-routes', 'none')).toBe(true)
+    expect(shouldIncludeCustomRoutesSection('apps-routes', 'hcms')).toBe(true)
+  })
+})

--- a/node/services/routes.ts
+++ b/node/services/routes.ts
@@ -1,8 +1,27 @@
 import { Internal, ListInternalsResponse } from 'vtex.rewriter'
 import { flatten } from 'ramda'
 
-import { SitemapIndex } from '../middlewares/generateMiddlewares/utils'
-import { EXTENDED_INDEX_FILE, getBucket, hashString } from '../utils'
+import {
+  SitemapIndex,
+} from '../middlewares/generateMiddlewares/utils'
+import {
+  EXTENDED_INDEX_FILE,
+  getBucket,
+  hashString,
+} from '../utils'
+import {
+  readCmsRoutesFromIndex,
+  resolveActiveCmsSource,
+} from './cmsSources'
+import { fetchEligibleHcmsSlugs } from './hcmsRoutes'
+
+// Re-export CMS source helpers for consumers that import from routes.ts.
+export {
+  ActiveCmsSource,
+  resolveActiveCmsSource,
+  resolveCmsBucket,
+  readCmsIndex,
+} from './cmsSources'
 
 const STORE_SITEMAP_BUILD_FILE = '/dist/vtex.store-sitemap/build.json'
 
@@ -56,7 +75,6 @@ async function fetchExtendedRoutes(ctx: Context) {
     vtex: { logger },
   } = ctx
 
-  // Extended routes require a binding context
   if (!binding) {
     logger.info({
       message: 'Skipping extended routes fetch - no binding context available',
@@ -88,9 +106,7 @@ export async function getUserRoutes(ctx: Context) {
     .filter(isValidRoute)
     .map(route => route.from)
 
-  const userRoutes = [...validInternalRoutes, ...extendedRoutes]
-
-  return userRoutes
+  return [...validInternalRoutes, ...extendedRoutes]
 }
 
 export async function getAppsRoutes(ctx: Context) {
@@ -112,4 +128,30 @@ export async function getAppsRoutes(ctx: Context) {
   )
 
   return flatten<string>(routes)
+}
+
+export async function getCmsRoutes(ctx: Context): Promise<string[]> {
+  const {
+    state: { settings },
+  } = ctx
+
+  if (resolveActiveCmsSource(settings) !== 'hcms') {
+    return []
+  }
+
+  return fetchEligibleHcmsSlugs(ctx)
+}
+
+export async function getContentPlatformRoutes(ctx: Context): Promise<string[]> {
+  const {
+    state: { binding, settings },
+    clients: { vbase },
+  } = ctx
+
+  const activeSource = resolveActiveCmsSource(settings)
+  if (activeSource !== 'content-platform' || !binding?.id) {
+    return []
+  }
+
+  return readCmsRoutesFromIndex(activeSource, vbase, binding.id)
 }

--- a/node/test/fixtures/cmsTestFixtures.ts
+++ b/node/test/fixtures/cmsTestFixtures.ts
@@ -1,0 +1,83 @@
+import {
+  IOContext,
+  VBase,
+  VBaseSaveResponse,
+} from '@vtex/api'
+import * as TypeMoq from 'typemoq'
+
+export interface LoggerCapture {
+  error: jest.Mock
+  info: jest.Mock
+  warn: jest.Mock
+}
+
+export const makeLogger = (): LoggerCapture => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+})
+
+export interface MemoryVBaseOptions {
+  initialData?: Record<string, Record<string, unknown>>
+}
+
+/**
+ * In-memory VBase mock shared by CMS middleware tests.
+ */
+export const createMemoryVBaseMock = (
+  ioContext: IOContext,
+  options: MemoryVBaseOptions = {}
+) => {
+  const vbaseTypeMock = TypeMoq.Mock.ofInstance(VBase)
+
+  // tslint:disable-next-line:max-classes-per-file
+  return class MemoryVBaseMock extends vbaseTypeMock.object {
+    public jsonData: Record<string, Record<string, unknown>> = {
+      ...(options.initialData ?? {}),
+    }
+
+    constructor() {
+      super(ioContext)
+    }
+
+    public getJSON = async <T>(
+      bucket: string,
+      file: string,
+      nullOrUndefined?: boolean
+    ): Promise<T> => {
+      if (!this.jsonData[bucket]?.[file] && nullOrUndefined) {
+        return (null as unknown) as T
+      }
+      return Promise.resolve(this.jsonData[bucket]?.[file] as T)
+    }
+
+    public saveJSON = async <T>(
+      bucket: string,
+      file: string,
+      data: T
+    ): Promise<VBaseSaveResponse> => {
+      if (!this.jsonData[bucket]) {
+        this.jsonData[bucket] = {}
+      }
+      this.jsonData[bucket][file] = data
+      return ({ updated: true } as unknown) as VBaseSaveResponse
+    }
+  }
+}
+
+export interface CmsActiveSettings {
+  enableCmsRoutes: boolean
+  enableContentPlatformRoutes: boolean
+}
+
+export const defaultCmsServingSettings = (
+  activeSettings: CmsActiveSettings
+) => ({
+  disableRoutesTerm: '',
+  enableAppsRoutes: true,
+  enableCmsRoutes: activeSettings.enableCmsRoutes,
+  enableContentPlatformRoutes: activeSettings.enableContentPlatformRoutes,
+  enableNavigationRoutes: true,
+  enableProductRoutes: true,
+  ignoreBindings: false,
+})

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -15,6 +15,25 @@ export const CUSTOM_ROUTES_BUCKET = 'custom-routes'
 export const CUSTOM_ROUTES_FILENAME = 'custom-routes.json'
 export const CUSTOM_ROUTES_GENERATION_LOCK_FILENAME = 'generation-lock.json'
 
+// CMS routes — per Google's sitemap protocol limits (50k URLs / 50 MB per file).
+// These ceilings drive the chunking in generateCmsRoutes.
+export const CMS_ROUTES_MAX_URLS_PER_FILE = 50000
+export const CMS_ROUTES_MAX_BYTES_PER_FILE = 50 * 1024 * 1024
+// Legacy hCMS (Headless CMS) routes use the 'hcms-routes' prefix.
+export const CMS_ROUTES_PREFIX = 'hcms-routes'
+
+// Content Platform (new VTEX CMS) routes — same Google protocol ceilings, own
+// VBase bucket prefix and file-name prefix so that hCMS-legacy and Content
+// Platform artifacts coexist (mutually exclusive per generation — spec
+// Decision 8).
+// VBase enforces a 50-char limit on the full metadata bucket name
+// (`vtex.store-sitemap.<bucket>`). The app prefix alone is 19 chars, leaving
+// at most 31 chars for the bucket part. `getBucket` appends `_<hash>` (up to
+// 12 chars), so the prefix must stay ≤ 19 chars. 'cms-routes' (10 chars) is
+// safely within that limit and is used for both external file names and
+// internal VBase bucket names.
+export const CONTENT_PLATFORM_ROUTES_PREFIX = 'cms-routes'
+
 export const TENANT_CACHE_TTL_S = 60 * 10
 
 export const STORE_PRODUCT = 'vtex-storefront'

--- a/specs/cms-routes-in-sitemap-for-faststore.md
+++ b/specs/cms-routes-in-sitemap-for-faststore.md
@@ -1,0 +1,568 @@
+# Include CMS routes in Sitemap generation for FastStore
+
+> **Status**: Done
+> **Created**: 2026-05-27
+> **Last updated**: 2026-05-27 — added support for the new VTEX CMS (Content Platform) as a parallel route source
+> **Jira**: [SFS-3123](https://vtex-dev.atlassian.net/browse/SFS-3123)
+> **PRD**: [Sitemap generation in FastStore](https://docs.google.com/document/d/18QrjAJmGpfLJCW-br5a2Tw-rAvC57biKAl5Z2_4djiM/edit)
+> **Related**: [Known Issue — Native sitemap is not fully integrated with FastStore](https://help.vtex.com/known-issues/native-sitemap-is-not-fully-integrated-with-faststore--5IrsqCEtQKPFstqywlV7Nn) · [Headless CMS stores will be upgraded to the new VTEX CMS (Mar 30, 2026)](https://help.vtex.com/announcements/2026-03-30-headless-cms-stores-will-be-upgraded-to-the-new-vtex-cms)
+
+## Assumptions
+
+These assumptions guide this spec; revisit during review if they change.
+
+- **Implementation repo**: `vtex.store-sitemap` (this repo). The IO app is extended to source CMS routes from VTEX Rewriter (hCMS legacy) and from the VTEX CMS Data Plane API (Content Platform), and expose them through the existing `/_v/public/sitemap/*` and `/sitemap*.xml` pipelines that FastStore already consumes. Changes inside the FastStore project (Next.js side) are out of scope of this spec.
+- **CMS sources** (both first-party VTEX, in scope):
+  - **Headless CMS (hCMS, legacy)** — pages persisted as Rewriter `Internal` entries (the same store of record already used by `generateRewriterRoutes` and `customRoutes`). Source of record for FastStore v1/v2 stores and v3 stores not yet upgraded.
+  - **VTEX CMS (Content Platform, new)** — pages stored in the CMS's own CQRS data plane and read through a read-only Data Plane REST API, with native branches, ETag caching and multi-language. Source of record for FastStore v3+ stores being [progressively upgraded since March 2026](https://help.vtex.com/announcements/2026-03-30-headless-cms-stores-will-be-upgraded-to-the-new-vtex-cms).
+  - External CMSs (Contentful, etc.) remain out of scope.
+  - A store is expected to use **one** of the two VTEX surfaces at a time during the migration window — the two route sources are **mutually exclusive per generation** (see [Decision 8](#decision-8-mutual-exclusivity-between-hcms-legacy-and-content-platform)).
+- **Multi-binding/locale strategy** (subfolder vs. subdomain) is owned by the [Multi-bindings Sitemap Support](https://docs.google.com/document/d/12NfWIF9boKgOSh3u4BqwSSJkwB7cm9PG7iBUAJ0QzGQ/edit?tab=t.yfo5oamq0rgl) spec. This document defines only the **shape** of multi-locale output (hreflang/x-default tags per URL entry), not how bindings are resolved.
+
+---
+
+## 1. Business Context
+
+### Problem Statement
+
+Stores running **FastStore** (Next.js storefront) do not have a native, integrated way to generate and keep their `sitemap.xml` up to date. The current solution — the IO Sitemap app (this repo) — was designed for Store Framework with Site Editor and does **not** include pages created via VTEX CMS / hCMS. As a result, merchants resort to manual workarounds with high maintenance cost:
+
+- Combining the IO Sitemap with the `next-sitemap` plugin and custom rewrites in the store repository
+- Manually downloading product/category data, running scripts, and editing `sitemap.xml` by hand whenever CMS pages change
+
+Any content change (a new category, product, or CMS page) requires a developer to regenerate and republish the sitemap, creating ongoing overhead and risk of stale sitemaps — which hurts the store's SEO. This is a publicly mapped Known Issue impacting customers like **Hearst, ODP, JW Pepper and Americanas**.
+
+In parallel, a multi-language / multi-currency evolution is underway in FastStore that demands that each URL declare its locale alternates in the sitemap.
+
+On top of that, VTEX is [progressively migrating stores from the Headless CMS (legacy) to the new VTEX CMS — the Content Platform](https://help.vtex.com/announcements/2026-03-30-headless-cms-stores-will-be-upgraded-to-the-new-vtex-cms) — starting March 2026. The Content Platform has a different architecture (CQRS with a read-only Data Plane REST API, Git-like branches, native multi-language) and **does not store pages as Rewriter Internals**. Without explicit support, sitemap coverage regresses for every store that flips to the new CMS. The first wave includes FastStore v3 stores that have already onboarded the new CMS and lost their CMS-page coverage in the sitemap as a result.
+
+### Goals
+
+- FastStore stores expose a single, automatically maintained sitemap that **includes all CMS pages** — sourced from either the **Headless CMS (legacy)** or the new **VTEX CMS (Content Platform)** — alongside framework-generated pages (PDPs, PLPs, landing pages, and any custom-slug page).
+- The merchant can **opt a page out of the sitemap from the CMS** without code changes (per-page toggle on hCMS legacy; SEO field `canonical` pointing to another URL on Content Platform — see [Decision 10](#decision-10-content-platform-opt-out-via-seo-canonical)).
+- The generated sitemap follows the Google sitemap protocol — including `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>`, the **50,000 URL / 50 MB chunking limit**, and a `robots.txt` entry pointing to it.
+- For multi-locale stores, each URL declares all locale alternates via `xhtml:link` `hreflang` tags, including `x-default`.
+- Eliminate the manual workarounds described in the Problem Statement for the customers listed above and equivalent FastStore tenants.
+- **Same FastStore-side experience regardless of CMS surface**: stores being upgraded from hCMS to Content Platform see no regression in sitemap coverage; the contract on `/sitemap.xml`, `/sitemap/*.xml`, `/robots.txt` and `/_v/public/sitemap/custom-routes` is preserved, with only the set name in the JSON response and the file name of the sub-sitemap reflecting the active source (`cms-routes-*` vs. `content-platform-routes-*`).
+
+### User Stories
+
+#### US-1: Merchant — CMS pages appear in the sitemap
+
+- **Story**: As a merchant on FastStore, I want every page I publish in the CMS (PDP, PLP, landing page or custom-slug page) to automatically appear in my store sitemap, so that Google can discover and index it without me editing files. This must hold whether the store uses the legacy Headless CMS or the new VTEX CMS (Content Platform).
+- **Acceptance Criteria** (hCMS legacy):
+  - **Given** a published hCMS page with a custom slug `/our-story`, **when** the sitemap is regenerated, **then** `https://{store}/our-story` appears as a `<url>` entry in the served sitemap.
+  - **Given** a published hCMS-defined PLP at `/black-friday`, **when** the sitemap is regenerated, **then** the URL is present **and** is not duplicated by an automatically generated category URL.
+  - **Given** an hCMS page is unpublished or deleted, **when** the next regeneration completes, **then** the URL is removed from the served sitemap.
+- **Acceptance Criteria** (Content Platform):
+  - **Given** the store has `enableContentPlatformRoutes: true` and a `landingPage` entry is published with `seo.slug: /our-story`, **when** the sitemap is regenerated, **then** `https://{store}/our-story` appears as a `<url>` entry inside `content-platform-routes-N.xml`.
+  - **Given** a Content Platform entry of a **custom content type** added to the `contentPlatformContentTypes` app setting (default `["landingPage", "home"]`), **when** the sitemap is regenerated, **then** its URL is included — i.e., the routable-type set is **settings-driven** with a planned auto-discovery follow-up against `vtex.admin-cms-graphql` (see [Decision 9](#decision-9-routable-type-discovery--settings-allowlist-with-future-graphql-discovery)).
+  - **Given** a Content Platform entry that has not been published to production (only saved as a draft on the Control Plane), **when** the sitemap is regenerated, **then** the URL is NOT included — the Data Plane REST API used by this app exposes only production data (see [Decision 7](#decision-7-content-platform-data-plane-as-a-parallel-source)).
+  - **Given** a Content Platform entry is unpublished or deleted, **when** the next regeneration completes, **then** the URL is removed from the served sitemap.
+
+#### US-2: Merchant — Opt a page out of the sitemap
+
+- **Story**: As a merchant, I want a CMS-native way to exclude a specific page from the sitemap, so that I can keep internal/test pages out of search engine indexes without losing the page itself.
+- **Acceptance Criteria** (hCMS legacy — dedicated toggle):
+  - **Given** an hCMS page where the "Include in sitemap" toggle is **on** (the default), **when** the sitemap is regenerated, **then** the URL is included.
+  - **Given** an hCMS page where the toggle is **off**, **when** the sitemap is regenerated, **then** the URL is excluded.
+  - **Given** an hCMS page configured with `noindex`, **canonical pointing to a different URL**, or marked as a **login / error page**, **when** the sitemap is regenerated, **then** the URL is excluded regardless of the toggle. (Content Platform exposes only `canonical` of these today — see the next bullet.)
+- **Acceptance Criteria** (Content Platform — SEO fields only, no dedicated toggle):
+  - **Given** a Content Platform page where the SEO field `canonical` is set to a URL different from the entry's own `slug`, **when** the sitemap is regenerated, **then** the URL is excluded. (`canonical = ""` is the Data Plane default and means "no override".)
+  - **Given** a Content Platform page where the SEO field `canonical` is set and points to a URL different from the entry's own path, **when** the sitemap is regenerated, **then** the URL is excluded.
+  - **Given** a Content Platform page with default SEO fields (no `canonical` override — empty string), **when** the sitemap is regenerated, **then** the URL is included.
+  - **Given** the Content Platform does not currently expose a per-page "Include in sitemap" toggle or `noindex` field in the schema (this is by design — see [Decision 10](#decision-10-content-platform-opt-out-via-seo-canonical)), **when** an operator wants to hide a single page from the sitemap, **then** the documented path is to set that page's `seo.canonical` to another URL.
+
+#### US-3: SEO operator — Multi-locale alternates
+
+- **Story**: As an SEO operator for a multi-language store, I want each URL in the sitemap to declare its alternate locale versions, so that Google serves the correct localized URL to each user.
+- **Acceptance Criteria**:
+  - **Given** a page `/about` exists in locales `en-US`, `pt-BR`, `es-ES`, **when** the sitemap is served, **then** the `<url>` entry for the `en-US` version contains three `<xhtml:link rel="alternate" hreflang="..." href="..."/>` tags — **one for each locale, including itself** — plus one `hreflang="x-default"` pointing to the store's default locale version.
+  - **Given** a single-locale store, **when** the sitemap is served, **then** no `<xhtml:link>` tags are emitted.
+  - **Given** a page exists only in `en-US`, **when** the sitemap is served, **then** that URL declares no alternates beyond `x-default` (which equals itself).
+
+#### US-4: SEO operator — Spec-compliant sitemap
+
+- **Story**: As an SEO operator, I want the generated sitemap to respect Google's protocol, so that no manual chunking or `robots.txt` edits are needed.
+- **Acceptance Criteria**:
+  - **Given** the store has more than 50,000 indexable URLs **or** a sub-sitemap would exceed 50 MB, **when** the sitemap is generated, **then** it is automatically chunked into multiple sub-sitemaps referenced by a top-level `<sitemapindex>`.
+  - **Given** any `<url>` entry, **when** the sitemap is served, **then** it contains `<loc>`, `<lastmod>`, `<changefreq>` and `<priority>` tags with valid values.
+  - **Given** the store has a sitemap, **when** `GET /robots.txt` is served, **then** it contains a `Sitemap: https://{store}/sitemap.xml` directive.
+
+#### US-5: Developer / Integrator — Programmatic access to CMS-included routes
+
+- **Story**: As a FastStore developer building or migrating a store, I want to fetch the list of CMS-backed routes via a public JSON endpoint, so that I can use them in build-time or runtime sitemap composition if needed.
+- **Acceptance Criteria**:
+  - **Given** the store has hCMS pages and `enableCmsRoutes: true`, **when** I `GET /_v/public/sitemap/custom-routes`, **then** the response includes a section named `cms-routes` (in addition to existing `apps-routes` and `user-routes`).
+  - **Given** the store has Content Platform pages and `enableContentPlatformRoutes: true`, **when** I `GET /_v/public/sitemap/custom-routes`, **then** the response includes a section named `content-platform-routes` (in addition to existing `apps-routes` and `user-routes`).
+  - **Given** both flags are set to `true` simultaneously, **when** I `GET /_v/public/sitemap/custom-routes`, **then** only `content-platform-routes` is present (Content Platform wins — see [Decision 8](#decision-8-mutual-exclusivity-between-hcms-legacy-and-content-platform)) and the `cms-routes` section is absent for that response.
+  - **Given** the response is cached, **when** I make multiple requests within the cache window, **then** I receive the same data without triggering regeneration.
+
+#### US-6: Site operator — Migrate from hCMS to Content Platform without sitemap regression
+
+- **Story**: As a site operator going through the VTEX hCMS → Content Platform upgrade, I want to switch the active source for my sitemap with a single setting flip, so that I get parity in coverage with no manual republishing and no XML editing.
+- **Acceptance Criteria**:
+  - **Given** the store has `enableCmsRoutes: true` and serves a `<sitemapindex>` referencing `cms-routes-*.xml`, **when** the operator sets `enableContentPlatformRoutes: true` and `enableCmsRoutes: false`, **then** the next successful regeneration serves a `<sitemapindex>` that references `content-platform-routes-*.xml` instead of `cms-routes-*.xml`, with no leftover references to the old files.
+  - **Given** both `enableCmsRoutes` and `enableContentPlatformRoutes` are `true`, **when** regeneration runs, **then** Content Platform wins, hCMS ingestion is skipped, and a one-shot structured log `cms-routes-ignored-by-mutual-exclusivity` is emitted per generation cycle.
+  - **Given** the operator rolls back by setting `enableContentPlatformRoutes: false` and `enableCmsRoutes: true`, **when** the next regeneration completes, **then** the sitemap reflects the hCMS source again, without manual VBase cleanup.
+  - **Given** the operator has both flags `false`, **when** I `GET /_v/public/sitemap/custom-routes`, **then** the response contains only `apps-routes` and `user-routes` (current behavior preserved).
+
+### Key Scenarios
+
+| Scenario | Pre-conditions | Steps | Expected Result |
+|---|---|---|---|
+| Happy path — hCMS page included | FastStore store with hCMS active and `enableCmsRoutes: true`; merchant publishes `/our-mission` with default toggle | Sitemap regeneration runs (scheduled or triggered) | `/our-mission` appears with `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>` in `cms-routes-N.xml` |
+| Happy path — Content Platform landing page included | FastStore v3 store with `enableContentPlatformRoutes: true`; merchant publishes a `landingPage` whose `seo.slug` is `/our-mission` | Sitemap regeneration runs | `/our-mission` appears with `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>` in `content-platform-routes-N.xml` |
+| Happy path — Content Platform custom type added to allowlist | Content Platform store with a custom type `microsite`; operator adds `"microsite"` to `contentPlatformContentTypes` in app settings; entries are published | Sitemap regeneration runs | URLs from `microsite` entries are emitted alongside `landingPage` entries (settings-driven allowlist — see [Decision 9](#decision-9-routable-type-discovery--settings-allowlist-with-future-graphql-discovery)) |
+| Happy path — Multi-locale page | Store with `en-US` (default), `pt-BR`, `es-ES`; page `/about` exists in all three | Sitemap is served | `<url>` entry contains 3 `<xhtml:link>` alternates + 1 `x-default` |
+| Error — Canonical to external URL | CMS page `/promo-old` has canonical → `/promo-new` (works for both sources) | Sitemap regeneration runs | `/promo-old` is excluded; `/promo-new` is included (if eligible) |
+| Error — Rewriter unavailable (hCMS path) | Rewriter GraphQL is failing during generation | Sitemap regeneration is triggered | Generation retries (per existing `listInternalsWithRetry`), logs `cms-routes-generation-error`, and falls back to the **previous successful sitemap**; served XML does not regress to empty |
+| Error — Content Platform Data Plane outage | Content Platform Data Plane returns 5xx during generation; `enableContentPlatformRoutes: true` | Sitemap regeneration runs | Client retries with exponential backoff; on persistent failure, logs `content-platform-routes-generation-error`, the **previous successful** `content-platform-routes-*.xml` is kept; served XML does not regress |
+| Error — Both flags ON | `enableCmsRoutes: true` AND `enableContentPlatformRoutes: true` | Sitemap regeneration runs | Content Platform wins; `cms-routes-*.xml` is NOT emitted nor referenced in the index for this generation; a single `cms-routes-ignored-by-mutual-exclusivity` log is emitted per generation cycle |
+| Edge — Chunking boundary (>50k URLs) | Store has 120,000 indexable URLs | Sitemap regeneration runs | Top-level `<sitemapindex>` references three sub-sitemap files (`50k + 50k + 20k`), all linked from `/sitemap.xml`; `robots.txt` references the index |
+| Edge — Toggle off + multi-locale (hCMS) | `/secret` toggle is off in locale `en-US` only | Sitemap is served | `/secret` is fully excluded across all locales (a page hidden in any locale is treated as not-in-sitemap for all alternates) |
+| Edge — Content Platform draft / unpublished isolation | Content Platform has 50 landing pages drafted in the Content Studio but not yet published to production | Sitemap regeneration runs | Only published entries appear; drafts are absent because the Data Plane REST API exposes only production data (see [Decision 7](#decision-7-content-platform-data-plane-as-a-parallel-source)) |
+| Edge — Content Platform locale fidelity | Content Platform `landingPage` exists in `en-US` only; store has `en-US` + `pt-BR` with runtime fallback `pt-BR → en-US` | Sitemap regeneration runs | URL is emitted under `en-US` only; **no** `pt-BR` `<xhtml:link>` alternate is synthesized from the runtime fallback (see [Decision 11](#decision-11-locale-emission-for-content-platform)) |
+| Edge — CMS page conflicts with auto route | A CMS page `/p/12345` overrides an auto-generated product URL with same path | Sitemap regeneration runs | A single entry is emitted (deduplicated); CMS metadata (`lastmod`, toggle) takes precedence over the auto-generated one |
+| Edge — Content Platform mid-migration rollback | Operator flipped Content Platform on yesterday, today flips it off and hCMS back on | Sitemap regeneration runs | `<sitemapindex>` references `cms-routes-*.xml` again; stale `content-platform-routes-*.xml` files in VBase are no longer referenced and are ignored on serve (cleanup is passive, see [Decision 8](#decision-8-mutual-exclusivity-between-hcms-legacy-and-content-platform)) |
+
+### Functional Requirements
+
+**FR-1 — CMS route ingestion (hCMS legacy)**
+The generator MUST source CMS-published routes from VTEX Rewriter Internals whose origin is `hcms` / `cms` and include them in the sitemap together with framework-generated PDPs, PLPs and landing pages.
+
+**FR-2 — Per-page hCMS toggle**
+For the **hCMS (legacy) source only**, the CMS MUST surface a boolean configuration field "Include in sitemap" (default `true`) that, when `false`, causes the route to be omitted from the sitemap. The generator MUST honor this flag (mapped onto Rewriter `disableSitemapEntry` or an equivalent attribute — see [Decision 3](#decision-3-cms-toggle--persistence-model)). The Content Platform source uses SEO fields for opt-out instead — see [FR-11](#fr-11--opt-out-via-seo-fields-content-platform) and [Decision 10](#decision-10-content-platform-opt-out-via-seo-canonical).
+
+**FR-3 — Mandatory exclusions**
+The generator MUST exclude (for both CMS sources):
+- Pages classified as login pages
+- Pages declaring `noindex` (robots meta or page setting / SEO field)
+- Pages whose canonical URL points to a **different** URL
+- Pages classified as error pages (e.g., `notFound*`)
+
+**FR-4 — Multi-locale alternates**
+For each indexable URL in a multi-locale store, the generator MUST emit one `<xhtml:link rel="alternate" hreflang="{locale}" href="{href}"/>` per locale version (including the URL itself) **and** one `<xhtml:link rel="alternate" hreflang="x-default" href="{defaultHref}"/>` pointing to the store's default locale version.
+
+**FR-5 — Sitemap protocol tags**
+Each `<url>` entry MUST contain `<loc>`, `<lastmod>`, `<changefreq>` and `<priority>` with valid values per [sitemaps.org/protocol](https://www.sitemaps.org/protocol.html).
+
+**FR-6 — Chunking**
+The generator MUST split content into multiple sub-sitemap files whenever a single file would exceed **50,000 URLs** or **50 MB uncompressed**, exposing them through a top-level `<sitemapindex>` at `/sitemap.xml`.
+
+**FR-7 — `robots.txt` integration**
+The `/robots.txt` served by this app MUST contain a `Sitemap:` directive pointing to the canonical `https://{host}/sitemap.xml` for the current binding.
+
+**FR-8 — Public JSON endpoint**
+The existing `/_v/public/sitemap/custom-routes` endpoint MUST expose CMS-backed routes alongside the current `apps-routes` and `user-routes` sections. The CMS section's `name` reflects the active source: `cms-routes` (hCMS) or `content-platform-routes` (Content Platform); at most one is present per response (see [FR-10](#fr-10--source-mutual-exclusivity)).
+
+**FR-9 — Content Platform route ingestion**
+The generator MUST be able to source routes from the **VTEX CMS Data Plane REST API** (Content Platform) as an alternative to the hCMS source. Ingestion MUST:
+- Read only **published** entries; preview / draft / feature content lives on the Content Platform Control Plane and is never reachable through the Data Plane REST API this app uses, so non-production data cannot leak into the sitemap by construction.
+- **Discover ingestable content types via settings**: ingest entries from every content type listed in the `contentPlatformContentTypes` app setting (default `["landingPage", "home"]`). Custom routable types are added by appending to that array; no app release is required. Auto-discovery via `vtex.admin-cms-graphql` is a planned follow-up (see [Decision 9](#decision-9-routable-type-discovery--settings-allowlist-with-future-graphql-discovery)).
+- Materialize one `<url>` entry per published entry × per locale where the entry is actually published (no synthetic fallback locales — see [Decision 11](#decision-11-locale-emission-for-content-platform)).
+- Use **ETag-based caching** (`If-None-Match`) on Data Plane reads to skip rewriting VBase entries when content has not changed.
+
+**FR-10 — Source mutual exclusivity**
+At most one CMS source MUST be active per generation. When both `enableCmsRoutes` (hCMS legacy) and `enableContentPlatformRoutes` (new CMS) are `true` simultaneously, the **Content Platform source wins**, hCMS ingestion is skipped for that generation, no `cms-routes-*.xml` is emitted nor referenced in the `<sitemapindex>`, and a structured log entry `cms-routes-ignored-by-mutual-exclusivity` is emitted exactly once per generation cycle. See [Decision 8](#decision-8-mutual-exclusivity-between-hcms-legacy-and-content-platform).
+
+**FR-11 — Opt-out via SEO canonical (Content Platform)**
+For Content Platform entries, exclusion from the sitemap MUST be driven exclusively by the `seo.canonical` field:
+- `canonical` is a non-empty string AND points to a URL different from the entry's own `seo.slug` → excluded
+- `canonical = ""` (Data Plane default) → "no override", the entry stays included
+The generator MUST NOT require a new per-page toggle in the Content Platform schema; SEO canonical is the contract today (see [Decision 10](#decision-10-content-platform-opt-out-via-seo-canonical)). If the CMS team adds `seo.noindex` in a future schema version, the middleware can layer that on without breaking this rule.
+
+### Non-Functional Requirements
+
+- **Performance**: Full regeneration for a store with 100k URLs and 3 locales completes within the existing background-generation budget (target: ≤ 30 min, matching today's documented ≈ 30 min for 60k products). No additional synchronous load on the sitemap serve path. **Content Platform parity**: the Data Plane's read-optimization (CQRS) plus ETag caching is expected to make the Content Platform path at least as fast as the hCMS one for an equivalent catalog.
+- **Cacheability**: Served XML continues to honor existing cache-control rules (long cache control for the `customRoutes` route, public for `robots`). The CMS toggle / SEO-field changes propagate at most within the existing generation cadence (≤ 1 day stale window, mirroring the `customRoutes` cache).
+- **ETag caching (Content Platform)**: The Data Plane client MUST send `If-None-Match` on subsequent reads of the same `(contentType, entryId, locale)` triple, and the middleware MUST persist returned ETags in the VBase `content-platform-data-cache` bucket. A `304 Not Modified` response MUST reuse the cached `PublishedEntry` verbatim and emit a route whose `<loc>` matches the previous successful run.
+- **Reliability**: Generation failures MUST NOT cause the served sitemap to regress to empty; the previous successful version remains available until a new one is produced (current VBase-cached behavior). This applies to both the hCMS and Content Platform paths independently.
+- **Observability**: Every regeneration emits structured logs and metrics: counts per source (hCMS, Content Platform, product, navigation, apps), exclusion counters per reason — `canonical-mismatch` (Content Platform & hCMS), `noindex`, `login`, `error`, `toggle-off` (all hCMS-only today; the Content Platform half is added once the CMS team ships those fields), chunking outcome, and (Content Platform only) per-content-type entry counts and total bindings touched.
+- **Locale fidelity (Content Platform)**: locale alternates are emitted **only for locales where the entry actually has published content**. The generator does not synthesize fallback URLs under a different locale's prefix even if the FastStore runtime would serve fallback content for that locale.
+- **Backwards compatibility**: Existing consumers of `/sitemap.xml`, `/sitemap/*.xml`, `/robots.txt`, and `/_v/public/sitemap/custom-routes` MUST continue to work without contract-breaking changes. Both CMS-source additions are additive (new array entries, new sub-sitemap files); existing entry shapes are not modified.
+- **Security**: hCMS uses existing Rewriter / GraphQL apps (no new outbound policies). Content Platform requires a new outbound-access policy in `manifest.json` for the VTEX CMS Data Plane host; no inbound surface is added.
+
+### Out of Scope
+
+- Multi-locale support for **non-CMS, framework-generated routes** (PDP/PLP/department auto-routes) — owned by the Store Framework Multi-bindings work referenced in the PRD.
+- Image and video sub-sitemaps.
+- Gzip compression of sitemap files.
+- Changes to the FastStore Next.js project (`next-sitemap` removal, rewrites cleanup, etc.) — only the IO-side API changes.
+- A new admin UI inside the IO app for sitemap content (configuration continues to live in the CMS and in the existing settings schema).
+- Migration tooling for stores currently using the `next-sitemap` workaround.
+- Reading **non-production** Content Platform data (drafts / preview content / Control Plane reads — sitemaps are for production crawlers; the Data Plane API used here only exposes production data anyway).
+- Adding new fields to the Content Platform schema — opt-out relies on the existing `seo.canonical` field per [Decision 10](#decision-10-content-platform-opt-out-via-seo-canonical). A dedicated `includeInSitemap` toggle is not pursued; if the CMS team adds `seo.noindex` natively in the future, the middleware can layer that on without a schema change.
+- **Parallel ingestion of both VTEX CMSs** in the same generation. The two sources are mutually exclusive per [Decision 8](#decision-8-mutual-exclusivity-between-hcms-legacy-and-content-platform); side-by-side coverage during long migrations is explicitly deferred.
+- Content migration between hCMS and the Content Platform — handled by the CMS team's upgrade flow described in the [announcement](https://help.vtex.com/announcements/2026-03-30-headless-cms-stores-will-be-upgraded-to-the-new-vtex-cms).
+
+---
+
+## 2. Arch Decisions
+
+### Proposed Solution
+
+Extend the existing `vtex.store-sitemap` IO app to treat **CMS-published routes as a first-class route source**, alongside the current product, navigation and apps sources. Concretely:
+
+1. **hCMS source layer** — Add a `generateCmsRoutes` middleware (sibling to `generateRewriterRoutes`/`generateAppsRoutes`/`generateProductRoutes`) that fetches CMS-origin Rewriter Internals and stores them in a dedicated VBase bucket using the existing `SitemapEntry`/`SitemapIndex` shape. CMS pages already flow through Rewriter today (the same mechanism that backs `generateRewriterRoutes`), so the change is primarily about **classifying, filtering and enriching** those entries rather than fetching from a new system. If hCMS exposes additional metadata (canonical, noindex, login/error flags, `includeInSitemap` toggle) that Rewriter does not currently carry, those fields are materialized at generation time via a thin hCMS client (see [Decision 3](#decision-3-cms-toggle--persistence-model)).
+2. **Content Platform source layer** — Add a parallel `generateContentPlatformRoutes` middleware that reads from the **VTEX CMS Data Plane REST API** via a new `cmsDataPlane` client. The middleware: (a) reads the **settings-driven allowlist** `contentPlatformContentTypes` (default `["landingPage", "home"]`) — see [Decision 9](#decision-9-routable-type-discovery--settings-allowlist-with-future-graphql-discovery); (b) for each content type, paginates `listEntries` via the `scroll` cursor (Data Plane is **production-only by API design**, so there is no branch parameter — see [Decision 7](#decision-7-content-platform-data-plane-as-a-parallel-source)); (c) fans out per (entry, binding-locale) `getEntry` calls, treating `404 Not Found` as "locale not published" (silent skip); (d) honours `seo.canonical` opt-out, see [Decision 10](#decision-10-content-platform-opt-out-via-seo-canonical); (e) writes a dedicated `content-platform-routes_*` VBase bucket using the same `SitemapEntry` shape as hCMS. ETag (`If-None-Match`) caching is persisted in a separate `content-platform-data-cache` VBase bucket keyed by `(contentType, entryId, locale)` so steady-state regenerations collapse to ΔN re-serializations.
+3. **Source selection** — The two CMS sources are **mutually exclusive per generation** (see [Decision 8](#decision-8-mutual-exclusivity-between-hcms-legacy-and-content-platform)). When both flags are `true`, Content Platform wins; the hCMS middleware is skipped and a structured log is emitted. From the bucket-write step downstream, the served XML, `<sitemapindex>` composition, multi-locale `xhtml:link` emission, chunking, and `robots.txt` directive are **shared** between the two source paths — only the upstream ingestion differs.
+4. **Entry shape** — Reuse the `URLEntry` builder in `sitemapEntry.ts` and extend it to emit `<changefreq>`, `<priority>` and a full `xhtml:link` alternate set including `x-default`. Today only a partial alternate set is emitted (and only when the binding differs from the current one).
+5. **Index layer** — Use the existing `<sitemapindex>` composition (`sitemap.ts`) to glue the active CMS source's index (either `cms-routes` or `content-platform-routes`) into the served `/sitemap.xml`. The 50k / 50 MB chunking rule replaces the current per-entity `5k` limit for CMS entries.
+6. **Public endpoint** — Augment the `customRoutes` middleware response with a `cms-routes` OR `content-platform-routes` section (whichever is active). The shape is **additive** (new entry in the existing array), preserving backwards compatibility.
+7. **`robots.txt`** — Add a single `Sitemap:` directive at the end of the served `robots.txt` (or merge into existing per-binding overrides). Avoid duplicates when the merchant already added one. This path is independent of the active CMS source.
+
+The current cache (1 day fresh / 23 h lock) and stale-while-revalidate semantics documented in [`docs/CUSTOM_ROUTES_ARCHITECTURE.md`](../docs/CUSTOM_ROUTES_ARCHITECTURE.md) are reused as-is for both sources.
+
+### Architecture Overview
+
+```mermaid
+flowchart LR
+    subgraph hCMS[VTEX Headless CMS - legacy]
+      direction TB
+      CmsPage[hCMS Page<br/>slug, locale, includeInSitemap,<br/>noindex, canonical, type]
+    end
+
+    subgraph Rewriter[VTEX Rewriter]
+      InternalRoute[Internal route<br/>from, type, binding,<br/>disableSitemapEntry,<br/>endDate, imagePath]
+    end
+
+    subgraph CP[VTEX CMS - Content Platform]
+      direction TB
+      CpEntry[CP Entry<br/>contentType, entryId,<br/>seo.slug, seo.canonical,<br/>locale_metadata]
+      CpDataPlane[Data Plane REST API<br/>read-only, ETag, CQRS]
+      CpEntry --> CpDataPlane
+    end
+
+    CmsPage -->|published| InternalRoute
+
+    subgraph App[vtex.store-sitemap IO app]
+      direction TB
+      Flag{enableContentPlatformRoutes?<br/>Decision 8 - mutex}
+      GenCms[generateCmsRoutes<br/>middleware - hCMS path]
+      GenCp[generateContentPlatformRoutes<br/>middleware - new]
+      GenProd[generateProductRoutes]
+      GenNav[generateRewriterRoutes]
+      GenApps[generateAppsRoutes]
+      GroupEntries[groupEntries<br/>chunks 50k/50MB]
+      VBase[(VBase<br/>cms-routes OR<br/>content-platform-routes<br/>+ existing buckets)]
+      SitemapMW[sitemap middleware<br/>builds sitemap.xml]
+      EntryMW[sitemapEntry middleware<br/>builds /sitemap/*.xml]
+      RobotsMW[robots middleware]
+      CustomRoutesMW[customRoutes middleware<br/>/_v/public/sitemap/custom-routes]
+    end
+
+    InternalRoute --> Flag
+    CpDataPlane --> Flag
+    Flag -->|false| GenCms
+    Flag -->|true| GenCp
+    GenCms --> GroupEntries
+    GenCp --> GroupEntries
+    GenProd --> GroupEntries
+    GenNav --> GroupEntries
+    GenApps --> GroupEntries
+    GroupEntries --> VBase
+
+    VBase --> SitemapMW
+    VBase --> EntryMW
+    VBase --> CustomRoutesMW
+
+    subgraph FastStore[FastStore storefront]
+      Browser[Search engines / Browsers]
+    end
+
+    Browser -->|GET /sitemap.xml| SitemapMW
+    Browser -->|GET /sitemap/*.xml| EntryMW
+    Browser -->|GET /robots.txt| RobotsMW
+    FastStore -->|GET /_v/public/sitemap/custom-routes| CustomRoutesMW
+```
+
+### Alternatives Considered
+
+| Alternative | Pros | Cons | Verdict |
+|---|---|---|---|
+| **Generate sitemap entirely client-side in FastStore (via `next-sitemap`)** | No IO changes; lives next to the storefront codebase | Reproduces today's manual workaround; requires storefront developers per change; can't easily incorporate Rewriter/Apps routes; no central caching | Rejected — recreates the original problem |
+| **Standalone microservice for FastStore sitemap** | Clean separation; can be optimized for FastStore | Re-implements infrastructure already present here (VBase caching, locking, Rewriter integration, multi-binding, robots); fragments the contract | Rejected — duplication and ops cost |
+| **Extend `vtex.store-sitemap` (this proposal)** | Reuses caching, locking, multi-binding logic, `customRoutes` endpoint, robots; already serves IO traffic for FastStore stores | Couples FastStore evolution to an IO app currently shared with Store Framework | **Accepted** — lowest risk, highest reuse |
+| **Source CMS directly via hCMS API (bypass Rewriter)** | Single source of truth for CMS metadata (`noindex`, canonical, toggle) | Bypasses Rewriter's existing publish/translate/multi-binding plumbing; duplicates URL resolution logic | Partially accepted — Rewriter is the primary source for hCMS; hCMS API is queried only for metadata fields Rewriter does not carry (see [Decision 3](#decision-3-cms-toggle--persistence-model)) |
+| **Force Content Platform to publish into Rewriter so we reuse `generateCmsRoutes` 1:1** | Zero new code in this app; reuses existing pipeline as-is | Forces the new CMS to mirror content into Rewriter Internals — the whole architectural shift of Content Platform is to avoid that monolithic dependency; not on the CMS team's roadmap | Rejected — fights the platform direction |
+| **Run hCMS and Content Platform sources in parallel with URL-level dedup** | Smooth transition window for stores mid-migration; no flag-flip cliff | Doubles generation work; ambiguous source-of-truth for the same path; complicates `lastmod` precedence; harder to reason about / log | Rejected for v1 — mutual exclusivity is simpler and predictable (see [Decision 8](#decision-8-mutual-exclusivity-between-hcms-legacy-and-content-platform)); revisit only if real customer demand emerges |
+| **Hardcoded Content Platform content-type allowlist baked into the app source** | Simplest implementation; no settings required; no schema introspection needed | Doesn't accommodate custom content types created by stores (Content Platform actively encourages them); requires an app release every time a customer adds a new routable type | Rejected — settings-driven allowlist (`contentPlatformContentTypes`, see [Decision 9](#decision-9-routable-type-discovery--settings-allowlist-with-future-graphql-discovery)) keeps the operator workflow self-service without an app release. Fully automatic discovery via `vtex.admin-cms-graphql` is a follow-up, deferred because the Data Plane itself has no schema-listing endpoint. |
+
+### Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|---|---|---|---|
+| Sitemap explosion (CMS adds tens of thousands of pages) | Medium | Medium | Reuse `groupEntries`-style chunking with 50k/50 MB limits; emit metrics on counts; document a cap warning |
+| Rewriter pagination timeouts during generation | High | Low–Medium | Already mitigated by `listInternalsWithRetry`; extend retry to the CMS-metadata fetch path and keep fallback to previous successful VBase entry |
+| Duplicate URLs between CMS and auto-generated sources | Medium | Medium | Deduplicate by canonical URL during `groupEntries`; CMS metadata wins ties (see [Decision 4](#decision-4-deduplication-and-precedence)) |
+| Backwards-incompatible change to `customRoutes` response | High | Low | Add `cms-routes` / `content-platform-routes` as **new** entries in the existing array; do not modify shape of existing entries |
+| Multi-locale alternate explosion (Cartesian growth with locales × URLs) | Medium | Low–Medium | Cap alternate-set generation to declared store locales (not arbitrary CMS locales); skip alternates for single-locale stores |
+| `disableRoutesTerm` interaction (existing substring exclude) | Low | Low | Apply the existing `disableRoutesTerm` to both CMS sources, for consistency with `generateRewriterRoutes` |
+| `robots.txt` duplicate Sitemap entries | Low | Medium | Detect existing `Sitemap:` directives in custom robots (per-binding) before appending |
+| Content Platform routable-type drift (a store adds a new custom content type but forgets to update the setting) | Medium | Medium | Document the `contentPlatformContentTypes` setting prominently in `docs/CMS_ROUTES.md` and surface it in the admin UI label; planned follow-up: auto-populate via `vtex.admin-cms-graphql` (see [Decision 9](#decision-9-routable-type-discovery--settings-allowlist-with-future-graphql-discovery)) |
+| Content Platform non-production reads (a future API version exposes a branch parameter and someone wires it up) | Medium | Low | The current Data Plane REST contract has no branch parameter — production-only is structural, not configurable (see [Decision 7](#decision-7-content-platform-data-plane-as-a-parallel-source)). If a future API version exposes branch, gating the parameter behind an explicit setting (defaulting to production) keeps the invariant. |
+| Both flags set after a botched config rollout | Low | Medium | Mutual exclusivity is enforced server-side, not in UI; behavior is deterministic and logged ([FR-10](#fr-10--source-mutual-exclusivity)) |
+| Content Platform locale fallback misinterpretation (emitting a URL under `pt-BR` when only `en-US` is published) | Medium | Medium | Treat the Data Plane response per-locale verbatim; do not synthesize fallback URLs from the storefront's runtime fallback rules ([Decision 11](#decision-11-locale-emission-for-content-platform)) |
+| Content Platform Data Plane outage during a long migration window | High | Low | ETag short-circuits mean most reads are cheap; on persistent 5xx, keep previous successful VBase entries (no regression to empty); emit `content-platform-routes-generation-error` log |
+| Operator confusion about which source is active | Low | Medium | `/_v/public/sitemap/custom-routes` response makes the active source self-describing (`cms-routes` vs. `content-platform-routes`); per-generation logs name the active source explicitly |
+
+### Key Decisions
+
+#### Decision 1: New route source plugged into the existing pipeline (vs. a parallel sitemap pipeline)
+
+- **Status**: Accepted
+- **Context**: We need to add CMS pages to the sitemap. We could either add a new source to the existing pipeline (`generateProductRoutes`, `generateRewriterRoutes`, `generateAppsRoutes`) or build a separate "FastStore sitemap" pipeline.
+- **Decision**: Add a new source — `generateCmsRoutes` — to the existing pipeline. It writes a dedicated VBase bucket using the established `SitemapEntry` / `SitemapIndex` shape, and is composed into `/sitemap.xml` via the same `<sitemapindex>` logic.
+- **Consequences**: Maximum reuse of caching, locking, multi-binding handling, observability and security policies. The trade-off is that FastStore-specific behavior must coexist with Store Framework behavior in the same code; we manage this via clear file boundaries and feature flags in the settings schema.
+
+#### Decision 2: Reuse the `<sitemapindex>` chunking model for the 50k / 50 MB limit
+
+- **Status**: Accepted
+- **Context**: Today, sitemap entries are split per entity type with a per-file limit of 5,000 routes (see README). Google allows up to 50,000 URLs or 50 MB per file. We need to honor that explicitly.
+- **Decision**: Continue producing one file per entity bucket, but raise the per-file budget to Google's protocol limit (50,000 URLs **or** 50 MB serialized, whichever is hit first). The `groupEntries` step splits oversized buckets into numbered files (`cms-routes-1.xml`, `cms-routes-2.xml`, …) and references all of them from the top-level index.
+- **Consequences**: Fewer HTTP round-trips for crawlers; bigger XML payloads per file. Existing 5k-per-file behavior for product/navigation/apps may need to be revisited for consistency, but that's outside this spec.
+
+#### Decision 3: CMS toggle — persistence model
+
+- **Status**: Accepted
+- **Context**: The merchant-visible "Include in sitemap" toggle (default `true`) must be readable by the generator. Today, Rewriter `Internal` already carries `disableSitemapEntry`, populated for legacy Store Framework routes. Surfacing the toggle in the CMS UI and the additional metadata fields (`noindex`, canonical, login/error classification) requires a coordinated change in the hCMS team's surface.
+- **Decision**: Reuse `disableSitemapEntry` as the **wire** for the toggle. The CMS UI writes to Rewriter (the existing CMS-publish path) and sets `disableSitemapEntry = !includeInSitemap`. Additional metadata that Rewriter does not yet carry — `noindex`, `canonical` (when pointing to a different URL), explicit `login`/`error` classification — is fetched from hCMS at generation time and joined by Rewriter `id`. The hCMS UI change and the metadata endpoint contract are tracked as **dependencies on the hCMS team** but do not gate the start of P1; the generator ships defensively (treats missing metadata as "not excluded" and `includeInSitemap = true`) until those fields land.
+- **Consequences**: Avoids a new column/index in Rewriter for FastStore-specific data; keeps the generator's primary loop dependent on Rewriter only. The metadata join introduces a per-page hCMS read during generation — mitigated by batching and the daily generation cadence. Carries a cross-team dependency that must be tracked alongside this spec (separate Jira link to be added once the hCMS counterpart ticket is filed).
+
+#### Decision 4: Deduplication and precedence
+
+- **Status**: Accepted
+- **Context**: A CMS-defined PLP and an auto-generated category page may resolve to the same URL.
+- **Decision**: After all sources produce their entries, `groupEntries` deduplicates by **final URL** (taking the binding/locale into account). When a duplicate is found, the CMS-origin entry wins (its `lastmod`, toggle and metadata are used) because it represents an explicit editorial choice.
+- **Consequences**: Predictable behavior; no double-listing in Google. CMS authors can override auto-routes by republishing through the CMS.
+
+#### Decision 5: Multi-locale shape (hreflang + x-default)
+
+- **Status**: Accepted
+- **Context**: The existing `URLEntry` emits `<xhtml:link>` only for alternates that belong to a **different** binding than the current one, and never emits `x-default`. The ticket requires the full set including self and `x-default`.
+- **Decision**: Update `URLEntry` so that, when more than one matching binding has the same `targetProduct` (i.e., a multi-locale store), it emits **one `<xhtml:link>` per locale including self** and one `hreflang="x-default"` pointing to the default binding's canonical URL.
+- **Consequences**: Slightly larger XML per entry, but aligned with [Google's recommendation](https://developers.google.com/search/docs/specialty/international/localized-versions#example_2). Single-locale stores emit zero alternates (behavior preserved).
+
+#### Decision 6: `robots.txt` Sitemap directive
+
+- **Status**: Accepted
+- **Context**: The current `robots` middleware serves robots content from an app's `build.json` (per binding) and falls back to a legacy source. It does not guarantee a `Sitemap:` directive.
+- **Decision**: The `robots` middleware appends `Sitemap: https://{host}/sitemap.xml` to the served body if one is not already present. The check is case-insensitive and stripped of trailing whitespace.
+- **Consequences**: Merchants who already declared their sitemap manually are unaffected; everyone else gets it for free. No new VBase write.
+
+#### Decision 7: Content Platform Data Plane as a parallel source
+
+- **Status**: Accepted (revised after the real API contract was reverse-engineered from `@vtex/client-cp` and a smoke test on `pm2023team2`)
+- **Context**: The new VTEX CMS (Content Platform) does NOT persist pages in Rewriter Internals. Its CQRS architecture exposes a dedicated read-only **Data Plane REST API** that is the platform-blessed path for read workloads, with native ETag caching and multi-language. Reading via Rewriter would force the CMS team to mirror content back into Rewriter — opposite of the platform's direction.
+- **Decision**: Add a parallel `generateContentPlatformRoutes` middleware that reads from the Content Platform's Data Plane REST API via a new `cmsDataPlane` client. The Data Plane is **production-only by design** — there is no branch parameter; preview / draft reads happen on a separate Control Plane that the sitemap never queries. The client targets `https://{account}.vtexcommercestable.com.br/api/content-platform/data/{accountName}/{storeId}/{contentType}/...`, sends `If-None-Match` based on prior responses (persisted in VBase, see [invariant 13](#invariants--constraints)), and writes per-binding entries into a `content-platform-routes_*` VBase bucket. The downstream pipeline (chunking, XML serialization, `<sitemapindex>`, `xhtml:link`, robots) is shared with the hCMS path; only the source differs.
+- **Consequences**: One additional outbound integration to operate and a new `manifest.json` outbound-access policy for the Data Plane host. Clear separation between legacy and new CMS code paths means either can be removed cleanly once migration completes (timeline owned by the CMS team). ETag caching against a VBase-backed `content-platform-data-cache` bucket is expected to make the Content Platform path cheaper than the hCMS path at steady state — only entries the editor actually touched re-serialize through the network. The "production-only" property is structural, not configurable: there is no flag to read non-production data.
+
+#### Decision 8: Mutual exclusivity between hCMS legacy and Content Platform
+
+- **Status**: Accepted
+- **Context**: A store is expected to use exactly one VTEX CMS surface at a time during the upgrade window. Running both sources simultaneously would (a) double the generation work for no real benefit during a migration, (b) emit duplicate `<url>` entries when the same path exists in both surfaces, and (c) require ambiguous tie-breaking for `lastmod` and SEO metadata.
+- **Decision**: At most one of `enableCmsRoutes` / `enableContentPlatformRoutes` may take effect per generation. When both are `true`, **Content Platform wins** (it is the platform's forward direction), hCMS ingestion is skipped, and a one-shot structured log `cms-routes-ignored-by-mutual-exclusivity` is emitted per generation cycle. Stale `cms-routes-*.xml` artifacts from a previous run are NOT re-served (the `<sitemapindex>` excludes them) but are not eagerly purged from VBase — they're naturally cleaned up by being overwritten if the operator flips back to hCMS.
+- **Consequences**: Predictable, simple operator mental model: "flip flag, regenerate, see results." Trade-off: stores genuinely needing parallel coverage during a long migration window have to wait for a future enhancement (explicitly deferred — see Out of Scope). Easy to lift later if customer demand emerges, by switching the resolution rule from "wins" to "merge with dedup."
+
+#### Decision 9: Routable-type discovery — settings allowlist (with future GraphQL discovery)
+
+- **Status**: Accepted (revised: the Data Plane REST API does **not** expose a schema-listing endpoint. The original plan to auto-discover routable types from a `path` field at runtime is therefore not implementable against the v1 Data Plane and has been replaced by an explicit allowlist, with auto-discovery kept as a follow-up against `vtex.admin-cms-graphql`.)
+- **Context**: Content Platform actively encourages stores to define custom content types beyond the predefined `landingPage` / `home` / `pdp` / `plp` / `search` (e.g., `microsite`, `campaign`, `gift-guide`, `editorial`). The Data Plane's `listEntries` endpoint requires the caller to know the content type up front — there is no `/schemas` listing — so the sitemap generator needs some mechanism to know which types to iterate.
+- **Decision**: Routable content types are taken from the new `contentPlatformContentTypes` setting (string array, default `["landingPage", "home"]`). Adding a custom routable type is a one-line change in the app settings, no code release required. PDP / PLP / search Content Types should not be added — their URLs come from the catalog pipelines (`generateProductRoutes`, `generateRewriterRoutes`); the Content Platform entries for those types are page templates, not addressable URLs. **Future enhancement** (not in this increment): an optional auto-discovery path against the `vtex.admin-cms-graphql` admin GraphQL surface that populates the setting automatically for stores that opt in.
+- **Consequences**: Settings-driven discovery is explicit and inspectable — operators see exactly which types are ingested. Trade-off: adding a custom routable content type now requires an admin touch (flip a setting) instead of being fully automatic. We accept this because (a) the default `["landingPage", "home"]` covers the FastStore baseline, (b) custom routable types are a deliberate authoring decision and editors are likely the same people configuring the app, and (c) the auto-discovery follow-up via admin-cms-graphql removes the manual step once the admin schema is mapped.
+
+#### Decision 10: Content Platform opt-out via SEO canonical
+
+- **Status**: Accepted (revised: the real Content Platform `seo` object exposes `slug`, `title`, `description`, `canonical` and `titleTemplate` — it does **not** carry `noindex` today. The original "noindex OR canonical-mismatch" rule has been narrowed to canonical-only until / unless the CMS team adds `noindex` to the schema.)
+- **Context**: hCMS legacy uses the `disableSitemapEntry` Rewriter flag for per-page sitemap opt-out (Decision 3). Content Platform does not have that flag, and the CMS team is not planning to add one — they consider opt-out to be SEO semantics, not a separate concern. The fields the Data Plane currently exposes per entry are `seo.slug`, `seo.canonical`, `seo.title`, `seo.description` and `seo.titleTemplate`. `seo.canonical` defaults to the empty string `""` ("no override").
+- **Decision**: For the Content Platform source, exclusion from the sitemap is driven by `seo.canonical` only: when `canonical` is a non-empty string AND points to a URL different from the entry's own `seo.slug`, the entry is excluded. Empty string is treated as "no override" and the entry stays included. **No new schema field is required.** If the CMS team adds `seo.noindex` in the future, the middleware can layer that on without breaking the current contract.
+- **Consequences**: Zero cross-team dependency on the CMS team to ship this feature, aligned with standard SEO semantics (a page whose canonical points elsewhere should not be listed under both URLs in sitemaps). Trade-off: operators who want a single page hidden from the sitemap have one mechanism today — set the page's `seo.canonical` to another URL (which also tells Google to credit the other URL). This matches the platform's current SEO model. The historical "noindex" leg of this rule is documented here for traceability but is **not implemented** against the current Content Platform contract.
+
+#### Decision 11: Locale emission for Content Platform
+
+- **Status**: Accepted (revised: implementation drives locale from the **binding** side via per-locale `getEntry` calls — the Data Plane's listing payload does not carry locale information.)
+- **Context**: Content Platform has native multi-language with **runtime fallback rules** (e.g., when `pt-BR` is missing, serve `en-US` content under the `pt-BR` URL). Reflecting runtime fallbacks in the sitemap would emit a `pt-BR` URL whose response is actually `en-US` content — confusing/duplicate from a crawler's point of view and not a real localized resource. The Data Plane's `listEntries` payload returns only `{id, name, updatedAt, search_keywords}` — SEO and locale fields live on the per-entry `getEntry` response, scoped to the locale passed via `?locale=`.
+- **Decision**: For every (entry, binding) pair, call `getEntry({entryId, locale: binding.defaultLocale})`. A `200 OK` produces a `{bindingId, path: seo.slug}` candidate; a `404 Not Found` is treated as "the editor did not publish this locale" and the binding is silently skipped (no synthesized alternate). The `xhtml:link` alternate set is then built from the actually-200-ing locales plus `hreflang="x-default"`.
+- **Consequences**: Aligned with Decision 5 (multi-locale shape) and Google's hreflang guidance. Crawler sees the real published surface. The fan-out is structural (N entries × M bindings); the ETag cache from [invariant 13](#invariants--constraints) collapses it on subsequent runs to roughly N+ΔM calls (only entries the editor touched). Trade-off: locales served by runtime fallback do not get explicit URLs in the sitemap — search engines still reach them via the canonical locale URL and the `hreflang="x-default"` link.
+
+### Implementation Plan
+
+Phased rollout, each phase independently shippable behind the existing settings schema or new boolean flag (`enableCmsRoutes`, `enableContentPlatformRoutes`, both default `false` until validated):
+
+**hCMS legacy track (shipped):**
+
+| Phase | Scope | Outcome |
+|---|---|---|
+| **P1 — Foundation** | New `generateCmsRoutes` middleware + VBase bucket; classification (`type === 'cms'` or equivalent); reuse the existing `customRoutes` lock/cache. Add `enableCmsRoutes` setting to `manifest.json`. | CMS routes can be generated and inspected via VBase; no impact on served XML yet. |
+| **P2 — Public exposure** | Glue `cms-routes` into the served `<sitemapindex>` and expose them in `/_v/public/sitemap/custom-routes`. | FastStore can consume the new section; sitemap reflects CMS pages for opt-in stores. |
+| **P3 — Protocol completeness** | Extend `URLEntry` with `<changefreq>`, `<priority>`, full `xhtml:link` set including `x-default`. Raise per-file limit to 50k/50 MB and apply chunking. | Sitemap is spec-compliant per Google protocol. |
+| **P4 — `robots.txt` directive + exclusions** | Append `Sitemap:` to robots if missing; honor hCMS metadata for `noindex`, canonical-mismatch, login/error classification. | Mandatory exclusions enforced; SEO operators get robots-integrated discovery. |
+| **P5 — Rollout** | Enable `enableCmsRoutes` by default; coordinate with FastStore docs and customer success for Hearst, ODP, JW Pepper and Americanas migration paths. | Replace `next-sitemap` workarounds in customer projects. |
+
+**Content Platform increment (planned):**
+
+| Phase | Scope | Outcome |
+|---|---|---|
+| **P6 — Content Platform foundation** | New `cmsDataPlane` client targeting `{account}.vtexcommercestable.com.br/api/content-platform/data/*` (production-only by API design, `If-None-Match`, retries on 5xx, 404-as-skip). New `generateContentPlatformRoutes` middleware. New settings in `manifest.json`: `enableContentPlatformRoutes` (boolean, default `false`), `contentPlatformStoreId` (string, default `"faststore"`), `contentPlatformContentTypes` (string[], default `["landingPage","home"]`). Per-binding VBase entries written to `content-platform-routes_*` bucket. Outbound-access policy added for the Data Plane host. Mutual exclusivity logic in source selection. | Content Platform routes can be generated and inspected via VBase for opt-in stores; mutual exclusivity is enforced; no impact on served XML yet. |
+| **P7 — Multi-locale + ETag persistence** | Multi-locale fan-out — per (entry, binding) `getEntry({locale})` call, 404 → silent skip, alternates built from 200-ing locales only. VBase-backed ETag cache (`content-platform-data-cache` bucket) keyed by `(contentType, entryId, locale)`. On `304 Not Modified` the cached entry is reused verbatim; on `200 OK` the new ETag+entry are persisted; on `404 Not Found` the binding is skipped. | Steady-state regenerations collapse to ΔN re-serializations (only entries touched by editors); multi-binding stores get full per-locale URL coverage with correct hreflang alternates. |
+| **P8 — Content Platform public exposure** | Glue `content-platform-routes` into the served `<sitemapindex>` (replacing `cms-routes` when its flag wins). Expose `{ name: 'content-platform-routes', routes: [...] }` in `/_v/public/sitemap/custom-routes`. Wire `URLEntry` shared path (already extended in P3) and `robots.txt` directive (already shared from P4). Honor `seo.canonical` opt-out per Decision 10. | FastStore v3 stores on the new CMS get full sitemap coverage with no XML/contract changes. |
+| **P9 — Migration enablement + rollout** | Add a "Migrating from hCMS to Content Platform" section in `docs/CMS_ROUTES.md`. Coordinate ops playbook for the flag flip with CMS / Customer Success teams. Track and report on customers being progressively upgraded by the CMS team from Mar 30, 2026. Follow-up: optional auto-discovery of routable content types via `vtex.admin-cms-graphql` (Decision 9 follow-up). | Customers on the new CMS stop losing sitemap coverage during the migration; opt-in becomes the recommended default for v3 stores. |
+
+A minor-version bump (e.g., `2.19.0`) on P2 and `2.20.0` on P7. A major-version bump only if a backwards-incompatible change is unavoidable (none are currently anticipated — both the hCMS and Content Platform additions are additive to the `customRoutes` response and add new sub-sitemap files without changing existing ones).
+
+---
+
+## 3. Technical Contract
+
+### Data Models
+
+**hCMS route (internal, generator-side)**
+
+```ts
+interface CmsRouteEntry {
+  id: string                       // Rewriter Internal id (stable per hCMS page)
+  path: string                     // e.g. "/about", "/black-friday"
+  bindingId: string                // matches Binding.id
+  locale: string                   // e.g. "en-US"; derived from binding.defaultLocale
+  lastmod: string                  // ISO timestamp, UTC
+  changefreq?: ChangeFreq          // see below
+  priority?: number                // 0.0 – 1.0, two decimals
+  includeInSitemap: boolean        // ! Internal.disableSitemapEntry
+  noindex: boolean                 // from hCMS metadata
+  canonical?: string               // from hCMS; when present and != path, route is excluded
+  classification: 'pdp' | 'plp' | 'landing' | 'cms-custom' | 'login' | 'error' | 'other'
+  imagePath?: string
+  imageTitle?: string
+}
+
+type ChangeFreq =
+  | 'always' | 'hourly' | 'daily' | 'weekly'
+  | 'monthly' | 'yearly' | 'never'
+```
+
+**Content Platform route (internal, generator-side)**
+
+```ts
+interface ContentPlatformRouteEntry {
+  id: string                       // Content Platform entry id (stable per page across locales)
+  contentType: string              // e.g. "landingPage", "home", "microsite" — one of contentPlatformContentTypes
+  path: string                     // entry.seo.slug for the locale (the actual public URL)
+  bindingId: string                // matches Binding.id (one route per binding-locale that returned 200)
+  locale: string                   // binding.defaultLocale used in the getEntry call
+  lastmod: string                  // ISO timestamp from the listing-level entry.updatedAt
+  etag?: string                    // ETag persisted in VBase for the next If-None-Match
+  canonical?: string               // entry.seo.canonical; when non-empty AND != path, entry is excluded
+  changefreq?: ChangeFreq          // default 'weekly'
+  priority?: number                // default 0.5
+}
+```
+
+The Data Plane is **production-only by design** — there is no branch parameter on the API surface and no preview path through this client (see [Decision 7](#decision-7-content-platform-data-plane-as-a-parallel-source)). `noindex` and `loginOrErrorPage` are not part of the current Content Platform schema and are therefore absent from this model; see [Decision 10](#decision-10-content-platform-opt-out-via-seo-canonical) for the opt-out rule actually applied.
+
+**Sitemap entry (persisted in VBase, reuses existing `SitemapEntry`)**
+
+```ts
+interface SitemapEntry {
+  lastUpdated: string
+  routes: Route[]   // existing global Route type; extended below
+}
+
+interface Route {
+  id: string
+  path: string
+  alternates?: AlternateRoute[]
+  imagePath?: string
+  imageTitle?: string
+  // NEW (additive)
+  changefreq?: ChangeFreq
+  priority?: number
+  lastmod?: string  // overrides SitemapEntry.lastUpdated when set
+  source?: 'hcms' | 'content-platform' | 'apps' | 'user'  // for observability/dedup
+}
+```
+
+**Public `customRoutes` response (additive)**
+
+```ts
+type CustomRoutesResponse = Array<
+  | { name: 'apps-routes'; routes: string[] }
+  | { name: 'user-routes'; routes: string[] }
+  | { name: 'cms-routes'; routes: string[] }                // hCMS legacy source (when enableCmsRoutes wins)
+  | { name: 'content-platform-routes'; routes: string[] }   // NEW — Content Platform source (when its flag wins)
+>
+// Invariant per Decision 8: at most ONE of `cms-routes` / `content-platform-routes` is present per response.
+```
+
+**App settings (`manifest.json`)**
+
+```ts
+interface SitemapSettings {
+  // existing
+  enableCmsRoutes?: boolean                  // hCMS legacy, default false
+  // NEW (Content Platform)
+  enableContentPlatformRoutes?: boolean      // Content Platform, default false
+  contentPlatformStoreId?: string            // FastStore {storeId} path segment, default "faststore"
+  contentPlatformContentTypes?: string[]     // routable content type allowlist, default ["landingPage","home"]
+  // see Decision 8: when both `enable*` flags are true, enableContentPlatformRoutes wins
+  // see Decision 9: contentPlatformContentTypes is the source of truth for routable types
+  // ...other existing settings (disableRoutesTerm, etc.) unchanged
+}
+```
+
+### Interfaces
+
+**HTTP — served by this app**
+
+| Method | Path | Behavior change |
+|---|---|---|
+| `GET` | `/sitemap.xml` | Now includes **either** `cms-routes-*.xml` (when `enableCmsRoutes` wins) **or** `content-platform-routes-*.xml` (when `enableContentPlatformRoutes` wins) entries in the top-level `<sitemapindex>`, per the mutual-exclusivity rule of [Decision 8](#decision-8-mutual-exclusivity-between-hcms-legacy-and-content-platform). Each sub-sitemap respects the 50k/50 MB limit. |
+| `GET` | `/sitemap/cms-routes-{n}.xml` | **New** sub-sitemap files for hCMS-sourced routes. Each `<url>` carries `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>` and (multi-locale only) the full `xhtml:link` set including `hreflang="x-default"`. Served only when `enableCmsRoutes` is the winning flag. |
+| `GET` | `/sitemap/content-platform-routes-{n}.xml` | **New** sub-sitemap files for Content Platform-sourced routes. Same tag shape as `cms-routes-{n}.xml`. Served only when `enableContentPlatformRoutes` is the winning flag. |
+| `GET` | `/sitemap/*.xml` | Existing sub-sitemaps gain `<changefreq>` and `<priority>` tags and the extended `xhtml:link` set when the store is multi-locale. |
+| `GET` | `/robots.txt` | Adds `Sitemap: https://{host}/sitemap.xml` at the end if not already present. Independent of which CMS source is active. |
+| `GET` | `/_v/public/sitemap/custom-routes` | Response array additionally contains **either** `{ name: 'cms-routes', routes: string[] }` **or** `{ name: 'content-platform-routes', routes: string[] }` depending on the active source (mutually exclusive — at most one is present per response). Stores with neither flag enabled get the legacy 2-entry response (`apps-routes` + `user-routes`). |
+
+**Module boundaries — internal**
+
+| Module | Responsibility |
+|---|---|
+| `node/middlewares/generateMiddlewares/generateCmsRoutes.ts` | Pull hCMS-origin Rewriter Internals, join with hCMS metadata, write per-binding `SitemapEntry` files into a `cms-routes_*` bucket via `getBucket('cms-routes', hashString(binding.id))`. **Skipped at runtime** when `enableContentPlatformRoutes` is true ([FR-10](#fr-10--source-mutual-exclusivity)). |
+| `node/middlewares/generateMiddlewares/generateContentPlatformRoutes.ts` (new) | For each content type in `contentPlatformContentTypes`, paginate `listEntries` via the `scroll` cursor, then fan out per (entry, binding-locale) `getEntry` calls. ETag-cached via `services/contentPlatformCache.ts`. Apply `seo.canonical` opt-out per [Decision 10](#decision-10-content-platform-opt-out-via-seo-canonical) and `disableRoutesTerm` substring filter. Group routes by entry id to build the `alternates` array. Write per-binding `SitemapEntry` files into a `content-platform-routes_*` bucket via `getBucket('content-platform-routes', hashString(binding.id))`. |
+| `node/clients/cmsDataPlane.ts` (new) | Typed client for the VTEX Content Platform Data Plane REST API at `https://{account}.vtexcommercestable.com.br/api/content-platform/data/*`. Three primitives: `listEntries` (cursor-based via `scroll`), `getEntry`, `getEntryBySlug`. Sends `If-None-Match`, treats `304 Not Modified` as `{notModified: true}` (cache hit) and `404 Not Found` as `{notFound: true}` (locale unpublished — silent skip). Retries 5xx with bounded backoff; surfaces structured `content-platform-routes-generation-error` logs on persistent failure. |
+| `node/services/contentPlatformCache.ts` (new) | VBase-backed ETag cache. Bucket `content-platform-data-cache`, one file per `(contentType, entryId, locale)` triple (base64url-safe filename). Exposes `readCachedEntry` / `writeCachedEntry`; consumed exclusively by `generateContentPlatformRoutes`. |
+| `node/services/routes.ts` | Add `getCmsRoutes(ctx)` and `getContentPlatformRoutes(ctx)` analogous to `getUserRoutes` / `getAppsRoutes` for use by `generateCustomRoutes` and `customRoutes`. The active-source resolver (`resolveActiveCmsSource(settings) → 'hcms' \| 'content-platform' \| 'none'`) lives here and is shared by every consumer. |
+| `node/middlewares/sitemap.ts` | Read the **active** CMS source's index file (`cms-routes` OR `content-platform-routes`) from VBase and append to the `<sitemapindex>`. Stale files from the inactive source are not referenced. |
+| `node/middlewares/sitemapEntry.ts` | Extend `URLEntry` with `<changefreq>`, `<priority>`, full alternate set + `x-default`. Path is shared by both CMS sources. |
+| `node/middlewares/robots.ts` | Ensure the served body contains a `Sitemap:` directive; idempotent append. Independent of CMS source. |
+| `node/middlewares/customRoutes.ts` | Add `cms-routes` OR `content-platform-routes` to the cached payload, based on the active source (uses `resolveActiveCmsSource`). |
+| `node/clients/hcms.ts` (new, if needed per [Decision 3](#decision-3-cms-toggle--persistence-model)) | Read hCMS metadata (`noindex`, canonical, `includeInSitemap`, classification) for a batch of page ids. |
+| `manifest.json` settings schema | New booleans `enableCmsRoutes` (default `false`, flipped to `true` in P5) and `enableContentPlatformRoutes` (default `false`, flipped to `true` in P8 for upgraded v3 stores). New `outbound-access` policy for the VTEX CMS Data Plane host. |
+
+### Integration Points
+
+- **VTEX Rewriter** (`vtex.rewriter`) — primary source of routes for the hCMS legacy path. Already consumed via `listInternalsWithRetry`. CMS pages are filtered by `type` (CMS-classified) and by `binding`.
+- **VTEX hCMS** — secondary source for per-page metadata not currently surfaced by Rewriter Internal. Accessed via the relevant CMS GraphQL/REST endpoints (exact host depends on hCMS API, to be confirmed during P1). New `outbound-access` policy may be required in `manifest.json` if not already covered.
+- **VTEX CMS Data Plane (Content Platform)** — **new** read-only REST integration backing `generateContentPlatformRoutes`. Host `https://{account}.vtexcommercestable.com.br`, base path `/api/content-platform/data/{accountName}/{storeId}/{contentType}`. Used to (a) paginate the listing of published entries per type via the `scroll` cursor, (b) read full SEO + locale data per (entry, locale) via `getEntry`. ETag-based caching via `If-None-Match` (cache persisted in the VBase `content-platform-data-cache` bucket). The corresponding `outbound-access` policy in `manifest.json` targets `{{account}}.vtexcommercestable.com.br /api/content-platform/data/*`.
+- **Tenant API** (`@vtex/api` `TenantClient`) — already used for binding/locale discovery. No changes.
+- **VBase** — already used. New bucket prefixes `cms-routes` and `content-platform-routes`, each keyed per binding; existing buckets unchanged.
+- **`@vtex/api` Logger / Metrics** — emit `cms-routes-generation-*` event types analogous to existing `custom-routes-*`; **new** `content-platform-routes-generation-*` events (`-start`, `-success`, `-error`), `content-platform-entry-hydration-failed` for soft per-entry skips, and `cms-routes-ignored-by-mutual-exclusivity` for the mutual-exclusivity guard. (The earlier `content-platform-new-routable-type` event was tied to the schema-driven discovery model and is **no longer emitted** under the settings-driven allowlist of [Decision 9](#decision-9-routable-type-discovery--settings-allowlist-with-future-graphql-discovery); it will return when the admin-cms-graphql auto-discovery follow-up ships.)
+- **FastStore storefront** — consumes `/sitemap.xml` and `/_v/public/sitemap/custom-routes`; no contract break. Same code on the storefront side works regardless of whether the store is on hCMS or Content Platform.
+
+### Invariants & Constraints
+
+1. **No empty sitemap regression**: if a regeneration fails, `/sitemap.xml` continues to serve the most recent successful version from VBase. This applies independently to both CMS source paths.
+2. **Per-file budget**: each sub-sitemap is at most **50,000 URLs** AND at most **50 MB** uncompressed. Exceeding either triggers a new file.
+3. **`includeInSitemap` precedence (hCMS)**: a route with `includeInSitemap = false` (from hCMS) or `disableSitemapEntry = true` (from Rewriter) MUST NOT appear in any served sitemap or in `customRoutes`.
+4. **Exclusion superseding**: if any mandatory exclusion applies (`noindex`, canonical-mismatch, login, error classification), the route is excluded **regardless** of the merchant toggle / source (i.e., merchant cannot force-include a `noindex` page from either CMS).
+5. **Locale completeness**: in a multi-locale store, every emitted `<url>` declares alternates for **every store locale where the page exists**, plus `x-default`. Missing locales are silently omitted (not faked). For Content Platform specifically, runtime fallback is NEVER used to synthesize alternates ([Decision 11](#decision-11-locale-emission-for-content-platform)).
+6. **Determinism**: two consecutive successful generations on the same Rewriter+hCMS / Content-Platform-Data-Plane state MUST produce semantically equivalent XML (entry order is not part of the contract, but the set of `<loc>` values is).
+7. **Backwards compatibility**: existing `customRoutes` consumers must continue to work; new entry types are additive. Existing `<url>` entries gain `<changefreq>`/`<priority>` (optional in the protocol) without removing or renaming any tag.
+8. **`robots.txt` idempotency**: the appended `Sitemap:` directive must not duplicate an existing one (case-insensitive match on the URL).
+9. **Settings gating**: when both `enableCmsRoutes` and `enableContentPlatformRoutes` are `false`, the CMS-routes feature behaves as if it did not exist (no extra VBase reads, no extra response keys, no extra XML entries) so that rollout is reversible.
+10. **Single active CMS source**: at most one of `enableCmsRoutes` / `enableContentPlatformRoutes` produces emitted XML per generation; when both are `true`, Content Platform wins and hCMS ingestion is skipped ([Decision 8](#decision-8-mutual-exclusivity-between-hcms-legacy-and-content-platform), [FR-10](#fr-10--source-mutual-exclusivity)). The active source is observable in `/_v/public/sitemap/custom-routes` (the section name) and in structured logs.
+11. **Production-only API (Content Platform)**: the Data Plane has no branch parameter on its REST surface; production is the only data the client can read. Draft / preview / feature reads would have to go through a separate Control Plane that this app never touches, so no non-production content can leak into the served sitemap even transiently.
+12. **Settings-driven routable-type allowlist (Content Platform)**: content types are taken from the `contentPlatformContentTypes` app setting (default `["landingPage","home"]`). PDP / PLP / search Content Types should not be added to that setting — their URLs come from catalog pipelines. Auto-discovery via `vtex.admin-cms-graphql` is a planned follow-up.
+13. **ETag respect (Content Platform)**: ETags are persisted in the VBase `content-platform-data-cache` bucket per `(contentType, entryId, locale)`. On a `304 Not Modified` response the middleware MUST reuse the cached `PublishedEntry` verbatim instead of refetching the SEO payload, and the route emitted into VBase MUST match the previous run's value for that key (i.e., a 304 never changes the `<loc>`).
+14. **No synthetic locales (Content Platform)**: a `<url>` or alternate is emitted only for `(entry, binding)` pairs whose `getEntry({locale})` returned `200 OK`. A `404 Not Found` is treated as "the editor did not publish that locale" and the binding is skipped — runtime locale fallback is not reflected in the sitemap.
+


### PR DESCRIPTION
## Summary

Implements the **Content Platform increment (P6–P9)** of [`specs/cms-routes-in-sitemap-for-faststore.md`](https://github.com/vtex-apps/store-sitemap/blob/master/specs/cms-routes-in-sitemap-for-faststore.md), wiring the new **VTEX CMS (Content Platform) Data Plane REST API** as a parallel route source alongside the existing hCMS/Rewriter integration. Builds on PRs #187 (spec), #188 (hCMS implementation) and #189 (Content Platform spec increment).

> **Note** — the original commits in this branch were written against a hypothetical Data Plane (`{{account}}.myvtex.com/api/cms/data-plane`, schema-driven discovery, `noindex` field, production-branch resolution). Mid-PR we reverse-engineered the real contract against `pm2023team2` and rewired the integration. The current state is described below; older commit messages still reference the original design.

### Real Data Plane contract used

- **Host:** `https://{account}.vtexcommercestable.com.br/api/content-platform/data/*`
- **Production-only by design:** the Data Plane returns only published data; drafts live on the Control Plane and are unreachable from this app — there is no `branch` parameter on the REST surface.
- **No schema-listing endpoint:** routable content types are configured via a new app setting (`contentPlatformContentTypes`) rather than discovered. Auto-discovery via `vtex.admin-cms-graphql` is documented as a follow-up.
- **Methods used:** `listEntries` (cursor-paginated, returns `id` / `name` / `updatedAt` / `searchKeywords`, **no `slug`**) and `getEntry` (returns full `seo.slug`, `seo.canonical`, `seo.title`, locale metadata). `getEntryBySlug` is also exposed on the client for ad-hoc lookups but not used by the sitemap path.
- **Locale model:** `getEntry` is called once per `(entry, binding.defaultLocale)`. The Data Plane returns `404 Not Found` for locales that were never published — the binding is silently skipped, so we never synthesise locales (Decision 5).
- **ETag caching:** the Data Plane sends `ETag` headers and honors `If-None-Match` / `304 Not Modified`. Cached payloads are persisted in VBase across generations.

### hCMS (legacy) source — FastStore correction

FastStore Headless CMS pages live in the CMS builder data layer and are delivered to the storefront via the REST API (`/_v/cms/api/{projectId}/{contentType}`) — they are **never** registered as Rewriter Internals. The previous `generateCmsRoutes` read from `rewriter.listInternals`, so hCMS landing pages of FastStore stores never reached the sitemap. A `CmsBuilder` client + shared `fetchEligibleHcmsSlugs` helper now source these pages directly (published-only, requires `seo.slug`, excludes home `/`, honors `seo.canonical` opt-out and `disableRoutesTerm`); project id and routable content types are settings-driven (`hcmsProjectId`, `hcmsContentTypes`).

### Per user story

- **US-1 (Content Platform pages discoverable)** — `generateContentPlatformRoutes` iterates `contentPlatformContentTypes` (default `["landingPage", "home"]`), paginates `listEntries`, and fans out `getEntry` calls per binding-locale. Routes are emitted from `seo.slug`.
- **US-2 (SEO opt-out)** — A page is excluded when `seo.canonical` is non-empty AND points to a URL different from its own `seo.slug` (Decision 10). `noindex` is **not** available in the current Content Platform `seo` schema, so the opt-out is canonical-only for now. Login/error paths are excluded centrally (FR-3).
- **US-3 (Multi-locale & alternates)** — URL entries include `xhtml:link` tags for every locale where the entry actually returned `200`, plus an `x-default`. Bindings whose `getEntry` returns `404` are silently dropped — fallback locales are never synthesised.
- **US-5 (custom-routes endpoint)** — `/_v/public/sitemap/custom-routes` exposes a `content-platform-routes` (or `cms-routes`) section. Mutual exclusivity is enforced at serve time: only the active source's section is returned.
- **US-6 (Mutual exclusivity)** — `resolveActiveCmsSource(settings)` returns `'hcms' | 'content-platform' | 'none'`. When both flags are on, **Content Platform wins** (Decision 8) and `cms-routes-ignored-by-mutual-exclusivity` is logged once per generation. Enforced at four layers: event firing, generation middlewares, served `<sitemapindex>` / entry files, and `customRoutes`.

### Single-binding serving (catalog proxy path)

Single-binding stores (the common FastStore case, e.g. `isCrossBorder === false`) delegate **both** `/sitemap.xml` and `/sitemap/:path` to the catalog proxy (`catalog.getSitemap`), which never reads VBase. As a result the generated CMS routes were correctly persisted but **invisible** in the served XML — `/sitemap.xml` only listed `brand` / `category` / `product`, and `/sitemap/cms-routes-N.xml` returned `400` (the catalog has no such file). Only multi-binding (`legacySitemap`) stores and the `custom-routes` JSON endpoint surfaced them.

This increment closes that gap on the catalog path:

- `catalogSitemap` (in `node/middlewares/sitemap.ts`) now reads the active CMS index from VBase (`getCmsIndexFor`) and **merges** its sub-sitemap entries into the catalog `<sitemapindex>`, with a defensive fallback (catalog XML returned unchanged when it has no `<sitemapindex>` or no CMS index exists).
- `catalogSitemapEntry` (in `node/middlewares/sitemapEntry.ts`) now serves CMS entry files (`/sitemap/cms-routes-N.xml`, `/sitemap/hcms-routes-N.xml`) directly from the active CMS bucket in VBase **before** falling back to the catalog proxy.
- Both paths honor `resolveActiveCmsSource` (mutual exclusivity) and are fully gated by the existing settings — behavior is unchanged when no CMS source is enabled. Single-binding entries carry no `xhtml:link` alternates (preserved via `buildLocalization`).

### Key code additions

- `node/clients/cmsDataPlane.ts` — external client against `vtexcommercestable.com.br/api/content-platform/data/*` with cursor-based `listEntries`, `getEntry` (with `If-None-Match`), `getEntryBySlug`, 5xx retry, and graceful `404` handling (`{ notFound: true }`).
- `node/clients/cmsBuilder.ts` — external client against `{account}.myvtex.com/_v/cms/api/*` for the FastStore hCMS legacy source (paginated `listPages`, 5xx retry).
- `node/services/hcmsRoutes.ts` — shared `fetchEligibleHcmsSlugs` / `isEligibleHcmsPage` filter used by both the XML generator and the `custom-routes` endpoint (determinism, invariant 6).
- `node/middlewares/generateMiddlewares/generateContentPlatformRoutes.ts` — settings-driven ingestion, per-locale fan-out, canonical-based SEO opt-out, `disableRoutesTerm` filtering, multi-locale alternates, chunked persistence (50k URLs / 50 MB per file — Decision 2) under a dedicated `content-platform-routes` VBase bucket with its own index (Decision 7).
- `node/services/contentPlatformCache.ts` — VBase-backed ETag cache (`content-platform-data-cache` bucket) with base64url-safe filenames keyed by `(contentType, entryId, locale)`.
- `node/services/routes.ts` — `resolveActiveCmsSource` + `resolveCmsBucket` + `getContentPlatformRoutes`; `getCmsRoutes` early-returns when hCMS is not active and now sources from the CMS builder API.
- `node/middlewares/{sitemap,sitemapEntry,customRoutes}.ts` and `generateMiddlewares/{generateSitemap,generateCustomRoutes,generateCmsRoutes}.ts` — wire the active-source resolver through both pipelines, including the single-binding catalog path (see above).
- `node/globals.ts` — `Route.source: 'hcms' | 'content-platform' | 'apps' | 'user'`.
- `manifest.json` — `enableContentPlatformRoutes` (boolean, default `false`), `contentPlatformStoreId` (string, default `"faststore"`), `contentPlatformContentTypes` (string[], default `["landingPage", "home"]`), `hcmsProjectId` / `hcmsContentTypes`, and outbound-access policies for `{{account}}.vtexcommercestable.com.br/api/content-platform/data/*` and `{{account}}.myvtex.com/_v/cms/api/*`.

## Tests

- **`generateContentPlatformRoutes.test.ts`** — settings allowlist honored / falls back to default, multi-locale fan-out emits one URL per actually-published locale with grouped alternates, 404 silently skips unpublished locales (no synthesised alternates), single-binding stores write only the en-US bucket, ETag is persisted on fresh `200`, cached `PublishedEntry` is reused on `304`, `seo.canonical`-based exclusion, login/error exclusion, `disableRoutesTerm` filter, mutual-exclusivity logging.
- **`generateCmsRoutes.test.ts`** — hCMS pages sourced from the CMS builder API: published-only, canonical opt-out, `disableRoutesTerm`, chunking, off-by-default and mutual-exclusivity short-circuits.
- **`node/services/routes.test.ts`** — exhaustive matrix for `resolveActiveCmsSource` (all flag combinations, Content Platform tie-breaker).
- **`sitemap.test.ts` / `sitemapEntry.test.ts`** — single-binding catalog path: index merge for hCMS and Content Platform, catalog XML unchanged when no CMS source is enabled, mutual exclusivity (only the active source merged), entry served from VBase before the catalog fallback, and `404`/proxy fallback when the CMS file is absent or the flag is off.
- **Augmented suites** — `generateSitemap.test.ts`, `customRoutes.test.ts` cover event firing, bucket reads, and mutual exclusivity at every layer.

## Assumptions

- `contentPlatformStoreId` / `hcmsProjectId` default to `"faststore"`, matching the typical FastStore `contentSource.project`. Stores using a different project must override the setting before enabling the flag.
- The shared `disableRoutesTerm` setting (already used by hCMS) applies identically to Content Platform paths — same mental model for merchants migrating between sources.
- ETag persistence is best-effort: if VBase write fails, the next generation simply re-fetches the entry. We do not surface cache writes as user-visible errors.

## Deviations from spec (carried into the spec text)

- **Decision 7** — Data Plane is production-only by design (no branch parameter exists on the REST surface).
- **Decision 9** — routable content type **discovery** replaced by a **settings-driven allowlist** (`contentPlatformContentTypes`); auto-discovery via `vtex.admin-cms-graphql` is a follow-up.
- **Decision 10** — SEO opt-out is **canonical-only** today (`noindex` is not in the current Content Platform `seo` schema). The original `noindex OR canonical-mismatch` rule is preserved in the decision text for traceability and will be re-enabled when the field is added.

These changes are reflected in [`specs/cms-routes-in-sitemap-for-faststore.md`](https://github.com/vtex-apps/store-sitemap/blob/feat/content-platform-cms-support/specs/cms-routes-in-sitemap-for-faststore.md) (Decisions 7/9/10/11 + Implementation Plan P6–P9) and in [`docs/CMS_ROUTES.md`](https://github.com/vtex-apps/store-sitemap/blob/feat/content-platform-cms-support/docs/CMS_ROUTES.md).

## Validation notes

- The single-binding serving was verified end-to-end on a FastStore workspace (`vendemo`): with `enableCmsRoutes` on, `/sitemap.xml` now lists `…/sitemap/cms-routes-0.xml` alongside the catalog entries, and `/sitemap/cms-routes-0.xml` serves the hCMS landing page.
- **XML generation depends on the IO event bus.** The `generateCmsRoutes` / `generateContentPlatformRoutes` middlewares run as event handlers. In a flaky `vtex link` dev environment the event server can drop these events (`Connection to event server has failed`), leaving the CMS bucket empty and the serving path falling back to the catalog proxy. This is a dev-link limitation, not a serving bug — the `custom-routes` JSON endpoint (which generates synchronously) is unaffected, and events work normally on a deployed app.

## Follow-ups

- **`noindex` opt-out** — re-enable as a second leg of the SEO opt-out as soon as the Content Platform `seo` schema exposes the field.
- **Auto-discovery of routable types** — query `vtex.admin-cms-graphql` to auto-populate `contentPlatformContentTypes` instead of forcing a manual setting.
- **Pre-existing test failures** (in `utils.test.ts`, `prepare.test.ts`, `generateRewriterRoutes.test.ts`) were already red on `master` — out of scope here, worth a separate cleanup PR.
- **TSLint baseline** — repo carries ~49 pre-existing lint errors; the new files in this PR introduce **zero** additional lint errors.

## Spec & related PRs

- Spec: [`specs/cms-routes-in-sitemap-for-faststore.md`](https://github.com/vtex-apps/store-sitemap/blob/feat/content-platform-cms-support/specs/cms-routes-in-sitemap-for-faststore.md) — status updated from `Approved (Content Platform increment)` to `Done` in this PR.
- #187 — original spec
- #188 — hCMS legacy implementation (Increment 1)
- #189 — Content Platform spec increment

Made with [Cursor](https://cursor.com)
